### PR TITLE
Fix license reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ FluidMCP is open for collaboration. Feel free to open issues or submit PRs.
 ## 📌 License
 
 
-[MIT License](LICENSE)
+[GNU General Public License v3.0](LICENSE)
 
 
 ---


### PR DESCRIPTION
## Summary
- Updated the license link in README.md from "MIT License" to "GNU General Public License v3.0" to match the actual LICENSE file in the repository

## Test plan
- [x] Verified LICENSE file contains GPL-3.0 text
- [x] Updated README.md reference to match
- [x] Confirmed link still points to LICENSE file correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)