### PR TITLE
Added /sse endpoint to FastAPI and updated README.md with examples/sample_notebook.ipynb.

### DIFF
--- a/fluidai_mcp/examples/chat_google_maps.ipynb
+++ b/fluidai_mcp/examples/chat_google_maps.ipynb
@@ -1,0 +1,294 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": 37,
+      "metadata": {
+        "id": "xQSCyix25FHu"
+      },
+      "outputs": [],
+      "source": [
+        "API_URL = \"https://276d-45-127-89-92.ngrok-free.app\""
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "MCP_URL = f\"{API_URL}/google-maps/mcp\""
+      ],
+      "metadata": {
+        "id": "L0um77QJ5wte"
+      },
+      "execution_count": 38,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "!pip install google-genai"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "LtjNh49d5Qr_"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "import requests\n",
+        "import json\n",
+        "from google import genai\n",
+        "import os\n",
+        "from IPython.display import display, Markdown"
+      ],
+      "metadata": {
+        "id": "UFf8HQkM5Poj"
+      },
+      "execution_count": 40,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Set up Gemini API\n",
+        "GEMINI_API_KEY = os.environ.get(\"GEMINI_API_KEY\")\n",
+        "client = genai.Client(api_key=GEMINI_API_KEY)"
+      ],
+      "metadata": {
+        "id": "l0Rmxo155SKE"
+      },
+      "execution_count": 41,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def call_maps_tool(query):\n",
+        "    \"\"\"Call the Google Maps MCP tool with a specific query.\"\"\"\n",
+        "    payload = {\n",
+        "        \"jsonrpc\": \"2.0\",\n",
+        "        \"id\": 1,\n",
+        "        \"method\": \"tools/call\",\n",
+        "        \"params\": {\n",
+        "            \"name\": \"maps_search_places\",\n",
+        "            \"arguments\": {\n",
+        "                \"query\": query\n",
+        "            }\n",
+        "        }\n",
+        "    }\n",
+        "\n",
+        "    try:\n",
+        "        response = requests.post(MCP_URL, json=payload)\n",
+        "        response.raise_for_status()\n",
+        "\n",
+        "        parsed_response = json.loads(response.text)\n",
+        "        places_data = None\n",
+        "\n",
+        "        # Extract the places data from the nested response\n",
+        "        for item in parsed_response[\"result\"][\"content\"]:\n",
+        "            if item[\"type\"] == \"text\":\n",
+        "                places_data = json.loads(item[\"text\"])\n",
+        "                break\n",
+        "\n",
+        "        return places_data\n",
+        "    except Exception as e:\n",
+        "        print(f\"Error calling Maps tool: {e}\")\n",
+        "        return None"
+      ],
+      "metadata": {
+        "id": "fIcX30GA5U1a"
+      },
+      "execution_count": 42,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def should_use_maps_tool(query):\n",
+        "    \"\"\"Use Gemini to decide if the query requires the Maps tool.\"\"\"\n",
+        "    prompt = f\"\"\"\n",
+        "    Determine if the following query requires information about places, locations, or maps:\n",
+        "\n",
+        "    Query: \"{query}\"\n",
+        "\n",
+        "    Respond with just \"YES\" if the query needs geographical information like:\n",
+        "    - Finding places (restaurants, hotels, attractions, etc.)\n",
+        "    - Information about locations\n",
+        "    - Distances between places\n",
+        "    - Addresses or directions\n",
+        "\n",
+        "    Otherwise respond with just \"NO\".\n",
+        "    \"\"\"\n",
+        "\n",
+        "    response = client.models.generate_content(\n",
+        "        model=\"gemini-2.0-flash\",  # or \"gemini-1.0-pro\" depending on what's available to you\n",
+        "        contents=[prompt]\n",
+        "    )\n",
+        "    decision = response.text.strip().upper()\n",
+        "    return decision == \"YES\""
+      ],
+      "metadata": {
+        "id": "zWffElYx5Zwx"
+      },
+      "execution_count": 43,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def answer_with_gemini(query, places_data=None):\n",
+        "    \"\"\"Generate a response using Gemini with optional places data.\"\"\"\n",
+        "\n",
+        "    if places_data:\n",
+        "        # Format the first 5 places to avoid overwhelming the model\n",
+        "        places_info = []\n",
+        "        for i, place in enumerate(places_data.get(\"places\", [])[:5]):\n",
+        "            places_info.append(f\"\"\"\n",
+        "            Place {i+1}: {place.get('name')}\n",
+        "            Address: {place.get('formatted_address')}\n",
+        "            Rating: {place.get('rating', 'N/A')}\n",
+        "            Types: {', '.join(place.get('types', []))}\n",
+        "            \"\"\")\n",
+        "\n",
+        "        places_text = \"\\n\".join(places_info)\n",
+        "\n",
+        "        prompt = f\"\"\"\n",
+        "        The user asked: \"{query}\"\n",
+        "\n",
+        "        I searched for places and found the following information:\n",
+        "\n",
+        "        {places_text}\n",
+        "\n",
+        "        Please provide a helpful response to the user's query using this information. Include specific details about the places when relevant.\n",
+        "        \"\"\"\n",
+        "    else:\n",
+        "        prompt = f\"\"\"\n",
+        "        The user asked: \"{query}\"\n",
+        "\n",
+        "        Please provide a helpful response to this query. If you don't have enough information, you can suggest the user to be more specific.\n",
+        "        \"\"\"\n",
+        "\n",
+        "    response = client.models.generate_content(\n",
+        "        model=\"gemini-2.0-flash\",  # or \"gemini-1.0-pro\"\n",
+        "        contents=[prompt]\n",
+        "    )\n",
+        "    return response.text"
+      ],
+      "metadata": {
+        "id": "Q5t2TlB15bu7"
+      },
+      "execution_count": 44,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def process_user_query(query):\n",
+        "    \"\"\"Process a user query using the appropriate tools.\"\"\"\n",
+        "    # Decide if we should use the Maps tool\n",
+        "    use_maps = should_use_maps_tool(query)\n",
+        "\n",
+        "    if use_maps:\n",
+        "        print(\"Using Google Maps tool to find information...\")\n",
+        "        places_data = call_maps_tool(query)\n",
+        "        if places_data:\n",
+        "            response = answer_with_gemini(query, places_data)\n",
+        "        else:\n",
+        "            response = \"I couldn't retrieve location information. Please try again.\"\n",
+        "    else:\n",
+        "        print(\"Answering without using Maps tool...\")\n",
+        "        response = answer_with_gemini(query)\n",
+        "\n",
+        "    return response"
+      ],
+      "metadata": {
+        "id": "EN45e54v5eu8"
+      },
+      "execution_count": 45,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "def run_assistant():\n",
+        "    user_query = input(\"What would you like to know? \")\n",
+        "    response = process_user_query(user_query)\n",
+        "\n",
+        "    try:\n",
+        "        # Try using IPython display (works in notebooks)\n",
+        "        display(Markdown(response))\n",
+        "    except (NameError, TypeError):\n",
+        "        # Fallback for terminal environments\n",
+        "        print(\"\\n--- Response ---\")\n",
+        "        print(response)\n",
+        "        print(\"--------------\\n\")"
+      ],
+      "metadata": {
+        "id": "RWgNGNv45jc8"
+      },
+      "execution_count": 46,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Run the assistant\n",
+        "run_assistant()"
+      ],
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 198
+        },
+        "id": "-96R9iN85mN0",
+        "outputId": "c0cca4e0-d3da-49c1-e499-287b83889892"
+      },
+      "execution_count": 47,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "What would you like to know? coffee shops in france\n",
+            "Using Google Maps tool to find information...\n"
+          ]
+        },
+        {
+          "output_type": "display_data",
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": "Okay, I found some highly-rated coffee shops in Paris, France:\n\n*   **Clove:** Located at 14 Rue Chappe in the 18th arrondissement, it boasts a rating of 4.9.\n*   **The Caféothèque of Paris:** This cafe, with a rating of 4.3, is located at 52 Rue de l'Hôtel de ville in the 4th arrondissement.\n*   **Crible - coffee shop:** Find this cafe at 75 Rue Buffon in the 5th arrondissement. It also has a rating of 4.9.\n*   **BlackBird Coffee:** Located at 77 Rue du Temple in the 3rd arrondissement, it has a rating of 4.7. It's categorized as both a cafe and a restaurant.\n*   **Coffee Specialty Coffee:** This cafe, with a rating of 4.9, is located at 40 Rue Chapon in the 3rd arrondissement.\n\nAll of these options are categorized as cafes and have food available, so you should be able to grab a coffee and a bite to eat. Enjoy!\n"
+          },
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "IGwfUljc5pTH"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/fluidai_mcp/examples/chat_google_maps.ipynb
+++ b/fluidai_mcp/examples/chat_google_maps.ipynb
@@ -1,18 +1,4 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "code",
@@ -27,57 +13,62 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "MCP_URL = f\"{API_URL}/google-maps/mcp\""
-      ],
+      "execution_count": 38,
       "metadata": {
         "id": "L0um77QJ5wte"
       },
-      "execution_count": 38,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "MCP_URL = f\"{API_URL}/google-maps/mcp\""
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "!pip install google-genai"
-      ],
+      "execution_count": null,
       "metadata": {
         "collapsed": true,
         "id": "LtjNh49d5Qr_"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "!pip install google-genai"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 40,
+      "metadata": {
+        "id": "UFf8HQkM5Poj"
+      },
+      "outputs": [],
       "source": [
         "import requests\n",
         "import json\n",
         "from google import genai\n",
         "import os\n",
         "from IPython.display import display, Markdown"
-      ],
-      "metadata": {
-        "id": "UFf8HQkM5Poj"
-      },
-      "execution_count": 40,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 41,
+      "metadata": {
+        "id": "l0Rmxo155SKE"
+      },
+      "outputs": [],
       "source": [
         "# Set up Gemini API\n",
         "GEMINI_API_KEY = os.environ.get(\"GEMINI_API_KEY\")\n",
         "client = genai.Client(api_key=GEMINI_API_KEY)"
-      ],
-      "metadata": {
-        "id": "l0Rmxo155SKE"
-      },
-      "execution_count": 41,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 42,
+      "metadata": {
+        "id": "fIcX30GA5U1a"
+      },
+      "outputs": [],
       "source": [
         "def call_maps_tool(query):\n",
         "    \"\"\"Call the Google Maps MCP tool with a specific query.\"\"\"\n",
@@ -110,15 +101,15 @@
         "    except Exception as e:\n",
         "        print(f\"Error calling Maps tool: {e}\")\n",
         "        return None"
-      ],
-      "metadata": {
-        "id": "fIcX30GA5U1a"
-      },
-      "execution_count": 42,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 43,
+      "metadata": {
+        "id": "zWffElYx5Zwx"
+      },
+      "outputs": [],
       "source": [
         "def should_use_maps_tool(query):\n",
         "    \"\"\"Use Gemini to decide if the query requires the Maps tool.\"\"\"\n",
@@ -142,15 +133,15 @@
         "    )\n",
         "    decision = response.text.strip().upper()\n",
         "    return decision == \"YES\""
-      ],
-      "metadata": {
-        "id": "zWffElYx5Zwx"
-      },
-      "execution_count": 43,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 44,
+      "metadata": {
+        "id": "Q5t2TlB15bu7"
+      },
+      "outputs": [],
       "source": [
         "def answer_with_gemini(query, places_data=None):\n",
         "    \"\"\"Generate a response using Gemini with optional places data.\"\"\"\n",
@@ -189,15 +180,15 @@
         "        contents=[prompt]\n",
         "    )\n",
         "    return response.text"
-      ],
-      "metadata": {
-        "id": "Q5t2TlB15bu7"
-      },
-      "execution_count": 44,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 45,
+      "metadata": {
+        "id": "EN45e54v5eu8"
+      },
+      "outputs": [],
       "source": [
         "def process_user_query(query):\n",
         "    \"\"\"Process a user query using the appropriate tools.\"\"\"\n",
@@ -216,15 +207,15 @@
         "        response = answer_with_gemini(query)\n",
         "\n",
         "    return response"
-      ],
-      "metadata": {
-        "id": "EN45e54v5eu8"
-      },
-      "execution_count": 45,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 46,
+      "metadata": {
+        "id": "RWgNGNv45jc8"
+      },
+      "outputs": [],
       "source": [
         "def run_assistant():\n",
         "    user_query = input(\"What would you like to know? \")\n",
@@ -238,19 +229,11 @@
         "        print(\"\\n--- Response ---\")\n",
         "        print(response)\n",
         "        print(\"--------------\\n\")"
-      ],
-      "metadata": {
-        "id": "RWgNGNv45jc8"
-      },
-      "execution_count": 46,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Run the assistant\n",
-        "run_assistant()"
-      ],
+      "execution_count": 47,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -259,36 +242,54 @@
         "id": "-96R9iN85mN0",
         "outputId": "c0cca4e0-d3da-49c1-e499-287b83889892"
       },
-      "execution_count": 47,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "What would you like to know? coffee shops in france\n",
             "Using Google Maps tool to find information...\n"
           ]
         },
         {
-          "output_type": "display_data",
           "data": {
+            "text/markdown": [
+              "Okay, I found some highly-rated coffee shops in Paris, France:\n",
+              "\n",
+              "*   **Clove:** Located at 14 Rue Chappe in the 18th arrondissement, it boasts a rating of 4.9.\n",
+              "*   **The Caféothèque of Paris:** This cafe, with a rating of 4.3, is located at 52 Rue de l'Hôtel de ville in the 4th arrondissement.\n",
+              "*   **Crible - coffee shop:** Find this cafe at 75 Rue Buffon in the 5th arrondissement. It also has a rating of 4.9.\n",
+              "*   **BlackBird Coffee:** Located at 77 Rue du Temple in the 3rd arrondissement, it has a rating of 4.7. It's categorized as both a cafe and a restaurant.\n",
+              "*   **Coffee Specialty Coffee:** This cafe, with a rating of 4.9, is located at 40 Rue Chapon in the 3rd arrondissement.\n",
+              "\n",
+              "All of these options are categorized as cafes and have food available, so you should be able to grab a coffee and a bite to eat. Enjoy!\n"
+            ],
             "text/plain": [
               "<IPython.core.display.Markdown object>"
-            ],
-            "text/markdown": "Okay, I found some highly-rated coffee shops in Paris, France:\n\n*   **Clove:** Located at 14 Rue Chappe in the 18th arrondissement, it boasts a rating of 4.9.\n*   **The Caféothèque of Paris:** This cafe, with a rating of 4.3, is located at 52 Rue de l'Hôtel de ville in the 4th arrondissement.\n*   **Crible - coffee shop:** Find this cafe at 75 Rue Buffon in the 5th arrondissement. It also has a rating of 4.9.\n*   **BlackBird Coffee:** Located at 77 Rue du Temple in the 3rd arrondissement, it has a rating of 4.7. It's categorized as both a cafe and a restaurant.\n*   **Coffee Specialty Coffee:** This cafe, with a rating of 4.9, is located at 40 Rue Chapon in the 3rd arrondissement.\n\nAll of these options are categorized as cafes and have food available, so you should be able to grab a coffee and a bite to eat. Enjoy!\n"
+            ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
+      ],
+      "source": [
+        "# Run the assistant\n",
+        "run_assistant()"
       ]
-    },
-    {
-      "cell_type": "code",
-      "source": [],
-      "metadata": {
-        "id": "IGwfUljc5pTH"
-      },
-      "execution_count": null,
-      "outputs": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/fluidai_mcp/examples/chat_google_maps.ipynb
+++ b/fluidai_mcp/examples/chat_google_maps.ipynb
@@ -2,13 +2,13 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 37,
+      "execution_count": null,
       "metadata": {
         "id": "xQSCyix25FHu"
       },
       "outputs": [],
       "source": [
-        "API_URL = \"https://276d-45-127-89-92.ngrok-free.app\""
+        "API_URL = \"localhost:8099\""
       ]
     },
     {


### PR DESCRIPTION
## Feat: Add SSE Endpoint for Streaming MCP Responses

**Description:**

This PR introduces a `/{package_name}/sse` endpoint to stream responses from MCP servers in real-time using Server-Sent Events (SSE). This allows clients to receive incremental data from MCP methods that produce output over time, improving responsiveness.

**Key Changes:**

*   Added a new POST route `/{package_name}/sse` in `create_mcp_router` within `fluidai_mcp/services/package_launcher.py`.
*   The endpoint accepts a JSON-RPC request, forwards it to the MCP server via STDIO, and streams stdout lines back to the client, formatted as SSE events (`data: ...\n\n`).
*   Uses FastAPI's `StreamingResponse` and an async generator for efficient streaming.
*   Secured with the existing `get_token` dependency for consistency.


**For testing:**
hit json request at {package_name}/sse:
Example input:
```
{
    "jsonrpc": "2.0",
    "id": 1,
    "method": "tools/call",
    "params": {
      "name": "maps_search_places",
      "arguments": {
        "query": "coffee shops in San Francisco"
      }
    }
}
```
Example Output:

data: {"result":{"content":[{"type":"text","text":"{\n  \"places\": [\n    {\n      \"name\": \"The Coffee Movement\",\n      \"formatted_address\": \"1030 Washington St, San Francisco, CA 94108, United States\",\n      \"location\": {\n        \"lat\": 37.7947575,\n        \"lng\": -122.4102936\n      },\n      \"place_id\": \"ChIJoTMb3PKAhYARsXkQt469sBw\",\n      \"rating\": 4.8,\n      \"types\": [\n        \"cafe\",\n        \"store\",\n        \"food\",\n        \"point_of_interest\",\n        \"establishment\"\n      ]\n    },\n    {\n      \"name\": \"Sextant Coffee Roasters\",\n      \"formatted_address\": \"1415 Folsom St, San Francisco, CA 94103, United States\",\n      \"location\": {\n        \"lat\": 37.77....}

## Updated README.md and added `examples/chat_google_maps.ipynb`
- Added examples snippets for quick-running the server and also added `examples/chat_google_maps.ipynb` which has an example using MCP server with LLM.