### PR TITLE
feat: prompt for edit-env-variables during package installation

### DIFF
--- a/fluidai_mcp/cli.py
+++ b/fluidai_mcp/cli.py
@@ -603,17 +603,22 @@ def install_command(args):
     Handles the 'install' CLI command, including --master logic.
     """
     pkg = parse_package_string(args.package)
-    # Install the package, skip env prompts if --master
-    install_package(args.package, skip_env=getattr(args, "master", False))
+    # Install the package, skip env prompts ONLY if --master flag is used
+    skip_env = getattr(args, "master", False)
+    install_package(args.package, skip_env=skip_env)
+    
     try:
         dest_dir = resolve_package_dest_dir(args.package)
     except Exception as e:
         print(str(e))
         sys.exit(1)
+        
     if not package_exists(dest_dir):
         print(f"Package not found at {dest_dir}. Have you installed it?")
         sys.exit(1)
-    if getattr(args, "master", False):
+        
+    # Only use master env logic if --master flag is used
+    if skip_env:  # This means --master was used
         update_env_from_common_env(dest_dir, pkg)
 
 def run_from_source(source,source_path, secure_mode=False, token=None):

--- a/fluidai_mcp/services/package_installer.py
+++ b/fluidai_mcp/services/package_installer.py
@@ -8,7 +8,7 @@ from typing import Dict, Any
 from pathlib import Path
 from loguru import logger
 from io import BytesIO
-from .env_manager import write_keys_during_install
+from .env_manager import write_keys_during_install, prompt_for_env_variables
 from .package_list import get_latest_version_dir
 
 # Environment variables for configuration
@@ -115,16 +115,21 @@ def install_package(package_str, skip_env=False):
         else:
             raise Exception("Unknown file type received from S3")
 
+        # NEW: Handle environment variables during installation
         try:
-            write_keys_during_install(dest_dir, pkg, skip_env=skip_env)
+            if not skip_env:
+                prompt_for_env_variables(dest_dir, pkg)
+            else:
+                write_keys_during_install(dest_dir, pkg, skip_env=skip_env)
         except Exception as e:
-            print(f":x: Error writing keys during installation: {e}")
+            print(f":x: Error setting up environment variables: {e}")
             return
         
         print(f":white_check_mark: Installation completed successfully.")
     except Exception as e:
         # Handle any errors that occur during the installation process
         print(f":x: Installation failed: {e}")
+
 
 def package_exists(dest_dir: Path) -> bool:
     """Check if the destination directory exists.


### PR DESCRIPTION
Fixed the bug that user had to use edit-env everytime they had to set the env-variables, and added `prompt_for_env_variables` function to **implement an interactive environment variable setup during installation**.
- It checks for env{} present in metadata.json and asks user if they want to change the placeholder values.
- User can choose to skip changing the env-variables by pressing 'Enter'.
- the flow doesn't call `prompt_for_env_variables` if we use `--master` as it sets the `skip_env` value to True.
<img width="795" alt="Screenshot 2025-06-20 at 5 34 38 PM" src="https://github.com/user-attachments/assets/7dd0a8da-1a30-442d-94be-9f1567fcb435" />
