### PR TITLE
Add GitHub cloning option for MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ fluidmcp list
 fluidmcp run ./config.json --file
 ```
 
+### 3b. Clone & Run Directly from GitHub
+
+```bash
+fluidmcp github owner/repo --github-token <token> --branch main --start-server
+```
+
+You can also declare GitHub-hosted MCP servers inside your local or S3 configuration files using the same fields that the CLI
+expects:
+
+```json
+{
+  "mcpServers": {
+    "my-github-mcp": {
+      "github_repo": "owner/repo",
+      "github_token": "<token>",
+      "branch": "main",
+      "env": {
+        "OPENAI_API_KEY": "sk-..."
+      },
+      "port": 8085
+    }
+  }
+}
+```
+
+The CLI will clone the repository into the standard `.fmcp-packages` layout before launching it. If you omit `github_token` per
+server, set a default via the JSON top-level `github_token` field or environment variables `FMCP_GITHUB_TOKEN`/`GITHUB_TOKEN`.
+
 
 ---
 


### PR DESCRIPTION
## Summary
- add a `github` CLI command that clones MCP servers from GitHub using a provided access token and runs them through the FastAPI gateway
- normalize GitHub repo inputs, clone into the standard installation layout, and reuse existing FastAPI launch logic for the cloned server
- document the new GitHub workflow in the README quick start guide
- allow GitHub repo MCP definitions in file/S3 configs, cloning them with provided tokens before launching via FastAPI

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921c18ebe608329967f9dac3522127a)