### PR TITLE
Added documentation for metadata schema and troubleshooting

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,261 @@
+FluidMCP Troubleshooting Guide
+
+This document lists common errors encountered while using the FluidMCP CLI, explains why they occur, and provides practical steps to resolve them.
+
+FluidMCP errors generally fall into five categories:
+    1. Configuration resolution errors
+    2. Server startup failures
+    3. Port conflicts
+    4. GitHub authentication issues
+    5. Missing system dependencies
+
+Understanding these failure modes will help users debug issues quickly and confidently
+
+1. Common Error Messages and Their Solutions
+
+    ERROR: Package not found: <package>
+
+        Cause
+        - The package is not installed
+        - The package name or version is incorrect
+        - The installation directory is missing or corrupted
+
+        How to Fix
+        - List installed packages:
+            fluidmcp list
+
+        - Verify the package name and version
+        - Reinstall the package:
+            fluidmcp install <author/package@version>
+
+        Check the installation directory (MCP_INSTALLATION_DIR)
+
+
+    ERROR: No installations found.
+
+        Cause
+        - No MCP packages have been installed yet
+        - The installation directory does not exist
+
+        How to Fix
+        - Install at least one package:
+        - fluidmcp install <package>
+
+        Ensure the installation directory is accessible
+
+
+    ERROR: No metadata.json found at <path>
+
+        Cause
+        - The package installation is incomplete
+        - metadata.json was deleted or corrupted
+
+        How to Fix
+        - Reinstall the package
+        - Verify the package directory structure
+
+
+    ERROR: Invalid configuration in <file>
+
+        Cause
+            - The JSON file is malformed
+            - Required fields (such as mcpServers) are missing
+            - The configuration schema is incorrect
+
+        How to Fix
+            - Validate the JSON syntax (use a JSON linter)
+            - Compare the file against a known valid sample
+            - Ensure mcpServers is present and correctly structured
+
+
+    Warning: Unknown format for server '<name>'
+
+        Cause
+        - A server entry does not match any supported configuration format
+        - The server definition is neither a package string, GitHub config, nor direct command config
+
+        How to Fix
+        - Verify the server entry format
+        - Ensure it follows one of the supported configuration styles
+        - Warnings do not always stop execution, but affected servers may be skipped.
+        
+
+2. Debugging Server Startup Failures       
+
+    ERROR: Failed to launch MCP server
+
+        Cause
+        - Invalid or missing metadata
+        - Runtime errors inside the server code
+        - Missing dependencies required by the server
+
+        How to Debug
+        - Inspect metadata.json for the server
+        - Try running the server command manually
+        - Check logs printed during startup
+        - Verify required dependencies are installed
+
+
+    ERROR: Error running servers
+
+        Cause
+        - Configuration resolution failed
+        - One or more servers failed during startup
+        - Runtime exceptions occurred while launching servers
+
+        How to Fix
+        - Identify whether the error is:
+            - Configuration-related (file, package, S3)
+            - Runtime-related (server process, dependencies)
+        - Fix the root cause and rerun:
+            fluidmcp run <package>
+
+
+3. Port Conflict Resolution
+
+    ERROR: Port <port> is already in use
+
+        Cause
+        - Another process is already using the required port
+        - A previously launched server is still running
+
+        How FluidMCP Handles This
+        - Detects the conflict automatically
+        - Prompts user to kill the existing process
+        - Supports forced reload with a flag
+
+        How to Fix
+        - Use force reload:
+            fluidmcp run <package> --force-reload
+
+        - Or manually stop the process using the port
+
+        Default Ports
+        - Client FastAPI server: 8090 (GitHub command)
+        - SuperGateway: 8111 (run command)
+
+
+4. GitHub Authentication Issues
+
+    ERROR: GitHub token missing for server '<name>'
+
+        Cause
+        - No GitHub token provided
+        - Required environment variables are missing
+
+        How to Fix
+        - Provide a GitHub Personal Access Token (PAT) using one of:
+            - CLI flag:
+                --github-token <TOKEN>
+
+        - Environment variables:
+            - FMCP_GITHUB_TOKEN
+            - GITHUB_TOKEN
+
+        Token Requirements
+        - Must have read access to the repository
+        - Required for private repositories
+
+
+    ERROR: Error preparing GitHub server '<name>'
+
+        Cause
+        - Repository clone failure
+        - Invalid repository URL
+        - Metadata extraction failed
+        - Network or permission issues
+
+        How to Fix
+        - Verify repository URL and branch
+        - Ensure the token has correct permissions
+        - Check network connectivity
+        - Retry after fixing the configuration
+
+
+5. Missing Dependencies (Implicit Errors)
+
+    FluidMCP does not explicitly check for system dependencies.
+    Failures appear as runtime or OS-level errors.
+
+    Common Symptoms
+        [Errno 2] No such file or directory: 'node'
+        command not found
+
+    Required Dependencies
+    - Node.js
+    - npm
+    - Python
+    - uv
+
+    How to Fix
+    - Install the missing dependency
+    - Ensure it is available in your system PATH
+    - Restart your terminal after installation
+
+
+6. S3 Configuration and Sync Issues
+
+    ERROR: Invalid configuration from S3
+
+        Cause
+        - The downloaded S3 file is invalid
+        - The file does not follow the metadata schema
+
+        How to Fix
+        - Verify the contents of the S3 file
+        - Ensure it includes a valid mcpServers section
+
+
+    ERROR: Failed to load s3_metadata_all.json
+
+        Cause
+        - Corrupted or missing S3 metadata file
+        - Download or permission failure
+
+        How to Fix
+        - Check AWS credentials:
+            S3_BUCKET_NAME
+            S3_ACCESS_KEY
+            S3_SECRET_KEY
+            S3_REGION
+
+        - Ensure the bucket and object exist
+        - Re-run in master mode to regenerate metadata
+
+7. Understanding Warnings vs Errors
+
+    Warnings
+    - Printed using print(...)
+    - Execution continues
+    - Affected servers may be skipped
+
+    Errors
+    - Trigger sys.exit(1)
+    - Stop execution immediately
+    I- f execution stops, always check the first error message printed — it usually indicates the root cause.
+
+8. General Debugging Checklist
+
+    If something goes wrong:
+
+    1. Identify the command used (install, run, github, etc.)
+
+    2. Read the first error message carefully
+
+    3. Determine the source:
+        Package
+        File
+        GitHub
+        S3
+
+    4. Verify:
+        metadata.json
+        Environment variables
+        Installed dependencies
+
+    5. Retry after fixing the issue
+
+
+9. Final Note
+    Most FluidMCP issues fall into configuration errors or missing prerequisites.
+    Once those are resolved, server startup is typically smooth.

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -1,0 +1,298 @@
+## Overview: How FluidMCP Handles metadata.json
+
+In FluidMCP, metadata.json is not a single static schema.
+Instead, it represents the final normalized runtime configuration that FluidMCP uses to start MCP servers.
+
+Users are allowed to define MCP servers in multiple ways (package references, GitHub repositories, or direct commands). FluidMCP resolves all these inputs into a uniform executable structure before running the servers.
+
+The goal of this design is to provide flexibility at the input level while keeping execution logic simple and predictable.
+
+### Conceptual Model
+FluidMCP processes server configuration in three conceptual layers:
+
+1. Input Layer (User-Facing Configuration)
+
+Users define servers using one of the supported configuration formats:
+    - Package string reference
+    - Direct command configuration
+    - GitHub repository reference
+
+These inputs may appear in:
+    - A local JSON file
+    - An S3-hosted configuration
+    - CLI-provided configuration
+
+These formats are not executed directly.
+
+
+2. Resolution Layer (Internal Processing)
+
+FluidMCP resolves user input by:
+    - Installing packages
+    - Cloning GitHub repositories
+    - Reading or generating metadata.json
+    - Extracting commands from README files when needed
+    - Injecting runtime fields such as ports and installation paths
+At the end of this process, all servers are normalized into the same runtime format.
+
+3. Runtime Metadata Layer (Executable Truth)
+
+All resolved configurations converge into a canonical structure:
+{
+    "mcpServers": {
+        "<serverName>": {
+        "command": "string",
+        "args": ["string"],
+        "env": {},
+        "port": "number",
+        "install_path": "string"
+        }
+    }
+}
+
+
+This is the only format consumed by:
+    - The MCP launcher
+    - Port assignment logic
+    - Metadata merging
+    - S3 synchronization
+
+Files such as `examples/sample-metadata.json` represent this final resolved state, not all possible input formats.
+
+### metadata.json Structure
+
+Top-Level Structure
+{
+  "mcpServers": { }
+}
+
+    Field   => mcpServers			
+    Required  => Yes
+    Type    =>  object 
+    Description => Map of MCP server definitions
+
+Keys are server names (strings)
+Values define how each server is configured
+
+## Server Entry Types
+
+Each entry inside mcpServers can be one of the following:
+    String → Package reference
+    Object → Direct configuration or GitHub configuration
+
+The allowed shape depends on the configuration format used.
+
+## Runtime Server Fields (Resolved Metadata)
+
+After resolution, every server entry contains the following fields:
+
+Field	        Required	            Description
+command	        Yes	            Executable used to start the server
+args	          Yes	            Command-line arguments
+env	            No	            Environment variables
+port	          Yes (auto)	    Unique port assigned by FluidMCP
+install_path	  Yes (auto)	    Path where server is installed or cloned
+
+Note:
+port and install_path are never expected to be provided by the user.
+They are injected during resolution.
+
+### Field Types and Validation Rules
+
+# Structural Validation
+    mcpServers must exist
+    mcpServers must be an object
+    Server names must be strings
+    Invalid JSON or missing structure results in immediate failure
+
+Validation is performed before resolution begins.
+
+# Package String Validation
+
+Example:
+
+"filesystem": "@modelcontextprotocol/server-filesystem"
+
+Rules:
+    - Must be a valid package identifier
+    - Must be resolvable from the package registry
+    - Must provide valid metadata after installation
+
+Failure cases:
+    - Package not found
+    - Missing or invalid metadata.json
+    - Registry lookup failure
+
+# Direct Configuration Validation
+
+Example:
+
+"filesystem": {
+  "command": "npx",
+  "args": [
+    "-y",
+    "@modelcontextprotocol/server-filesystem",
+    "/tmp/test-directory"
+  ],
+  "env": {}
+}
+
+Rules:
+    - command is required
+    - args must be an array (defaults to empty if missing)
+    - env must be an object if provided
+
+Resolution behavior:
+    - FluidMCP creates a temporary directory
+    - A metadata.json file is generated automatically
+    - The server is treated like a packaged server internally
+
+# GitHub Repository Validation
+
+Example:
+
+"myServer": {
+  "github_repo": "owner/repo",
+  "branch": "main"
+}
+
+Rules:
+    - github_repo is required
+    - A GitHub access token must be available
+    - Repository must be clonable
+    - Startup metadata must be extractable or creatable
+
+Resolution behavior:
+    - Repository is cloned locally
+    - If command is provided, it is used directly
+    - Otherwise, FluidMCP attempts to extract startup information from:
+        * Existing metadata.json, or
+        * README files
+
+Failure cases:
+  - Missing GitHub token
+  - Clone failure
+  - No startup instructions found
+
+### Supported Configuration Formats (Examples)
+1. Package String Configuration
+{
+  "mcpServers": {
+    "filesystem": "@modelcontextprotocol/server-filesystem"
+  }
+}
+
+FluidMCP will:
+  - Install the package
+  - Read its metadata
+  - Expand it into a runtime server configuration
+  - Package strings are expanded during preprocessing before validation.
+Note: This format is supported by FluidMCP but is not shown in the current sample files.
+
+2. Direct Configuration
+Source: `sample-config.json`, `sample-config-with-api-keys.json`
+
+{ 
+  "mcpServers": { 
+    "filesystem": { 
+      "command": "npx", 
+      "args": [ "-y", "@modelcontextprotocol/server-filesystem", "/tmp/test-directory" ], 
+      "env": {} 
+    } 
+  } 
+}
+
+Example with environment variables:
+
+{ 
+  "mcpServers": { 
+    "google-maps": { 
+      "command": "npx", 
+      "args": [ "-y", "@google-maps/mcp-server" ], 
+      "env": { "GOOGLE_MAPS_API_KEY": "your-api-key-here" } 
+    } 
+  } 
+}
+
+FluidMCP will:
+  - Generate a temporary metadata.json
+  - Assign a port
+  - Run the server like any other MCP server
+
+3. GitHub Repository Configuration (Automatic Metadata Extraction)
+Source: `sample-github-config.json`
+
+{ 
+  "mcpServers": { 
+    "fastmcp-quickstart": { 
+      "github_repo": "modelcontextprotocol/python-sdk", 
+      "github_token": "your-github-token-here", 
+      "branch": "main", 
+      "env": {} 
+    } 
+  } 
+}
+
+FluidMCP will:
+  - Clone the repository
+  - If metadata.json exists, it is used directly
+  - Otherwise, FluidMCP searches for a README file and attempts to infer startup commands
+
+4. GitHub Repository Configuration (Explicit Command)
+Source: `sample-github-with-command.json`
+
+{ 
+  "mcpServers": { 
+    "python-quickstart-explicit": { 
+      "github_repo": "modelcontextprotocol/python-sdk", 
+      "branch": "main", 
+      "command": "uv", 
+      "args": [ "run", "examples/snippets/servers/fastmcp_quickstart.py" ], 
+      "env": {} 
+    } 
+  } 
+}
+
+When command and args are explicitly provided:
+  - README parsing is skipped
+  - metadata.json is generated directly from the provided command
+
+
+### Common Mistakes and How to Avoid Them
+
+WRONG: Mixing configuration formats incorrectly
+"server": {
+  "command": "node",
+  "github_repo": "owner/repo"
+}
+    CORRECT: Use one format per server entry.
+
+
+WRONG: Missing GitHub token
+GitHub-based servers require authentication.
+CORRECT: Set one of:
+    - github_token in config
+    - FMCP_GITHUB_TOKEN
+    - GITHUB_TOKEN
+
+
+WRONG: Assuming port is user-defined
+Ports are auto-assigned.
+    CORRECT: Let FluidMCP manage ports.
+
+
+WRONG: Invalid package strings
+Unresolvable package names cause preprocessing failures.
+    CORRECT: Verify package identifiers before use.
+
+
+WRONG: Assuming README parsing is guaranteed
+README extraction is a fallback, not a guarantee.
+CORRECT: Prefer repositories with existing metadata.json or provide command explicitly.
+
+
+### Summary
+    - metadata.json is a resolved runtime contract, not just user input.
+    - Multiple configuration formats are supported.
+    - All inputs normalize into a single executable structure.
+    - Understanding the resolution pipeline is key to correct usage.


### PR DESCRIPTION
## Summary

This PR adds documentation to improve FluidMCP onboarding and debugging.

### Changes included
- Added `docs/metadata-schema.md` documenting the `metadata.json` schema:
    - Required vs optional fields
    - Supported configuration formats (package string, direct config, file/S3)
    - Validation rules and common mistakes
- Added `docs/TROUBLESHOOTING.md` covering common failure modes:
    - Configuration resolution errors
    - Server startup issues
    - Port conflicts
    - GitHub authentication problems
    - Missing dependencies and environment setup

### Motivation
These documents are based on actual error handling and resolution logic in the CLI and config resolver, and aim to make setup, debugging, and onboarding easier for new contributors and users.

### Scope
- Documentation-only changes
- No code or behavior changes
