### PR TITLE
feature: added /sse framework and mcp_remote_client to connect with claude/cursor.

### DIFF
--- a/fluidai_mcp/services/mcp_remote_client.py
+++ b/fluidai_mcp/services/mcp_remote_client.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+FluidMCP Remote Client - MCP STDIO to HTTP Bridge
+"""
+import sys
+import json
+import asyncio
+import aiohttp
+import os
+import re
+from typing import Dict, Any, Optional, List
+from dataclasses import dataclass
+
+@dataclass
+class PackageInfo:
+    name: str
+    session_id: Optional[str] = None
+
+class FluidMCPRemoteClient:
+    def __init__(self):
+        self.server_url = os.environ.get("FMCP_SERVER_URL", "http://localhost:8099")
+        self.bearer_token = os.environ.get("FMCP_BEARER_TOKEN")
+        self.single_package_mode = os.environ.get("FMCP_PACKAGE_NAME")
+        self.packages: Dict[str, PackageInfo] = {}
+        self.headers = {"Content-Type": "application/json"}
+        
+        if self.bearer_token:
+            self.headers["Authorization"] = f"Bearer {self.bearer_token}"
+
+    async def discover_packages(self) -> bool:
+        """Discover packages from OpenAPI spec"""
+        if self.single_package_mode:
+            self.packages[self.single_package_mode] = PackageInfo(self.single_package_mode)
+            return True
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.server_url}/openapi.json", headers=self.headers, timeout=10) as resp:
+                    if resp.status == 200:
+                        openapi_spec = await resp.json()
+                        package_names = self._extract_packages_from_openapi(openapi_spec)
+                        
+                        for package_name in package_names:
+                            self.packages[package_name] = PackageInfo(package_name)
+                        
+                        print(f"Discovered {len(package_names)} packages: {package_names}", file=sys.stderr)
+                        return len(package_names) > 0
+        except Exception as e:
+            print(f"Failed to discover packages: {e}", file=sys.stderr)
+        
+        return False
+
+    def _extract_packages_from_openapi(self, openapi_spec: Dict) -> List[str]:
+        """Extract package names from OpenAPI paths"""
+        packages = set()
+        paths = openapi_spec.get("paths", {})
+        
+        for path in paths.keys():
+            # Look for /{package}/mcp/ pattern
+            if "/mcp/" in path:
+                parts = path.strip("/").split("/")
+                if len(parts) >= 2:
+                    package_name = parts[0]
+                    if package_name and package_name not in ["docs", "openapi.json", "redoc"]:
+                        packages.add(package_name)
+        
+        return list(packages)
+
+    async def get_session_id(self, package_name: str) -> Optional[str]:
+        """Get or create SSE session for package"""
+        if package_name not in self.packages:
+            return None
+            
+        package_info = self.packages[package_name]
+        if package_info.session_id:
+            return package_info.session_id
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.server_url}/{package_name}/sse/start",
+                    headers=self.headers,
+                    timeout=10
+                ) as resp:
+                    if resp.status == 200:
+                        result = await resp.json()
+                        session_id = result["session_id"]
+                        package_info.session_id = session_id
+                        return session_id
+        except Exception as e:
+            print(f"Session init error for {package_name}: {e}", file=sys.stderr)
+        
+        return None
+
+    async def get_all_tools(self) -> List[Dict[str, Any]]:
+        """Get tools from all packages"""
+        all_tools = []
+        
+        for package_name in self.packages:
+            tools = await self._get_package_tools(package_name)
+            if tools:
+                if not self.single_package_mode:
+                    # Add package prefix for multi-package mode
+                    for tool in tools:
+                        tool["_package"] = package_name
+                        tool["_original_name"] = tool["name"]
+                        tool["name"] = f"{self._clean_name(package_name)}_{self._clean_name(tool['name'])}"
+                
+                all_tools.extend(tools)
+        
+        return all_tools
+
+    async def _get_package_tools(self, package_name: str) -> List[Dict[str, Any]]:
+        """Get tools from specific package"""
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.get(
+                    f"{self.server_url}/{package_name}/mcp/tools/list",
+                    headers=self.headers,
+                    timeout=10
+                ) as resp:
+                    if resp.status == 200:
+                        result = await resp.json()
+                        tools = result.get("result", {}).get("tools", [])
+                        return [self._clean_tool(tool) for tool in tools if tool.get("name")]
+        except Exception as e:
+            print(f"Failed to get tools from {package_name}: {e}", file=sys.stderr)
+        
+        return []
+
+    def _clean_tool(self, tool: Dict[str, Any]) -> Dict[str, Any]:
+        """Clean tool schema for Claude compatibility"""
+        clean_tool = {
+            "name": str(tool["name"]),
+            "description": str(tool.get("description", ""))
+        }
+        
+        # Copy package metadata if present
+        for field in ["_package", "_original_name"]:
+            if field in tool:
+                clean_tool[field] = tool[field]
+        
+        # Clean inputSchema
+        if "inputSchema" in tool and isinstance(tool["inputSchema"], dict):
+            schema = tool["inputSchema"]
+            clean_schema = {
+                "type": "object",
+                "properties": {},
+                "required": schema.get("required", [])
+            }
+            
+            # Copy properties with allowed fields only
+            if "properties" in schema:
+                for prop_name, prop_def in schema["properties"].items():
+                    if isinstance(prop_def, dict):
+                        clean_prop = {}
+                        for field in ["type", "description", "enum", "default"]:
+                            if field in prop_def:
+                                clean_prop[field] = prop_def[field]
+                        clean_schema["properties"][prop_name] = clean_prop
+            
+            clean_tool["inputSchema"] = clean_schema
+        
+        return clean_tool
+
+    def _clean_name(self, name: str) -> str:
+        """Clean name for Claude compatibility"""
+        cleaned = re.sub(r'[^a-zA-Z0-9_-]', '_', name)[:64].strip('_-')
+        return cleaned or "tool"
+
+    async def call_tool(self, tool_name: str, arguments: Dict[str, Any], request_id: int) -> Dict[str, Any]:
+        """Call tool via SSE endpoint"""
+        package_name, actual_tool_name = self._parse_tool_name(tool_name)
+        
+        if not package_name:
+            return self._error_response(request_id, -32601, f"Tool not found: {tool_name}")
+
+        session_id = await self.get_session_id(package_name)
+        if not session_id:
+            return self._error_response(request_id, -32603, f"Failed to get session for {package_name}")
+
+        tool_request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "tools/call",
+            "params": {"name": actual_tool_name, "arguments": arguments}
+        }
+
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{self.server_url}/{package_name}/sse/tools/call",
+                    headers=self.headers,
+                    json=tool_request,
+                    timeout=30
+                ) as resp:
+                    if resp.status == 200:
+                        result = await resp.json()
+                        return self._extract_response(result, request_id)
+                    else:
+                        text = await resp.text()
+                        return self._error_response(request_id, -32603, f"Tool call failed: {resp.status}")
+        except Exception as e:
+            return self._error_response(request_id, -32603, f"Tool call error: {e}")
+
+    def _parse_tool_name(self, tool_name: str) -> tuple[Optional[str], str]:
+        """Parse tool name to get package and actual tool name"""
+        if self.single_package_mode:
+            return self.single_package_mode, tool_name
+        
+        # Multi-package: extract from prefixed name
+        if "_" in tool_name:
+            package_name, actual_tool_name = tool_name.split("_", 1)
+            if package_name in self.packages:
+                return package_name, actual_tool_name
+        
+        return None, tool_name
+
+    def _extract_response(self, sse_result: Dict[str, Any], request_id: int) -> Dict[str, Any]:
+        """Extract final response from SSE result"""
+        messages = sse_result.get("messages", [])
+        if messages:
+            last_message = messages[-1]
+            if last_message.get("status") == "completed" and "response" in last_message:
+                try:
+                    return json.loads(last_message["response"])
+                except json.JSONDecodeError:
+                    pass
+        
+        return self._error_response(request_id, -32603, "No valid response from tool")
+
+    def _error_response(self, request_id: int, code: int, message: str) -> Dict[str, Any]:
+        """Create JSON-RPC error response"""
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message}
+        }
+
+    async def handle_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        """Handle MCP JSON-RPC request"""
+        method = request.get("method")
+        request_id = request.get("id")
+
+        if method == "initialize":
+            success = await self.discover_packages()
+            if success:
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {
+                            "name": f"FluidMCP ({len(self.packages)} packages)",
+                            "version": "1.0.0"
+                        }
+                    }
+                }
+            else:
+                return self._error_response(request_id, -32603, "No packages available")
+
+        elif method == "notifications/initialized":
+            return None
+
+        elif method == "tools/list":
+            if not self.packages:
+                await self.discover_packages()
+            
+            tools = await self.get_all_tools()
+            print(f"Returning {len(tools)} tools from {len(self.packages)} packages", file=sys.stderr)
+            return {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "result": {"tools": tools}
+            }
+
+        elif method == "tools/call":
+            params = request.get("params", {})
+            tool_name = params.get("name")
+            arguments = params.get("arguments", {})
+            
+            if not tool_name:
+                return self._error_response(request_id, -32602, "Tool name required")
+            
+            return await self.call_tool(tool_name, arguments, request_id)
+
+        else:
+            return self._error_response(request_id, -32601, f"Unknown method: {method}")
+
+    async def run(self):
+        """Main STDIO loop"""
+        mode = "single-package" if self.single_package_mode else "multi-package"
+        print(f"🔗 Starting FluidMCP remote client", file=sys.stderr)
+        print(f"📡 Server: {self.server_url}", file=sys.stderr)
+        print(f"📦 Mode: {mode}", file=sys.stderr)
+        
+        try:
+            for line in sys.stdin:
+                line = line.strip()
+                if not line:
+                    continue
+                
+                try:
+                    request = json.loads(line)
+                    response = await self.handle_request(request)
+                    
+                    if response:
+                        print(json.dumps(response), flush=True)
+                        
+                except json.JSONDecodeError:
+                    error = {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}}
+                    print(json.dumps(error), flush=True)
+                except Exception as e:
+                    error = {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": str(e)}}
+                    print(json.dumps(error), flush=True)
+                    
+        except KeyboardInterrupt:
+            print("Remote client stopped", file=sys.stderr)
+
+def main():
+    """CLI entry point"""
+    client = FluidMCPRemoteClient()
+    asyncio.run(client.run())
+
+if __name__ == "__main__":
+    main()

--- a/fluidai_mcp/services/package_installer.py
+++ b/fluidai_mcp/services/package_installer.py
@@ -196,7 +196,7 @@ def replace_package_metadata_from_package_name(package_name: str) -> Dict[str, A
     
     try:
         # Make the API request to fetch the package metadata
-        response = requests.get("https://registry-dev.fluidmcp.com/fetch-metadata", headers=headers, params=payload)
+        response = requests.get("https://registry.fluidmcp.com/fetch-metadata", headers=headers, params=payload)
         response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as e:

--- a/fluidai_mcp/services/package_launcher.py
+++ b/fluidai_mcp/services/package_launcher.py
@@ -2,22 +2,25 @@ import os
 import json
 import subprocess
 import shutil
-from typing import Union, Dict, Any, Iterator
+import uuid
+import asyncio
+from typing import AsyncGenerator, Dict, Any, Union
 from pathlib import Path
 from loguru import logger
 import time
-import sys
-import threading
-import json
-import subprocess
-from pathlib import Path
-from typing import Dict
-from fastapi import FastAPI, Request, APIRouter, Body, Depends, HTTPException
+from fastapi import FastAPI, Request, APIRouter, Body, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import uvicorn
-import threading
-import time
+
+# Import utilities
+from .utils import (
+    fix_npm_permissions, 
+    create_clean_npm_environment, 
+    initialize_mcp_server,
+    active_sessions,
+    persistent_tool_sessions
+)
 
 security = HTTPBearer(auto_error=False)
 
@@ -33,8 +36,10 @@ def get_token(credentials: HTTPAuthorizationCredentials = Depends(security)):
     return credentials.credentials
 
 def launch_mcp_using_fastapi_proxy(dest_dir: Union[str, Path]):
+    """Launch MCP server and return package name and router"""
     dest_dir = Path(dest_dir)
     metadata_path = dest_dir / "metadata.json"
+
     try:
         if not metadata_path.exists():
             logger.info(f":warning: No metadata.json found at {metadata_path}")
@@ -48,129 +53,104 @@ def launch_mcp_using_fastapi_proxy(dest_dir: Union[str, Path]):
     except Exception as e:
         print(f":x: Error reading metadata.json: {e}")
         return None, None
+
     try:
         base_command = servers["command"]
         raw_args = servers["args"]
-        if base_command == "npx" or base_command == "npm":
-            npm_path = shutil.which("npm")
-            npx_path = shutil.which("npx")
-            if npm_path and base_command == "npm":
-                base_command = npm_path
-            elif npx_path and base_command == "npx":
-                base_command = npx_path
+        
+        # Handle npm/npx commands with permission fixes
+        if base_command in ["npx", "npm"]:
+            fix_npm_permissions()
+            command_path = shutil.which(base_command)
+            if command_path:
+                base_command = command_path
+            clean_npm_env = create_clean_npm_environment()
+        else:
+            clean_npm_env = {}
+        
         args = [arg.replace("<path to mcp-servers>", str(dest_dir)) for arg in raw_args]
         stdio_command = [base_command] + args
-        env_vars = servers.get("env", {})
-        env = {**dict(os.environ), **env_vars}
-        process = subprocess.Popen(
-                stdio_command,
-                cwd=dest_dir,
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-                text=True,  # ensure stdin/stdout is in text mode
-                bufsize=1
-            )
         
-        # NEW: Initialize MCP server
+        # Combine environments
+        env_vars = servers.get("env", {})
+        env = {**dict(os.environ), **env_vars, **clean_npm_env}
+        
+        print(f"🔍 Attempting to launch: {stdio_command}")
+        print(f"🔍 Working directory: {dest_dir}")
+        print(f"🔍 Environment vars: {list(env_vars.keys())}")
+        
+        # Try with clean environment first
+        process = subprocess.Popen(
+            stdio_command,
+            cwd=dest_dir,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=env,
+            text=True,
+            bufsize=1
+        )
+        
+        # Check if process started successfully
+        time.sleep(2)
+        
+        if process.poll() is not None:
+            stderr_output = process.stderr.read()
+            print(f"❌ Process terminated. Exit code: {process.returncode}")
+            print(f"❌ Error output: {stderr_output}")
+            
+            # Try fallback: use npx with --no-install
+            if base_command.endswith("npx") and "-y" in args:
+                print("🔄 Trying fallback with --no-install...")
+                fallback_args = [arg.replace("-y", "--no-install") for arg in args]
+                fallback_command = [base_command] + fallback_args
+                
+                process = subprocess.Popen(
+                    fallback_command,
+                    cwd=dest_dir,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    env=env,
+                    text=True,
+                    bufsize=1
+                )
+                
+                time.sleep(1)
+                if process.poll() is not None:
+                    print("❌ Fallback also failed")
+                    return None, None
+        
+        print(f"✅ Process started successfully with PID: {process.pid}")
+        
+        # Initialize MCP server
         if not initialize_mcp_server(process):
             print(f"Warning: Failed to initialize MCP server for {pkg}")
-               
+            if process.poll() is not None:
+                stderr_output = process.stderr.read()
+                print(f"Process error output: {stderr_output}")
+        
         router = create_mcp_router(pkg, process)
         return pkg, router
+        
     except FileNotFoundError as e:
         print(f":x: Command not found: {e}")
         return None, None
     except Exception as e:
         print(f":x: Error launching MCP server: {e}")
         return None, None
-    
-
-
-def create_fastapi_jsonrpc_proxy(package_name: str, process: subprocess.Popen) -> FastAPI:
-    app = FastAPI()
-    @app.post(f"/{package_name}/mcp")
-    async def proxy_jsonrpc(request: Request):
-        try:
-            jsonrpc_request = await request.body()
-            jsonrpc_str = jsonrpc_request.decode() if isinstance(jsonrpc_request, bytes) else jsonrpc_request
-            # Send to MCP server via stdin
-            process.stdin.write(jsonrpc_str + "\n")
-            process.stdin.flush()
-            # Read from MCP server stdout
-            response_line = process.stdout.readline()
-            return JSONResponse(content=json.loads(response_line))
-        except Exception as e:
-            return JSONResponse(status_code=500, content={"error": str(e)})
-    return app
-
-
-def start_fastapi_in_thread(app: FastAPI, port: int):
-    def run():
-        uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")
-    thread = threading.Thread(target=run, daemon=True)
-    thread.start()
-
-
-def initialize_mcp_server(process: subprocess.Popen) -> bool:
-    """Initialize MCP server with proper handshake"""
-    try:
-        
-        
-        # Send initialize request
-        init_request = {
-            "jsonrpc": "2.0",
-            "id": 0,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {"roots": {"listChanged": True}, "sampling": {}},
-                "clientInfo": {"name": "fluidmcp-client", "version": "1.0.0"}
-            }
-        }
-        
-        process.stdin.write(json.dumps(init_request) + "\n")
-        process.stdin.flush()
-        
-        # Wait for response
-        start_time = time.time()
-        while time.time() - start_time < 10:
-            if process.poll() is not None:
-                return False
-            response_line = process.stdout.readline().strip()
-            if response_line:
-                response = json.loads(response_line)
-                if response.get("id") == 0 and "result" in response:
-                    # Send initialized notification
-                    notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
-                    process.stdin.write(json.dumps(notif) + "\n")
-                    process.stdin.flush()
-                    return True
-            time.sleep(0.1)
-        return False
-    except Exception as e:
-        print(f"Initialization error: {e}")
-        return False
-    
 
 def create_mcp_router(package_name: str, process: subprocess.Popen) -> APIRouter:
+    """Create FastAPI router with all MCP endpoints for a package"""
     router = APIRouter()
 
     @router.post(f"/{package_name}/mcp", tags=[package_name])
     async def proxy_jsonrpc(
-        request: Dict[str, Any] = Body(
-            ...,
-            example={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "",
-                "params": {}
-            }
-        ), token: str = Depends(get_token)
+        request: Dict[str, Any] = Body(...), 
+        token: str = Depends(get_token)
     ):
+        """Direct MCP JSON-RPC proxy endpoint"""
         try:
-            # Convert dict to JSON string
             msg = json.dumps(request)
             process.stdin.write(msg + "\n")
             process.stdin.flush()
@@ -179,130 +159,358 @@ def create_mcp_router(package_name: str, process: subprocess.Popen) -> APIRouter
         except Exception as e:
             return JSONResponse(status_code=500, content={"error": str(e)})
     
-    # New SSE endpoint
-    @router.post(f"/{package_name}/sse", tags=[package_name])
-    async def sse_stream(
-        request: Dict[str, Any] = Body(
-            ...,
-            example={
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "",
-                "params": {}
-            }
-        ), token: str = Depends(get_token)
-    ):
-        async def event_generator() -> Iterator[str]:
-            try:
-                # Convert dict to JSON string and send to MCP server
-                msg = json.dumps(request)
-                process.stdin.write(msg + "\n")
-                process.stdin.flush()
-                
-                # Read from stdout and stream as SSE events
-                while True:
-                    response_line = process.stdout.readline()
-                    if not response_line:
-                        break
-                    
-                    # Add logging
-                    logger.debug(f"Received from MCP: {response_line.strip()}")
-                    
-                    # Format as SSE event
-                    yield f"data: {response_line.strip()}\n\n"
-                    
-                    # Check if response contains "result" which indicates completion
-                    try:
-                        response_data = json.loads(response_line)
-                        if "result" in response_data:
-                            # If it's a final result, we can stop the stream
-                            break
-                    except json.JSONDecodeError:
-                        # If it's not valid JSON, just stream it as-is
-                        pass
-                    
-            except Exception as e:
-                # Send error as SSE event
-                yield f"data: {json.dumps({'error': str(e)})}\n\n"
-        
-        return StreamingResponse(
-            event_generator(),
-            media_type="text/event-stream"
-        )
-        
-    @router.get(f"/{package_name}/mcp/tools/list", tags=[package_name])
-    async def list_tools(token: str = Depends(get_token)):
+    # ===== STANDARD SSE PATTERN IMPLEMENTATION =====
+    
+    @router.post(f"/{package_name}/sse/start", tags=[package_name])
+    async def start_sse_session(token: str = Depends(get_token)):
+        """Start a new empty SSE session"""
         try:
-            # Pre-filled JSON-RPC request for tools/list
-            request_payload = {
-                "id": 1,
-                "jsonrpc": "2.0",
-                "method": "tools/list"
+            session_id = str(uuid.uuid4())
+            
+            active_sessions[session_id] = {
+                "messages": [],
+                "processed_count": 0,
+                "status": "ready",
+                "created_at": time.time(),
+                "package_name": package_name,
+                "process": process,
+                "context": {}
             }
             
-            # Convert to JSON string and send to MCP server
-            msg = json.dumps(request_payload)
-            process.stdin.write(msg + "\n")
-            process.stdin.flush()
-            
-            # Read response from MCP server
-            response_line = process.stdout.readline()
-            response_data = json.loads(response_line)
-            
-            return JSONResponse(content=response_data)
+            return JSONResponse(content={
+                "session_id": session_id,
+                "status": "ready",
+                "message_url": f"/{package_name}/sse/message?session_id={session_id}",
+                "stream_url": f"/{package_name}/sse/stream?session_id={session_id}"
+            })
             
         except Exception as e:
             return JSONResponse(status_code=500, content={"error": str(e)})
-        
-    
-    @router.post(f"/{package_name}/mcp/tools/call", tags=[package_name])
-    async def call_tool(request_body: Dict[str, Any] = Body(
-        ...,
-        alias="params",
-        example={
-            "name": "", 
-        }
-    ), token: str = Depends(get_token)
-):      
-        params = request_body
 
+    @router.post(f"/{package_name}/sse/message", tags=[package_name])
+    async def add_message(
+        request: Dict[str, Any] = Body(...),
+        session_id: str = Query(...),
+        token: str = Depends(get_token)
+    ):
+        """Add message to session queue"""
+        if session_id not in active_sessions:
+            raise HTTPException(status_code=404, detail="Session not found")
+        
+        session = active_sessions[session_id]
+        message_id = str(uuid.uuid4())
+        message = {
+            "id": message_id,
+            "content": request,
+            "timestamp": time.time(),
+            "status": "queued"
+        }
+        
+        session['messages'].append(message)
+        session['status'] = "has_new_messages"
+        
+        return JSONResponse(content={
+            "message_id": message_id,
+            "status": "queued",
+            "queue_position": len(session['messages']),
+            "session_status": session['status']
+        })
+    
+    @router.get(f"/{package_name}/sse/stream", tags=[package_name])
+    async def stream_sse(
+        session_id: str = Query(...),
+        token: str = Depends(get_token)
+    ):
+        """Stream real-time responses as server processes message queue"""
+        if session_id not in active_sessions:
+            raise HTTPException(status_code=404, detail="Session not found")
+        
+        session = active_sessions[session_id]
+        
+        async def event_generator() -> AsyncGenerator[str, None]:
+            try:
+                yield f"event: connected\ndata: {json.dumps({'session_id': session_id, 'status': 'connected'})}\n\n"
+                
+                while session_id in active_sessions:
+                    session = active_sessions[session_id]
+                    total_messages = len(session['messages'])
+                    processed_count = session['processed_count']
+                    
+                    if total_messages > processed_count:
+                        for i in range(processed_count, total_messages):
+                            message = session['messages'][i]
+                            
+                            yield f"event: processing\ndata: {json.dumps({'message_id': message['id'], 'status': 'processing'})}\n\n"
+                            
+                            try:
+                                mcp_request = message["content"]
+                                msg = json.dumps(mcp_request)
+                                process.stdin.write(msg + "\n")
+                                process.stdin.flush()
+                                
+                                response_line = process.stdout.readline()
+                                if response_line:
+                                    response_line = response_line.strip()
+                                    yield f"event: response\ndata: {response_line}\n\n"
+                                    
+                                    message['status'] = "completed"
+                                    message["response"] = response_line
+                                    
+                                    try:
+                                        response_data = json.loads(response_line)
+                                        if "error" in response_data:
+                                            yield f"event: error\ndata: {response_line}\n\n"
+                                        elif "result" in response_data:
+                                            yield f"event: result\ndata: {json.dumps(session['messages'])}\n\n"
+                                    except json.JSONDecodeError:
+                                        yield f"event: text\ndata: {json.dumps({'text': response_line})}\n\n"
+                                
+                            except Exception as e:
+                                error_data = json.dumps({"message_id": message['id'], "error": str(e)})
+                                yield f"event: error\ndata: {error_data}\n\n"
+                                message['status'] = "error"
+                            
+                            session['processed_count'] += 1
+                    
+                    if processed_count >= total_messages and session.get("status") != "has_new_messages":
+                        yield f"event: idle\ndata: {json.dumps({'status': 'waiting_for_messages'})}\n\n"
+                    
+                    session['status'] = "ready"
+                    await asyncio.sleep(0.1)
+                    
+            except Exception as e:
+                error_data = json.dumps({"error": str(e), "session_id": session_id})
+                yield f"event: error\ndata: {error_data}\n\n"
+        
+        return StreamingResponse(
+            event_generator(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+                "X-Accel-Buffering": "no"
+            }
+        )
+    
+    # ===== MCP TOOLS ENDPOINTS =====
+    
+    @router.get(f"/{package_name}/mcp/tools/list", tags=[package_name])
+    async def list_tools(token: str = Depends(get_token)):
+        """List available tools from MCP server"""
         try:
-            # Validate required fields
-            if "name" not in params:
-                return JSONResponse(
-                    status_code=400, 
-                    content={"error": "Tool name is required"}
-                )
+            request_payload = {"id": 1, "jsonrpc": "2.0", "method": "tools/list"}
+            msg = json.dumps(request_payload)
+            process.stdin.write(msg + "\n")
+            process.stdin.flush()
+            response_line = process.stdout.readline()
+            return JSONResponse(content=json.loads(response_line))
+        except Exception as e:
+            return JSONResponse(status_code=500, content={"error": str(e)})
+        
+    @router.post(f"/{package_name}/mcp/tools/call", tags=[package_name])
+    async def call_tool(
+        request_body: Dict[str, Any] = Body(...), 
+        token: str = Depends(get_token)
+    ):
+        """Call a specific tool"""
+        try:
+            if "name" not in request_body:
+                return JSONResponse(status_code=400, content={"error": "Tool name is required"})
             
-            # Construct complete JSON-RPC request
             request_payload = {
                 "jsonrpc": "2.0",
                 "id": 2,
                 "method": "tools/call",
-                "params": params
+                "params": request_body
             }
             
-            # Send to MCP server
             msg = json.dumps(request_payload)
             process.stdin.write(msg + "\n")
             process.stdin.flush()
-            
-            # Read response
             response_line = process.stdout.readline()
-            response_data = json.loads(response_line)
+            return JSONResponse(content=json.loads(response_line))
             
-            return JSONResponse(content=response_data)
-            
-        except json.JSONDecodeError:
-            return JSONResponse(
-                status_code=400, 
-                content={"error": "Invalid JSON in request body"}
-            )
         except Exception as e:
-            return JSONResponse(
-                status_code=500, 
-                content={"error": str(e)}
-            )
+            return JSONResponse(status_code=500, content={"error": str(e)})
+    
+    # ===== PERSISTENT SESSION ENDPOINTS =====
+    
+    @router.post(f"/{package_name}/sse/tools/call", tags=[package_name])
+    async def sse_tools_call(
+        request: Dict[str, Any] = Body(...),
+        timeout: int = Query(30),
+        reset_session: bool = Query(False),
+        token: str = Depends(get_token)
+    ):
+        """Convenient endpoint that maintains persistent session per package"""
+        session_id = None
+        is_new_session = False
+        
+        try:
+            # Get or create persistent session
+            if reset_session and package_name in persistent_tool_sessions:
+                old_session_id = persistent_tool_sessions[package_name]
+                if old_session_id in active_sessions:
+                    del active_sessions[old_session_id]
+                del persistent_tool_sessions[package_name]
+            
+            if package_name in persistent_tool_sessions:
+                session_id = persistent_tool_sessions[package_name]
+                if session_id not in active_sessions:
+                    del persistent_tool_sessions[package_name]
+                    session_id = None
+            
+            if session_id is None:
+                session_id = str(uuid.uuid4())
+                is_new_session = True
+                
+                active_sessions[session_id] = {
+                    "messages": [],
+                    "processed_count": 0,
+                    "status": "ready",
+                    "created_at": time.time(),
+                    "package_name": package_name,
+                    "process": process,
+                    "context": {},
+                    "persistent": True
+                }
+                
+                persistent_tool_sessions[package_name] = session_id
+            
+            session = active_sessions[session_id]
+            
+            # Add message and process
+            message_id = str(uuid.uuid4())
+            message = {
+                "id": message_id,
+                "content": request,
+                "timestamp": time.time(),
+                "status": "queued"
+            }
+            
+            session['messages'].append(message)
+            session['status'] = "has_new_messages"
+            session["last_used"] = time.time()
+            
+            # Wait for completion
+            start_time = time.time()
+            current_message_index = len(session['messages']) - 1
+            
+            while time.time() - start_time < timeout:
+                session = active_sessions[session_id]
+                
+                if current_message_index < session['processed_count']:
+                    processed_message = session['messages'][current_message_index]
+                    
+                    if processed_message['status'] == "completed":
+                        return JSONResponse(content={
+                            "message_id": message_id,
+                            "session_id": session_id,
+                            "is_new_session": is_new_session,
+                            "total_messages": len(session['messages']),
+                            "messages": session['messages']
+                        })
+                    elif processed_message['status'] == "error":
+                        error_detail = processed_message.get("error", "Unknown MCP error")
+                        raise HTTPException(status_code=500, detail=f"MCP processing error: {error_detail}")
+                
+                # Process pending messages
+                total_messages = len(session['messages'])
+                processed_count = session['processed_count']
+                
+                if total_messages > processed_count:
+                    message_to_process = session['messages'][processed_count]
+                    
+                    try:
+                        mcp_request = message_to_process["content"]
+                        msg = json.dumps(mcp_request)
+                        process.stdin.write(msg + "\n")
+                        process.stdin.flush()
+                        
+                        response_line = process.stdout.readline()
+                        if response_line:
+                            response_line = response_line.strip()
+                            message_to_process["status"] = "completed"
+                            message_to_process["response"] = response_line
+                            session['processed_count'] += 1
+                            continue
+                            
+                    except Exception as e:
+                        message_to_process["status"] = "error"
+                        message_to_process["error"] = str(e)
+                        session['processed_count'] += 1
+                        continue
+                
+                await asyncio.sleep(0.1)
+            
+            raise HTTPException(status_code=408, detail=f"Request timeout after {timeout} seconds")
+            
+        except HTTPException:
+            raise
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    
+    # ===== SESSION MANAGEMENT =====
+    
+    @router.get(f"/{package_name}/sse/status/{{session_id}}", tags=[package_name])
+    async def get_session_status(session_id: str, token: str = Depends(get_token)):
+        """Get session status"""
+        if session_id not in active_sessions:
+            raise HTTPException(status_code=404, detail="Session not found")
+        
+        session = active_sessions[session_id]
+        return JSONResponse(content={
+            "session_id": session_id,
+            "status": session['status'],
+            "created_at": session["created_at"],
+            "package_name": session["package_name"],
+            "message_count": len(session.get("messages", [])),
+            "processed_count": session.get("processed_count", 0)
+        })
+    
+    @router.delete(f"/{package_name}/sse/{{session_id}}", tags=[package_name])
+    async def cancel_session(session_id: str, token: str = Depends(get_token)):
+        """Cancel session"""
+        if session_id not in active_sessions:
+            raise HTTPException(status_code=404, detail="Session not found")
+        
+        del active_sessions[session_id]
+        return JSONResponse(content={"session_id": session_id, "status": "cancelled"})
+    
+    @router.delete(f"/{package_name}/sse/tools/session", tags=[package_name])
+    async def cleanup_persistent_session(token: str = Depends(get_token)):
+        """Clean up persistent session for package"""
+        if package_name in persistent_tool_sessions:
+            session_id = persistent_tool_sessions[package_name]
+            if session_id in active_sessions:
+                del active_sessions[session_id]
+            del persistent_tool_sessions[package_name]
+            return JSONResponse(content={"package_name": package_name, "session_id": session_id, "status": "cleaned_up"})
+        else:
+            return JSONResponse(content={"package_name": package_name, "status": "no_persistent_session"})
+
+    @router.get(f"/{package_name}/sse/tools/session/info", tags=[package_name])
+    async def get_persistent_session_info(token: str = Depends(get_token)):
+        """Get persistent session info"""
+        if package_name in persistent_tool_sessions:
+            session_id = persistent_tool_sessions[package_name]
+            if session_id in active_sessions:
+                session = active_sessions[session_id]
+                return JSONResponse(content={
+                    "package_name": package_name,
+                    "session_id": session_id,
+                    "status": "active",
+                    "created_at": session["created_at"],
+                    "last_used": session.get("last_used", session["created_at"]),
+                    "total_messages": len(session['messages']),
+                    "processed_count": session['processed_count']
+                })
+            else:
+                del persistent_tool_sessions[package_name]
+                return JSONResponse(content={"package_name": package_name, "status": "orphaned_cleaned_up"})
+        else:
+            return JSONResponse(content={"package_name": package_name, "status": "no_persistent_session"})
+    
     return router
 
 if __name__ == '__main__':

--- a/fluidai_mcp/services/utils/__init__.py
+++ b/fluidai_mcp/services/utils/__init__.py
@@ -1,0 +1,13 @@
+"""
+Utility modules for FluidMCP services
+"""
+from .npm_utils import fix_npm_permissions, create_clean_npm_environment
+from .mcp_session import initialize_mcp_server, active_sessions, persistent_tool_sessions
+
+__all__ = [
+    "fix_npm_permissions",
+    "create_clean_npm_environment", 
+    "initialize_mcp_server",
+    "active_sessions",
+    "persistent_tool_sessions"
+]

--- a/fluidai_mcp/services/utils/mcp_session.py
+++ b/fluidai_mcp/services/utils/mcp_session.py
@@ -1,0 +1,49 @@
+"""
+MCP session management utilities
+"""
+import json
+import time
+import subprocess
+from typing import Dict, Any
+
+def initialize_mcp_server(process: subprocess.Popen) -> bool:
+    """Initialize MCP server with proper handshake"""
+    try:
+        # Send initialize request
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {"roots": {"listChanged": True}, "sampling": {}},
+                "clientInfo": {"name": "fluidmcp-client", "version": "1.0.0"}
+            }
+        }
+        
+        process.stdin.write(json.dumps(init_request) + "\n")
+        process.stdin.flush()
+        
+        # Wait for response
+        start_time = time.time()
+        while time.time() - start_time < 10:
+            if process.poll() is not None:
+                return False
+            response_line = process.stdout.readline().strip()
+            if response_line:
+                response = json.loads(response_line)
+                if response.get("id") == 0 and "result" in response:
+                    # Send initialized notification
+                    notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+                    process.stdin.write(json.dumps(notif) + "\n")
+                    process.stdin.flush()
+                    return True
+            time.sleep(0.1)
+        return False
+    except Exception as e:
+        print(f"Initialization error: {e}")
+        return False
+
+# Global session storage
+active_sessions: Dict[str, Dict[str, Any]] = {}
+persistent_tool_sessions: Dict[str, str] = {}  # Maps package_name to session_id

--- a/fluidai_mcp/services/utils/npm_utils.py
+++ b/fluidai_mcp/services/utils/npm_utils.py
@@ -1,0 +1,76 @@
+"""
+NPM utility functions for fixing permissions and environment setup
+"""
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Dict
+
+def fix_npm_permissions() -> bool:
+    """Fix npm permissions automatically without requiring sudo"""
+    try:
+        npm_cache_dir = Path.home() / ".npm"
+        npm_global_dir = Path.home() / ".npm-global"
+        
+        # Check if we have permission issues
+        if npm_cache_dir.exists():
+            try:
+                # Try to create a test file in npm cache
+                test_file = npm_cache_dir / "test_permissions"
+                test_file.touch()
+                test_file.unlink()
+            except PermissionError:
+                print("🔧 Fixing npm cache permissions...")
+                # Clear the problematic cache instead of using sudo
+                if npm_cache_dir.exists():
+                    try:
+                        shutil.rmtree(npm_cache_dir)
+                        npm_cache_dir.mkdir(exist_ok=True)
+                        print("✅ Cleared npm cache")
+                    except Exception as e:
+                        print(f"⚠️  Could not clear npm cache: {e}")
+        
+        # Set up npm global directory
+        if not npm_global_dir.exists():
+            npm_global_dir.mkdir(exist_ok=True)
+            
+        # Configure npm to use the new directory
+        try:
+            subprocess.run(
+                ["npm", "config", "set", "prefix", str(npm_global_dir)], 
+                check=False, 
+                capture_output=True
+            )
+            subprocess.run(
+                ["npm", "config", "set", "cache", str(npm_cache_dir)], 
+                check=False, 
+                capture_output=True
+            )
+            print("✅ Configured npm global directory")
+        except Exception as e:
+            print(f"⚠️  Could not configure npm: {e}")
+            
+        return True
+    except Exception as e:
+        print(f"⚠️  Error fixing npm permissions: {e}")
+        return False
+
+def create_clean_npm_environment() -> Dict[str, str]:
+    """Create a clean npm environment for the current session"""
+    try:
+        # Create temporary directories
+        temp_cache = Path.cwd() / ".temp_npm_cache"
+        temp_global = Path.cwd() / ".temp_npm_global"
+        
+        temp_cache.mkdir(exist_ok=True)
+        temp_global.mkdir(exist_ok=True)
+        
+        # Return environment variables for clean npm
+        return {
+            "NPM_CONFIG_CACHE": str(temp_cache),
+            "NPM_CONFIG_PREFIX": str(temp_global),
+            "NPM_CONFIG_USER_CONFIG": "/dev/null",  # Ignore user config
+            "NPM_CONFIG_GLOBAL_CONFIG": "/dev/null"  # Ignore global config
+        }
+    except Exception:
+        return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,60 @@
 [build-system]
-requires = ["setuptools>=42", "wheel"]
+requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "fmcp-trial-atharva" 
+version = "1.1.0"
+description = "FluidMCP - Universal MCP server launcher and remote client (Trial Version)"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "Atharva Nawadkar", email = "atharva.n@trutech.org"}]
+keywords = ["mcp", "model-context-protocol", "ai", "tools", "trial"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "aiohttp>=3.8.0",
+    "fastapi>=0.100.0",
+    "uvicorn>=0.20.0",
+    "loguru>=0.7.0",
+    "boto3>=1.26.0",
+    "requests>=2.28.0",
+    "psutil>=5.9.0",
+    "pydantic>=2.0.0",
+    "click>=8.0.0",
+    "httpx>=0.24.0", 
+    "sse-starlette>=2.0.0",  
+]
+
+[project.urls]
+Homepage = "https://github.com/yourusername/fluidmcp"
+Documentation = "https://github.com/yourusername/fluidmcp#readme"
+Repository = "https://github.com/yourusername/fluidmcp"
+Issues = "https://github.com/yourusername/fluidmcp/issues"
+
+[project.scripts]
+fluidmcp = "fluidai_mcp.cli:main"
+fmcp = "fluidai_mcp.cli:main"  # Shorter alias
+
+# Optional tools configuration
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "black>=22.0",
+    "flake8>=4.0",
+    "twine>=4.0",
+    "build>=0.8",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ urllib3==2.4.0
 uvicorn==0.34.2
 uv==0.7.2
 asyncio==3.4.3
+aiohttp==3.9.4


### PR DESCRIPTION
- Created a mcp_remote_client.py which acts as a bridge between SSE server and MCP Client (Claude,Cursor) and translates between stdio(claude/cursor) and SSE(fmcp server). 
- Also made a few changes in package manager by modularizing and cleaning the code a bit. 
- Added "fmcp remote" to cli.py .
- Also made changes to the pyproject to publish it on PiPy. I have published a trial version on PiPy which anyone can use for connecting the server to claude.

- Connecting to claude:
-- fmcp run all
-- put this in claude_desktop_config.json:
```
{
  "mcpServers": {
    "fluidmcp-uvx": {
      "command": "uvx",
      "args": ["--from", "fmcp-trial-atharva","fmcp","remote","http://localhost:8099"]
    }
  }
}
```
-- check if you can see the tools on claude desktop:
<img width="616" alt="Screenshot 2025-06-12 at 7 07 53 PM" src="https://github.com/user-attachments/assets/eb83e8bc-d542-46e6-b817-e8a8c7489bd1" />
