### PR TITLE
Address PR #103 review comments - Code quality and test coverage improvements

### DIFF
--- a/fluidai_mcp/models/server_status.py
+++ b/fluidai_mcp/models/server_status.py
@@ -46,10 +46,12 @@ class ServerStatus:
             now = datetime.now()
 
         uptime_delta = now - self.started_at
-        return int(uptime_delta.total_seconds())
+        uptime_seconds = int(uptime_delta.total_seconds())
+        # Ensure uptime is never negative (possible with future started_at due to clock skew/manual changes)
+        return max(0, uptime_seconds)
 
     def get_status_display(self) -> str:
-        """Get human-readable status display for CLI with colors."""
+        """Get human-readable status display string for CLI using emoji icons."""
         state_emoji = {
             ServerState.STOPPED: "⏹️",
             ServerState.STARTING: "🔄",

--- a/fluidai_mcp/services/health_checker.py
+++ b/fluidai_mcp/services/health_checker.py
@@ -98,7 +98,7 @@ class HealthChecker:
         port: int,
         server_name: str
     ) -> Tuple[bool, Optional[str]]:
-        """Check MCP server health via JSON-RPC ping request.
+        """Check MCP server health via JSON-RPC tools/list request.
 
         Args:
             host: Server host
@@ -110,11 +110,11 @@ class HealthChecker:
         """
         url = f"http://{host}:{port}/{server_name}/mcp"
 
-        # JSON-RPC ping request
+        # JSON-RPC tools/list request (standard MCP method)
         payload = {
             "jsonrpc": "2.0",
             "id": f"health_check_{datetime.now().timestamp()}",
-            "method": "ping",
+            "method": "tools/list",
             "params": {}
         }
 
@@ -134,7 +134,7 @@ class HealthChecker:
             # Check for JSON-RPC error
             if "error" in data:
                 error = data["error"]
-                return False, f"JSON-RPC error: {error.get('message', error)}"
+                return False, f"JSON-RPC error: {error.get('message', str(error))}"
 
             # Successful response
             return True, None

--- a/tests/test_health_checker.py
+++ b/tests/test_health_checker.py
@@ -1,0 +1,368 @@
+"""Unit tests for HealthChecker class."""
+
+import pytest
+import psutil
+from unittest.mock import Mock, patch, MagicMock
+from fluidai_mcp.services.health_checker import HealthChecker
+
+
+class TestHealthChecker:
+    """Test suite for HealthChecker class."""
+
+    @pytest.fixture
+    def health_checker(self):
+        """Create a HealthChecker instance for testing."""
+        return HealthChecker(http_timeout=5)
+
+    def test_init(self, health_checker):
+        """Test HealthChecker initialization."""
+        assert health_checker.http_timeout == 5
+
+    # Process Health Check Tests
+
+    @patch('psutil.Process')
+    def test_check_process_alive_success(self, mock_process_class, health_checker):
+        """Test successful process health check."""
+        mock_process = Mock()
+        mock_process.is_running.return_value = True
+        mock_process.status.return_value = psutil.STATUS_RUNNING
+        mock_process_class.return_value = mock_process
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is True
+        assert error is None
+        mock_process_class.assert_called_once_with(1234)
+
+    @patch('psutil.Process')
+    def test_check_process_alive_not_running(self, mock_process_class, health_checker):
+        """Test process health check when process is not running."""
+        mock_process = Mock()
+        mock_process.is_running.return_value = False
+        mock_process_class.return_value = mock_process
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is False
+        assert "Process 1234 is not running" in error
+
+    @patch('psutil.Process')
+    def test_check_process_alive_zombie(self, mock_process_class, health_checker):
+        """Test process health check when process is a zombie."""
+        mock_process = Mock()
+        mock_process.is_running.return_value = True
+        mock_process.status.return_value = psutil.STATUS_ZOMBIE
+        mock_process_class.return_value = mock_process
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is False
+        assert "zombie" in error.lower()
+
+    @patch('psutil.Process')
+    def test_check_process_alive_dead(self, mock_process_class, health_checker):
+        """Test process health check when process is dead."""
+        mock_process = Mock()
+        mock_process.is_running.return_value = True
+        mock_process.status.return_value = psutil.STATUS_DEAD
+        mock_process_class.return_value = mock_process
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is False
+        assert "dead" in error.lower()
+
+    @patch('psutil.Process')
+    def test_check_process_alive_no_such_process(self, mock_process_class, health_checker):
+        """Test process health check when process doesn't exist."""
+        mock_process_class.side_effect = psutil.NoSuchProcess(1234)
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is False
+        assert "does not exist" in error
+
+    @patch('psutil.Process')
+    def test_check_process_alive_access_denied(self, mock_process_class, health_checker):
+        """Test process health check when access is denied."""
+        mock_process_class.side_effect = psutil.AccessDenied(1234)
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        # Should assume alive when access denied
+        assert is_alive is True
+        assert error is None
+
+    @patch('psutil.Process')
+    def test_check_process_alive_exception(self, mock_process_class, health_checker):
+        """Test process health check with unexpected exception."""
+        mock_process_class.side_effect = Exception("Unexpected error")
+
+        is_alive, error = health_checker.check_process_alive(1234)
+
+        assert is_alive is False
+        assert "Error checking process 1234" in error
+
+    # HTTP Health Check Tests
+
+    @patch('requests.get')
+    def test_check_http_health_success_get(self, mock_get, health_checker):
+        """Test successful HTTP health check with GET."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_get.return_value = mock_response
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080, "/health", "GET")
+
+        assert is_healthy is True
+        assert error is None
+        mock_get.assert_called_once_with("http://localhost:8080/health", timeout=5)
+
+    @patch('requests.post')
+    def test_check_http_health_success_post(self, mock_post, health_checker):
+        """Test successful HTTP health check with POST."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080, "/health", "POST")
+
+        assert is_healthy is True
+        assert error is None
+        mock_post.assert_called_once_with("http://localhost:8080/health", timeout=5)
+
+    @patch('requests.get')
+    def test_check_http_health_3xx_redirect(self, mock_get, health_checker):
+        """Test HTTP health check with 3xx redirect (should be healthy)."""
+        mock_response = Mock()
+        mock_response.status_code = 301
+        mock_get.return_value = mock_response
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is True
+        assert error is None
+
+    @patch('requests.get')
+    def test_check_http_health_4xx_error(self, mock_get, health_checker):
+        """Test HTTP health check with 4xx error."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is False
+        assert "HTTP 404" in error
+
+    @patch('requests.get')
+    def test_check_http_health_5xx_error(self, mock_get, health_checker):
+        """Test HTTP health check with 5xx error."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is False
+        assert "HTTP 500" in error
+
+    @patch('requests.get')
+    def test_check_http_health_connection_error(self, mock_get, health_checker):
+        """Test HTTP health check with connection error."""
+        import requests
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is False
+        assert "Connection refused" in error
+
+    @patch('requests.get')
+    def test_check_http_health_timeout(self, mock_get, health_checker):
+        """Test HTTP health check with timeout."""
+        import requests
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is False
+        assert "Timeout" in error
+
+    @patch('requests.get')
+    def test_check_http_health_generic_exception(self, mock_get, health_checker):
+        """Test HTTP health check with generic exception."""
+        mock_get.side_effect = Exception("Network error")
+
+        is_healthy, error = health_checker.check_http_health("localhost", 8080)
+
+        assert is_healthy is False
+        assert "Error checking" in error
+
+    # MCP JSON-RPC Health Check Tests
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_success(self, mock_post, health_checker):
+        """Test successful MCP JSON-RPC health check."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "health_check_123",
+            "result": {"tools": []}
+        }
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is True
+        assert error is None
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_json_rpc_error(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with JSON-RPC error."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "health_check_123",
+            "error": {
+                "code": -32601,
+                "message": "Method not found"
+            }
+        }
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "JSON-RPC error" in error
+        assert "Method not found" in error
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_json_rpc_error_no_message(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with JSON-RPC error without message key."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "jsonrpc": "2.0",
+            "id": "health_check_123",
+            "error": {
+                "code": -32601
+            }
+        }
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "JSON-RPC error" in error
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_http_error(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with HTTP error."""
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "HTTP 500" in error
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_connection_error(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with connection error."""
+        import requests
+        mock_post.side_effect = requests.exceptions.ConnectionError()
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "Connection refused" in error
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_timeout(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with timeout."""
+        import requests
+        mock_post.side_effect = requests.exceptions.Timeout()
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "Timeout" in error
+
+    @patch('requests.post')
+    def test_check_mcp_jsonrpc_health_invalid_json(self, mock_post, health_checker):
+        """Test MCP JSON-RPC health check with invalid JSON response."""
+        import json as json_module
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.side_effect = json_module.JSONDecodeError("error", "doc", 0)
+        mock_post.return_value = mock_response
+
+        is_healthy, error = health_checker.check_mcp_jsonrpc_health("localhost", 8099, "test-server")
+
+        assert is_healthy is False
+        assert "Invalid JSON response" in error
+
+    # Comprehensive Server Health Check Tests
+
+    @patch.object(HealthChecker, 'check_mcp_jsonrpc_health')
+    @patch.object(HealthChecker, 'check_process_alive')
+    def test_check_server_health_success_with_http(
+        self, mock_process_check, mock_http_check, health_checker
+    ):
+        """Test successful comprehensive server health check with HTTP."""
+        mock_process_check.return_value = (True, None)
+        mock_http_check.return_value = (True, None)
+
+        is_healthy, error = health_checker.check_server_health(
+            1234, "localhost", 8099, "test-server", use_http_check=True
+        )
+
+        assert is_healthy is True
+        assert error is None
+        mock_process_check.assert_called_once_with(1234)
+        mock_http_check.assert_called_once_with("localhost", 8099, "test-server")
+
+    @patch.object(HealthChecker, 'check_process_alive')
+    def test_check_server_health_process_failed(self, mock_process_check, health_checker):
+        """Test comprehensive server health check when process check fails."""
+        mock_process_check.return_value = (False, "Process not running")
+
+        is_healthy, error = health_checker.check_server_health(
+            1234, "localhost", 8099, "test-server", use_http_check=True
+        )
+
+        assert is_healthy is False
+        assert error == "Process not running"
+
+    @patch.object(HealthChecker, 'check_mcp_jsonrpc_health')
+    @patch.object(HealthChecker, 'check_process_alive')
+    def test_check_server_health_http_failed(
+        self, mock_process_check, mock_http_check, health_checker
+    ):
+        """Test comprehensive server health check when HTTP check fails."""
+        mock_process_check.return_value = (True, None)
+        mock_http_check.return_value = (False, "Connection refused")
+
+        is_healthy, error = health_checker.check_server_health(
+            1234, "localhost", 8099, "test-server", use_http_check=True
+        )
+
+        assert is_healthy is False
+        assert error == "Connection refused"
+
+    @patch.object(HealthChecker, 'check_process_alive')
+    def test_check_server_health_no_http_check(self, mock_process_check, health_checker):
+        """Test comprehensive server health check without HTTP check."""
+        mock_process_check.return_value = (True, None)
+
+        is_healthy, error = health_checker.check_server_health(
+            1234, "localhost", 8099, "test-server", use_http_check=False
+        )
+
+        assert is_healthy is True
+        assert error is None
+        mock_process_check.assert_called_once_with(1234)

--- a/tests/test_restart_manager.py
+++ b/tests/test_restart_manager.py
@@ -1,0 +1,350 @@
+"""Unit tests for RestartManager class."""
+
+import pytest
+import time
+from datetime import datetime, timedelta
+from unittest.mock import patch, Mock
+from fluidai_mcp.services.restart_manager import RestartManager, RestartStats
+from fluidai_mcp.models.server_status import RestartPolicy
+
+
+class TestRestartManager:
+    """Test suite for RestartManager class."""
+
+    @pytest.fixture
+    def restart_manager(self):
+        """Create a RestartManager instance for testing."""
+        return RestartManager()
+
+    @pytest.fixture
+    def default_policy(self):
+        """Create a default RestartPolicy for testing."""
+        return RestartPolicy(
+            max_restarts=5,
+            initial_delay_seconds=2,
+            backoff_multiplier=2.0,
+            max_delay_seconds=60,
+            restart_window_seconds=300
+        )
+
+    # Initialization Tests
+
+    def test_init(self, restart_manager):
+        """Test RestartManager initialization."""
+        assert restart_manager._restart_history == {}
+
+    # can_restart Tests
+
+    def test_can_restart_no_history(self, restart_manager, default_policy):
+        """Test can_restart with no restart history."""
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 0)
+
+        assert can_restart is True
+        assert reason is None
+
+    def test_can_restart_below_max(self, restart_manager, default_policy):
+        """Test can_restart when below max restarts."""
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 3)
+
+        assert can_restart is True
+        assert reason is None
+
+    def test_can_restart_at_max(self, restart_manager, default_policy):
+        """Test can_restart when at max restarts."""
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 5)
+
+        assert can_restart is False
+        assert "Max restarts (5) reached" in reason
+
+    def test_can_restart_above_max(self, restart_manager, default_policy):
+        """Test can_restart when above max restarts."""
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 10)
+
+        assert can_restart is False
+        assert "Max restarts (5) reached" in reason
+
+    def test_can_restart_window_check_pass(self, restart_manager, default_policy):
+        """Test can_restart with window check (pass)."""
+        # Record 3 restarts within window
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=100),
+            now - timedelta(seconds=200),
+            now - timedelta(seconds=250)
+        ]
+
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 3)
+
+        assert can_restart is True
+        assert reason is None
+
+    def test_can_restart_window_check_fail(self, restart_manager, default_policy):
+        """Test can_restart with window check (fail)."""
+        # Record 5 restarts within window (at limit)
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=10),
+            now - timedelta(seconds=50),
+            now - timedelta(seconds=100),
+            now - timedelta(seconds=150),
+            now - timedelta(seconds=200)
+        ]
+
+        # Use restart_count=4 so that max_restarts check passes, and window check triggers
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 4)
+
+        assert can_restart is False
+        assert "Too many restarts" in reason
+        assert "in 300s window" in reason
+
+    def test_can_restart_old_restarts_ignored(self, restart_manager, default_policy):
+        """Test can_restart ignores old restarts outside window."""
+        # Record restarts: 2 old (outside window) + 3 new (within window)
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=50),   # Within window
+            now - timedelta(seconds=100),  # Within window
+            now - timedelta(seconds=200),  # Within window
+            now - timedelta(seconds=400),  # Outside window
+            now - timedelta(seconds=500)   # Outside window
+        ]
+
+        can_restart, reason = restart_manager.can_restart("test-server", default_policy, 3)
+
+        assert can_restart is True  # Only 3 recent restarts count
+        assert reason is None
+
+    # calculate_backoff_delay Tests
+
+    def test_calculate_backoff_delay_first_restart(self, restart_manager, default_policy):
+        """Test backoff delay calculation for first restart."""
+        delay = restart_manager.calculate_backoff_delay("test-server", default_policy, 0)
+
+        assert delay == 2  # initial_delay_seconds * (2^0) = 2 * 1 = 2
+
+    def test_calculate_backoff_delay_exponential_growth(self, restart_manager, default_policy):
+        """Test exponential growth of backoff delay."""
+        delays = [
+            restart_manager.calculate_backoff_delay("test-server", default_policy, i)
+            for i in range(6)
+        ]
+
+        expected = [2, 4, 8, 16, 32, 60]  # Last one capped at max_delay_seconds
+        assert delays == expected
+
+    def test_calculate_backoff_delay_capped_at_max(self, restart_manager, default_policy):
+        """Test backoff delay is capped at max_delay_seconds."""
+        delay = restart_manager.calculate_backoff_delay("test-server", default_policy, 10)
+
+        assert delay == 60  # Capped at max_delay_seconds
+
+    def test_calculate_backoff_delay_exponent_capped(self, restart_manager, default_policy):
+        """Test exponent is capped at 10."""
+        delay_10 = restart_manager.calculate_backoff_delay("test-server", default_policy, 10)
+        delay_20 = restart_manager.calculate_backoff_delay("test-server", default_policy, 20)
+
+        assert delay_10 == delay_20  # Both should be capped
+
+    def test_calculate_backoff_delay_large_multiplier_warning(self, restart_manager):
+        """Test warning is logged for large backoff_multiplier."""
+        large_policy = RestartPolicy(
+            max_restarts=5,
+            initial_delay_seconds=2,
+            backoff_multiplier=15.0,  # Too large
+            max_delay_seconds=60,
+            restart_window_seconds=300
+        )
+
+        with patch('fluidai_mcp.services.restart_manager.logger') as mock_logger:
+            delay = restart_manager.calculate_backoff_delay("test-server", large_policy, 1)
+
+            mock_logger.warning.assert_called_once()
+            assert "too large" in mock_logger.warning.call_args[0][0]
+
+    def test_calculate_backoff_delay_multiplier_capped(self, restart_manager):
+        """Test backoff_multiplier is capped at 10.0."""
+        large_policy = RestartPolicy(
+            max_restarts=5,
+            initial_delay_seconds=2,
+            backoff_multiplier=15.0,  # Should be capped to 10.0
+            max_delay_seconds=200,
+            restart_window_seconds=300
+        )
+
+        delay = restart_manager.calculate_backoff_delay("test-server", large_policy, 2)
+
+        # Should use 10.0 instead of 15.0
+        expected = min(2 * (10.0 ** 2), 200)  # 2 * 100 = 200 (at max)
+        assert delay == expected
+
+    # record_restart Tests
+
+    def test_record_restart_new_server(self, restart_manager):
+        """Test recording restart for a new server."""
+        restart_manager.record_restart("test-server")
+
+        assert "test-server" in restart_manager._restart_history
+        assert len(restart_manager._restart_history["test-server"]) == 1
+
+    def test_record_restart_existing_server(self, restart_manager):
+        """Test recording restart for an existing server."""
+        restart_manager.record_restart("test-server")
+        restart_manager.record_restart("test-server")
+
+        assert len(restart_manager._restart_history["test-server"]) == 2
+
+    def test_record_restart_timestamps_ordered(self, restart_manager):
+        """Test restart timestamps are in chronological order."""
+        restart_manager.record_restart("test-server")
+        time.sleep(0.01)
+        restart_manager.record_restart("test-server")
+
+        history = restart_manager._restart_history["test-server"]
+        assert history[0] < history[1]
+
+    # reset_restart_history Tests
+
+    def test_reset_restart_history_existing_server(self, restart_manager):
+        """Test resetting restart history for existing server."""
+        restart_manager.record_restart("test-server")
+        restart_manager.reset_restart_history("test-server")
+
+        assert "test-server" not in restart_manager._restart_history
+
+    def test_reset_restart_history_nonexistent_server(self, restart_manager):
+        """Test resetting restart history for nonexistent server (should not error)."""
+        restart_manager.reset_restart_history("nonexistent")
+
+        # Should not raise an exception
+        assert "nonexistent" not in restart_manager._restart_history
+
+    # cleanup_old_history Tests
+
+    def test_cleanup_old_history_removes_old_entries(self, restart_manager):
+        """Test cleanup removes old entries."""
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=7200),  # Older than 3600s
+            now - timedelta(seconds=5400),  # Older than 3600s
+            now - timedelta(seconds=100),   # Recent
+            now - timedelta(seconds=50)     # Recent
+        ]
+
+        restart_manager.cleanup_old_history(max_age_seconds=3600)
+
+        assert len(restart_manager._restart_history["test-server"]) == 2
+
+    def test_cleanup_old_history_removes_server_if_no_recent(self, restart_manager):
+        """Test cleanup removes server if no recent history."""
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=3700),  # Old
+            now - timedelta(seconds=3800)   # Old
+        ]
+
+        restart_manager.cleanup_old_history(max_age_seconds=3600)
+
+        assert "test-server" not in restart_manager._restart_history
+
+    def test_cleanup_old_history_preserves_recent(self, restart_manager):
+        """Test cleanup preserves recent entries."""
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(seconds=100),
+            now - timedelta(seconds=200)
+        ]
+
+        restart_manager.cleanup_old_history(max_age_seconds=3600)
+
+        assert "test-server" in restart_manager._restart_history
+        assert len(restart_manager._restart_history["test-server"]) == 2
+
+    # get_restart_stats Tests
+
+    def test_get_restart_stats_no_history(self, restart_manager):
+        """Test get_restart_stats with no history."""
+        stats = restart_manager.get_restart_stats("test-server")
+
+        assert stats["total_restarts"] == 0
+        assert stats["last_restart"] is None
+        assert stats["recent_restarts_1h"] == 0
+        assert stats["recent_restarts_24h"] == 0
+
+    def test_get_restart_stats_with_history(self, restart_manager):
+        """Test get_restart_stats with restart history."""
+        now = datetime.now()
+        restart_manager._restart_history["test-server"] = [
+            now - timedelta(minutes=10),   # Within 1h and 24h
+            now - timedelta(minutes=30),   # Within 1h and 24h
+            now - timedelta(hours=2),      # Within 24h only
+            now - timedelta(hours=20),     # Within 24h only
+            now - timedelta(days=2)        # Outside both windows
+        ]
+
+        stats = restart_manager.get_restart_stats("test-server")
+
+        assert stats["total_restarts"] == 5
+        assert stats["last_restart"] is not None
+        assert stats["recent_restarts_1h"] == 2
+        assert stats["recent_restarts_24h"] == 4
+
+    def test_get_restart_stats_return_type(self, restart_manager):
+        """Test get_restart_stats returns RestartStats TypedDict."""
+        restart_manager.record_restart("test-server")
+        stats = restart_manager.get_restart_stats("test-server")
+
+        # Check all required keys are present
+        assert "total_restarts" in stats
+        assert "last_restart" in stats
+        assert "recent_restarts_1h" in stats
+        assert "recent_restarts_24h" in stats
+
+    # wait_with_backoff Tests
+
+    @patch('time.sleep')
+    def test_wait_with_backoff_positive_delay(self, mock_sleep, restart_manager, default_policy):
+        """Test wait_with_backoff with positive delay."""
+        restart_manager.wait_with_backoff("test-server", default_policy, 2)
+
+        expected_delay = 8  # initial_delay (2) * (2^2) = 8
+        mock_sleep.assert_called_once_with(expected_delay)
+
+    @patch('time.sleep')
+    def test_wait_with_backoff_zero_delay(self, mock_sleep, restart_manager):
+        """Test wait_with_backoff with zero delay."""
+        zero_policy = RestartPolicy(
+            max_restarts=5,
+            initial_delay_seconds=0,
+            backoff_multiplier=2.0,
+            max_delay_seconds=60,
+            restart_window_seconds=300
+        )
+
+        restart_manager.wait_with_backoff("test-server", zero_policy, 0)
+
+        mock_sleep.assert_not_called()
+
+    # Integration Tests
+
+    def test_typical_restart_workflow(self, restart_manager, default_policy):
+        """Test typical restart workflow."""
+        server_name = "test-server"
+
+        # First restart
+        can_restart, _ = restart_manager.can_restart(server_name, default_policy, 0)
+        assert can_restart is True
+        restart_manager.record_restart(server_name)
+
+        # Second restart
+        can_restart, _ = restart_manager.can_restart(server_name, default_policy, 1)
+        assert can_restart is True
+        restart_manager.record_restart(server_name)
+
+        # Check stats
+        stats = restart_manager.get_restart_stats(server_name)
+        assert stats["total_restarts"] == 2
+
+        # Reset and verify
+        restart_manager.reset_restart_history(server_name)
+        stats = restart_manager.get_restart_stats(server_name)
+        assert stats["total_restarts"] == 0


### PR DESCRIPTION
## Summary

This PR addresses all review comments from the merged PR #103 (trunk-1-watchdog-foundation). It includes code quality improvements and comprehensive test coverage for the watchdog foundation components.

## Changes Made

### RestartManager Improvements
- ✅ Fixed type hints: Changed `Dict[str, list]` to `Dict[str, List[datetime]]`
- ✅ Removed unused `_backoff_state` field
- ✅ Added validation/capping for `backoff_multiplier` to prevent overflow (caps at 10.0)
- ✅ Added `RestartStats` TypedDict for better type safety
- ✅ Fixed `get_restart_stats()` return type from `Dict` to `RestartStats`

### HealthChecker Improvements
- ✅ Changed MCP health check method from "ping" to "tools/list" (per @abhinav-fluidai suggestion)
- ✅ Fixed error message handling: Changed `error.get('message', error)` to `error.get('message', str(error))`

### ServerStatus Improvements
- ✅ Fixed negative uptime edge case: Added `max(0, uptime_seconds)` protection
- ✅ Fixed misleading docstring: Changed "with colors" to "using emoji icons"

### Test Coverage
- ✅ Added `tests/test_health_checker.py` with 27 comprehensive tests
  - Process health checks (8 tests): alive, not running, zombie, dead, no such process, access denied, exception
  - HTTP health checks (8 tests): GET/POST success, 3xx/4xx/5xx responses, connection errors, timeouts
  - MCP JSON-RPC health checks (7 tests): success, errors, timeouts, invalid JSON
  - Server health checks (4 tests): integrated tests with multiple components

- ✅ Added `tests/test_restart_manager.py` with 28 comprehensive tests
  - Initialization, can_restart, calculate_backoff_delay, record_restart tests
  - Restart history management, cleanup, and statistics tests
  - Edge cases: window-based limits, exponential backoff, large multipliers
  - Integration workflow test

### Test Results
All 55 tests pass successfully:
```
============================= test session starts ==============================
collected 55 items

tests/test_health_checker.py::TestHealthChecker ... 27 passed
tests/test_restart_manager.py::TestRestartManager ... 28 passed

============================== 55 passed in 0.82s ===============================
```

## Review Comments Addressed

### Copilot AI Comments (9):
1. Type hints improvement in RestartManager
2. Removed unused `_backoff_state` field
3. Added negative uptime protection
4. Added `backoff_multiplier` validation
5. Fixed error message construction
6. Fixed misleading docstring
7. Added `RestartStats` TypedDict
8. Added HealthChecker test coverage
9. Added RestartManager test coverage

### User Comment (1):
10. Changed health check method to "tools/list" (@abhinav-fluidai)

## Files Changed
- `fluidai_mcp/services/restart_manager.py` - Type safety and validation improvements
- `fluidai_mcp/services/health_checker.py` - Method change and error handling fix
- `fluidai_mcp/models/server_status.py` - Edge case fix and docstring correction
- `tests/test_health_checker.py` - New file with 27 tests
- `tests/test_restart_manager.py` - New file with 28 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>