### PR TITLE
MCP-66: Add ServerDetails page with routing and mock data

### DIFF
--- a/fluidmcp/frontend/src/App.tsx
+++ b/fluidmcp/frontend/src/App.tsx
@@ -1,7 +1,15 @@
+import { Routes, Route, Navigate } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
+import ServerDetails from "./pages/ServerDetails";
 
 function App() {
-  return <Dashboard />;
+  return (
+    <Routes>
+      <Route path="/dashboard" element={<Dashboard />} />
+      <Route path="/servers/:serverId" element={<ServerDetails />} />
+      <Route path="*" element={<Navigate to="/dashboard" />} />
+    </Routes>
+  );
 }
 
 export default App;

--- a/fluidmcp/frontend/src/data/serverDetails.mock.ts
+++ b/fluidmcp/frontend/src/data/serverDetails.mock.ts
@@ -1,0 +1,30 @@
+interface Tool {
+  name: string;
+  description: string;
+}
+
+interface ServerDetails {
+  id: string;
+  name: string;
+  description: string;
+  status: string;
+  tools: Tool[];
+}
+
+export const mockServerDetails: ServerDetails = {
+  id: "time",
+  name: "Time MCP Server",
+  description:
+    "Provides current time and timezone conversion capabilities using IANA timezone names.",
+  status: "running",
+  tools: [
+    {
+      name: "get_current_time",
+      description: "Get current time in a specific timezone",
+    },
+    {
+      name: "convert_time",
+      description: "Convert time between different timezones",
+    },
+  ],
+};

--- a/fluidmcp/frontend/src/main.tsx
+++ b/fluidmcp/frontend/src/main.tsx
@@ -1,12 +1,15 @@
 import React from 'react'
-import { createRoot } from 'react-dom/client'
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from 'react-router-dom';
 import './index.css'
 import App from './App.tsx'
 
 
 // Entry point of the React application.
-createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )

--- a/fluidmcp/frontend/src/pages/Dashboard.tsx
+++ b/fluidmcp/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,10 @@
 import ServerCard from "../components/ServerCard";
 import { mockServers } from "../data/servers.mock";
+import { useNavigate } from "react-router-dom";
 
 export default function Dashboard() {
 
+  const navigate = useNavigate();
   const activeServers = mockServers.filter(
     (server) => server.status === "running" || server.status === "starting"
   );
@@ -48,7 +50,9 @@ export default function Dashboard() {
                     </span>
                   </div>
 
-                  <button disabled className="details-btn">
+                  <button className="details-btn" 
+                    onClick={()=> navigate(`/servers/${server.id}`)}
+                  >
                     See details
                   </button>
                 </div>

--- a/fluidmcp/frontend/src/pages/ServerDetails.tsx
+++ b/fluidmcp/frontend/src/pages/ServerDetails.tsx
@@ -1,0 +1,68 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { mockServerDetails } from "../data/serverDetails.mock";
+
+export default function ServerDetails(){
+    const { serverId } = useParams();
+    const navigate = useNavigate();
+
+    // For now we only support mock "time" server
+    const server = serverId === "time" ? mockServerDetails : null;
+
+    if(!server){
+        return (
+            <div className="dashboard">
+                <header className="dashboard-header">
+                    <button className="details-btn" onClick={()=> navigate("/dashboard")}>
+                        ← Back to Dashboard
+                    </button>
+                    <h1>Server Not Found</h1>
+                    <p className="subtitle">The requested server could not be found.</p>
+                </header>
+            </div>
+        )
+    }
+
+    return(
+        <div className="dashboard">
+            {/* Header with Back Button */}
+            <header className="dashboard-header">
+                <button className="details-btn" onClick={()=> navigate("/dashboard")}>
+                    ← Back to Dashboard
+                </button>
+                <h1>{server.name}</h1>
+                <span className={`status ${server.status}`}>
+                    {server.status}
+                </span>
+                <p className="subtitle">{server.description}</p>
+            </header>
+
+            {/* Tools */}
+            <section className="dashboard-section">
+                <h2>Available tools</h2>
+                <div className="active-server-container">
+                    {server.tools.length === 0 ? (
+                        <p className="empty-state">No tools available for this server</p>
+                    ) : (
+                        <div className="active-server-list">
+                            {server.tools.map((tool)=>(
+                                <div key={tool.name} className="active-server-row">
+                                    <div>
+                                        <strong>{tool.name}</strong>
+                                        <p className="subtitle">{tool.description}</p>
+                                    </div>
+
+                                    <button
+                                        className="details-btn"
+                                        onClick={()=> alert(`Navigate to tool runner for ${tool.name}`)}
+                                    >
+                                        Run tool
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </section>
+        </div>
+    );
+}


### PR DESCRIPTION
<img width="1914" height="1001" alt="Screenshot (674)" src="https://github.com/user-attachments/assets/5a50cb27-8f83-4fc8-9087-5d374c43bc3b" />

## Summary
Add ServerDetails page with routing functionality to view individual server information and available tools.

## Changes
- **New Component**: ServerDetails page displaying server info and tools
- **Routing**: Added React Router setup in App.tsx and main.tsx
- **Navigation**: Dashboard "See details" buttons now navigate to ServerDetails
- **Mock Data**: Using serverDetails.mock.ts (temporary)

## Test Plan
1. Navigate to Dashboard
2. Click "See details" on Time server
3. Verify ServerDetails page displays correctly
4. Test back navigation

## Future Work
- Replace mock data with real API calls to MongoDB
- Integrate with backend `/api/tools` endpoint (added in MCP-71)
- Add loading states and error handling
- Expand tool runner functionality

## Notes
This PR uses mock data as placeholder. Backend API integration will be done in a separate PR once MongoDB endpoints are ready.

## Running the frontend
- cd fluidmcp/frontend
- npm install (if not done already)
- npm run dev 
- go to http://localhost:5173/ , dashboard will be visible
- http://localhost:5173/servers/time will show details page

🤖 Generated with [Claude Code](https://claude.com/claude-code)