### PR TITLE
[MCP-13]-Introduce server status models and restart policy utilities

### DIFF
--- a/fluidai_mcp/models/__init__.py
+++ b/fluidai_mcp/models/__init__.py
@@ -1,0 +1,5 @@
+"""Data models for FluidMCP watchdog and monitoring."""
+
+from .server_status import ServerState, ServerStatus, RestartPolicy
+
+__all__ = ["ServerState", "ServerStatus", "RestartPolicy"]

--- a/fluidai_mcp/models/server_status.py
+++ b/fluidai_mcp/models/server_status.py
@@ -1,0 +1,98 @@
+"""Server status and state tracking models for watchdog."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+
+class ServerState(str, Enum):
+    """Server lifecycle states."""
+    STOPPED = "stopped"
+    STARTING = "starting"
+    RUNNING = "running"
+    HEALTHY = "healthy"
+    UNHEALTHY = "unhealthy"
+    CRASHED = "crashed"
+    RESTARTING = "restarting"
+    FAILED = "failed"
+
+
+@dataclass
+class ServerStatus:
+    """Server status information."""
+    name: str
+    state: ServerState
+    pid: Optional[int] = None
+    port: Optional[int] = None
+    started_at: Optional[datetime] = None
+    last_health_check: Optional[datetime] = None
+    restart_count: int = 0
+    error_message: Optional[str] = None
+
+    def get_uptime_seconds(self) -> Optional[int]:
+        """Calculate uptime in seconds based on started_at timestamp.
+
+        Returns:
+            Uptime in seconds if server is running, None otherwise
+        """
+        if self.started_at is None:
+            return None
+
+        # Compute uptime based on the recorded start time
+        if self.started_at.tzinfo is not None:
+            now = datetime.now(self.started_at.tzinfo)
+        else:
+            now = datetime.now()
+
+        uptime_delta = now - self.started_at
+        return int(uptime_delta.total_seconds())
+
+    def get_status_display(self) -> str:
+        """Get human-readable status display for CLI with colors."""
+        state_emoji = {
+            ServerState.STOPPED: "⏹️",
+            ServerState.STARTING: "🔄",
+            ServerState.RUNNING: "▶️",
+            ServerState.HEALTHY: "✅",
+            ServerState.UNHEALTHY: "⚠️",
+            ServerState.CRASHED: "💥",
+            ServerState.RESTARTING: "🔄",
+            ServerState.FAILED: "❌"
+        }
+
+        emoji = state_emoji.get(self.state, "❓")
+        uptime_str = ""
+
+        uptime_seconds = self.get_uptime_seconds()
+        if uptime_seconds is not None and uptime_seconds > 0:
+            hours = int(uptime_seconds // 3600)
+            minutes = int((uptime_seconds % 3600) // 60)
+            seconds = int(uptime_seconds % 60)
+            uptime_str = f" (uptime: {hours}h {minutes}m {seconds}s)"
+
+        base_str = f"{emoji} {self.name} [{self.state.value}]"
+
+        if self.pid:
+            base_str += f" PID:{self.pid}"
+        if self.port:
+            base_str += f" Port:{self.port}"
+        if self.restart_count > 0:
+            base_str += f" Restarts:{self.restart_count}"
+
+        base_str += uptime_str
+
+        if self.error_message:
+            base_str += f"\n  Error: {self.error_message}"
+
+        return base_str
+
+
+@dataclass
+class RestartPolicy:
+    """Restart policy configuration."""
+    max_restarts: int = 5
+    initial_delay_seconds: float = 2.0
+    backoff_multiplier: float = 2.0
+    max_delay_seconds: float = 60.0
+    restart_window_seconds: Optional[int] = 300  # 5 minutes

--- a/fluidai_mcp/services/health_checker.py
+++ b/fluidai_mcp/services/health_checker.py
@@ -1,0 +1,189 @@
+"""Health checking utilities for MCP server monitoring."""
+
+import json
+import psutil
+import requests
+from typing import Optional, Tuple
+from datetime import datetime
+from loguru import logger
+
+
+class HealthChecker:
+    """Performs health checks on MCP servers."""
+
+    def __init__(self, http_timeout: int = 5):
+        """Initialize health checker.
+
+        Args:
+            http_timeout: Timeout in seconds for HTTP health checks
+        """
+        self.http_timeout = http_timeout
+
+    def check_process_alive(self, pid: int) -> Tuple[bool, Optional[str]]:
+        """Check if a process is still running.
+
+        Args:
+            pid: Process ID to check
+
+        Returns:
+            Tuple of (is_alive, error_message)
+        """
+        try:
+            process = psutil.Process(pid)
+
+            # Check if process exists and is running
+            if not process.is_running():
+                return False, f"Process {pid} is not running"
+
+            # Check process status
+            status = process.status()
+            if status == psutil.STATUS_ZOMBIE:
+                return False, f"Process {pid} is a zombie"
+            elif status == psutil.STATUS_DEAD:
+                return False, f"Process {pid} is dead"
+
+            return True, None
+
+        except psutil.NoSuchProcess:
+            return False, f"Process {pid} does not exist"
+        except psutil.AccessDenied:
+            # Process exists but we can't access it - assume it's alive
+            logger.warning(f"Access denied checking process {pid}, assuming alive")
+            return True, None
+        except Exception as e:
+            return False, f"Error checking process {pid}: {e}"
+
+    def check_http_health(
+        self,
+        host: str,
+        port: int,
+        path: str = "/health",
+        method: str = "GET"
+    ) -> Tuple[bool, Optional[str]]:
+        """Check HTTP endpoint health.
+
+        Args:
+            host: Server host
+            port: Server port
+            path: Health check endpoint path
+            method: HTTP method (GET or POST)
+
+        Returns:
+            Tuple of (is_healthy, error_message)
+        """
+        url = f"http://{host}:{port}{path}"
+
+        try:
+            if method.upper() == "POST":
+                response = requests.post(url, timeout=self.http_timeout)
+            else:
+                response = requests.get(url, timeout=self.http_timeout)
+
+            # Consider 2xx and 3xx as healthy
+            if 200 <= response.status_code < 400:
+                return True, None
+            else:
+                return False, f"HTTP {response.status_code} from {url}"
+
+        except requests.exceptions.ConnectionError:
+            return False, f"Connection refused to {url}"
+        except requests.exceptions.Timeout:
+            return False, f"Timeout connecting to {url}"
+        except Exception as e:
+            return False, f"Error checking {url}: {e}"
+
+    def check_mcp_jsonrpc_health(
+        self,
+        host: str,
+        port: int,
+        server_name: str
+    ) -> Tuple[bool, Optional[str]]:
+        """Check MCP server health via JSON-RPC ping request.
+
+        Args:
+            host: Server host
+            port: Server port
+            server_name: Name of the MCP server
+
+        Returns:
+            Tuple of (is_healthy, error_message)
+        """
+        url = f"http://{host}:{port}/{server_name}/mcp"
+
+        # JSON-RPC ping request
+        payload = {
+            "jsonrpc": "2.0",
+            "id": f"health_check_{datetime.now().timestamp()}",
+            "method": "ping",
+            "params": {}
+        }
+
+        try:
+            response = requests.post(
+                url,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=self.http_timeout
+            )
+
+            if response.status_code != 200:
+                return False, f"HTTP {response.status_code} from {url}"
+
+            data = response.json()
+
+            # Check for JSON-RPC error
+            if "error" in data:
+                error = data["error"]
+                return False, f"JSON-RPC error: {error.get('message', error)}"
+
+            # Successful response
+            return True, None
+
+        except requests.exceptions.ConnectionError:
+            return False, f"Connection refused to {url}"
+        except requests.exceptions.Timeout:
+            return False, f"Timeout connecting to {url}"
+        except json.JSONDecodeError:
+            return False, f"Invalid JSON response from {url}"
+        except Exception as e:
+            return False, f"Error checking {url}: {e}"
+
+    def check_server_health(
+        self,
+        pid: int,
+        host: str,
+        port: int,
+        server_name: str,
+        use_http_check: bool = True
+    ) -> Tuple[bool, Optional[str]]:
+        """Perform comprehensive health check on a server.
+
+        Checks both process status and HTTP endpoint (if enabled).
+
+        Args:
+            pid: Process ID
+            host: Server host
+            port: Server port
+            server_name: Name of the MCP server
+            use_http_check: Whether to check HTTP endpoint
+
+        Returns:
+            Tuple of (is_healthy, error_message)
+        """
+        # First check if process is alive
+        process_alive, process_error = self.check_process_alive(pid)
+
+        if not process_alive:
+            return False, process_error
+
+        # If HTTP checks are disabled, just return process status
+        if not use_http_check:
+            return True, None
+
+        # Check MCP JSON-RPC endpoint
+        http_healthy, http_error = self.check_mcp_jsonrpc_health(host, port, server_name)
+
+        if not http_healthy:
+            return False, http_error
+
+        return True, None

--- a/fluidai_mcp/services/restart_manager.py
+++ b/fluidai_mcp/services/restart_manager.py
@@ -1,0 +1,189 @@
+"""Restart policy management with exponential backoff."""
+
+import time
+from datetime import datetime, timedelta
+from typing import Dict, Optional, Tuple
+from loguru import logger
+
+from ..models.server_status import RestartPolicy
+
+
+class RestartManager:
+    """Manages server restart policies and tracks restart attempts."""
+
+    def __init__(self):
+        """Initialize restart manager."""
+        self._restart_history: Dict[str, list] = {}  # server_name -> list of restart timestamps
+        self._backoff_state: Dict[str, int] = {}  # server_name -> current backoff level
+
+    def can_restart(
+        self,
+        server_name: str,
+        policy: RestartPolicy,
+        current_restart_count: int
+    ) -> Tuple[bool, Optional[str]]:
+        """Check if a server can be restarted based on its policy.
+
+        Args:
+            server_name: Name of the server
+            policy: Restart policy configuration
+            current_restart_count: Current number of restarts
+
+        Returns:
+            Tuple of (can_restart, reason_if_not)
+        """
+        # Check if max restarts reached
+        if current_restart_count >= policy.max_restarts:
+            return False, f"Max restarts ({policy.max_restarts}) reached"
+
+        # Check restart window if configured
+        if policy.restart_window_seconds:
+            now = datetime.now()
+            window_start = now - timedelta(seconds=policy.restart_window_seconds)
+
+            # Get restart history within window
+            history = self._restart_history.get(server_name, [])
+            recent_restarts = [
+                ts for ts in history
+                if ts > window_start
+            ]
+
+            # Check if too many restarts in window
+            if len(recent_restarts) >= policy.max_restarts:
+                return False, (
+                    f"Too many restarts ({len(recent_restarts)}) "
+                    f"in {policy.restart_window_seconds}s window"
+                )
+
+        return True, None
+
+    def calculate_backoff_delay(
+        self,
+        server_name: str,
+        policy: RestartPolicy,
+        restart_count: int
+    ) -> float:
+        """Calculate backoff delay before next restart.
+
+        Uses exponential backoff: initial_delay * (backoff_multiplier ^ restart_count)
+
+        Args:
+            server_name: Name of the server
+            policy: Restart policy configuration
+            restart_count: Number of restarts so far
+
+        Returns:
+            Delay in seconds
+        """
+        # Calculate exponential backoff with a conservative exponent cap to avoid excessively large delays
+        exponent = min(restart_count, 10)  # Cap exponent to prevent excessively large intermediate values
+        delay = policy.initial_delay_seconds * (policy.backoff_multiplier ** exponent)
+        delay = min(delay, policy.max_delay_seconds)
+
+        logger.debug(
+            f"Calculated backoff delay for {server_name}: "
+            f"{delay:.2f}s (restart #{restart_count})"
+        )
+
+        return delay
+
+    def record_restart(self, server_name: str) -> None:
+        """Record a restart attempt.
+
+        Args:
+            server_name: Name of the server
+        """
+        now = datetime.now()
+
+        if server_name not in self._restart_history:
+            self._restart_history[server_name] = []
+
+        self._restart_history[server_name].append(now)
+
+        logger.debug(f"Recorded restart for {server_name} at {now}")
+
+    def reset_restart_history(self, server_name: str) -> None:
+        """Reset restart history for a server (e.g., after successful recovery).
+
+        Args:
+            server_name: Name of the server
+        """
+        if server_name in self._restart_history:
+            del self._restart_history[server_name]
+
+        if server_name in self._backoff_state:
+            del self._backoff_state[server_name]
+
+        logger.info(f"Reset restart history for {server_name}")
+
+    def cleanup_old_history(self, max_age_seconds: int = 3600) -> None:
+        """Clean up old restart history entries.
+
+        Args:
+            max_age_seconds: Maximum age of history entries to keep
+        """
+        cutoff = datetime.now() - timedelta(seconds=max_age_seconds)
+
+        for server_name in list(self._restart_history.keys()):
+            history = self._restart_history[server_name]
+
+            # Filter out old entries
+            recent = [ts for ts in history if ts > cutoff]
+
+            if recent:
+                self._restart_history[server_name] = recent
+            else:
+                # Remove server if no recent history
+                del self._restart_history[server_name]
+
+    def get_restart_stats(self, server_name: str) -> Dict:
+        """Get restart statistics for a server.
+
+        Args:
+            server_name: Name of the server
+
+        Returns:
+            Dictionary with restart statistics
+        """
+        history = self._restart_history.get(server_name, [])
+
+        if not history:
+            return {
+                "total_restarts": 0,
+                "last_restart": None,
+                "recent_restarts_1h": 0,
+                "recent_restarts_24h": 0
+            }
+
+        now = datetime.now()
+        one_hour_ago = now - timedelta(hours=1)
+        one_day_ago = now - timedelta(days=1)
+
+        return {
+            "total_restarts": len(history),
+            "last_restart": max(history).isoformat(),
+            "recent_restarts_1h": len([ts for ts in history if ts > one_hour_ago]),
+            "recent_restarts_24h": len([ts for ts in history if ts > one_day_ago])
+        }
+
+    def wait_with_backoff(
+        self,
+        server_name: str,
+        policy: RestartPolicy,
+        restart_count: int
+    ) -> None:
+        """Wait for the appropriate backoff delay before restarting.
+
+        Args:
+            server_name: Name of the server
+            policy: Restart policy configuration
+            restart_count: Number of restarts so far
+        """
+        delay = self.calculate_backoff_delay(server_name, policy, restart_count)
+
+        if delay > 0:
+            logger.info(
+                f"Waiting {delay:.2f}s before restarting {server_name} "
+                f"(attempt #{restart_count + 1})"
+            )
+            time.sleep(delay)


### PR DESCRIPTION
# PR Summary – Trunk 1 (Watchdog Foundation)

This PR introduces the **foundational building blocks** for the Watchdog / Auto-Respawn feature in FluidMCP.

It adds core **data models** and **utility services** required to track server state, perform health checks, and enforce restart policies.  
No existing behavior is changed and no watchdog logic is activated yet.

---

## ✅ What’s Included

- **ServerState** enum defining server lifecycle states (`stopped`, `starting`, `running`, `healthy`, `unhealthy`, `crashed`, `restarting`, `failed`)
- **ServerStatus** dataclass for tracking PID, uptime, port, and restart count
- **RestartPolicy** dataclass for configurable restart limits and exponential backoff
- **HealthChecker** utility for process and HTTP health checks
- **RestartManager** utility for restart policy enforcement and backoff calculation

---

## ❌ What’s NOT Included

- No CLI changes
- No server auto-restart logic
- No integration with `run_servers.py`
- No watchdog monitoring loop

---

## 🎯 Purpose

This PR lays the **foundation layer** only.  
These utilities will be wired together in subsequent PRs to enable full watchdog and auto-respawn functionality.

---

### Optional Short Description

> Adds foundational models and utilities for future Watchdog health checking and restart management.
