### PR TITLE
[MCP-34]-Added tests for network_utlis.py

### DIFF
--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -37,6 +37,7 @@ import time
 import subprocess
 import sys
 import os
+import select
 from fluidai_mcp.services.network_utils import (
     is_port_in_use,
     find_free_port,
@@ -160,7 +161,6 @@ def wait_for_server_ready(proc, timeout=TEST_TIMEOUT):
             pytest.fail(f"Test server process terminated unexpectedly: {stderr_output}")
 
         # Try to read a line with a short timeout
-        import select
         if select.select([proc.stdout], [], [], 0.1)[0]:
             line = proc.stdout.readline()
             if 'READY' in line:


### PR DESCRIPTION
# Network Utilities Test Suite

This test suite contains integration-level unit tests for the `network_utils.py` module in `fluidai_mcp.services`. The tests verify port detection, port finding, PID detection, process management, and edge cases using **real socket operations** and **subprocess servers**.

---

## Table of Contents

1. [Overview](#overview)  
2. [Tested Functions](#tested-functions)  
3. [Testing Strategy](#testing-strategy)  
4. [Port Ranges Used](#port-ranges-used)  
5. [Thread Safety & Cleanup](#thread-safety--cleanup)  
6. [Helper Functions](#helper-functions)  
7. [Test Classes](#test-classes)  
8. [CI Considerations](#ci-considerations)  

---

## Overview

These tests verify that the network utility functions behave correctly under realistic conditions:

- Actual socket binding is used to simulate ports being in use.
- Subprocess servers are spawned to simulate external processes listening on ports.
- Tests are mostly **integration-level**, since system state (existing port usage) can affect them.

---

## Tested Functions

- `is_port_in_use(port: int) -> bool`  
- `find_free_port(start: int = 8100, end: int = 9000, taken_ports: set[int] | None = None) -> int`  
- `get_pid_on_port(port: int) -> int | None`  
- `kill_process_on_port(port: int) -> bool`  

---

## Testing Strategy

1. Use **high port numbers (50000+)** to avoid conflicts with system services.  
2. Spawn ephemeral servers in subprocesses to simulate occupied ports.  
3. Use helper functions like `wait_for_condition` to poll for port availability or PID registration.  
4. Ensure **cleanup** via `finally` blocks for sockets and subprocesses.  
5. Cover **edge cases**, such as:

   - Port exhaustion  
   - Sequential calls to `find_free_port`  
   - Port reuse after closing sockets  
   - Multiple sockets with only one bound  

---

## Port Ranges Used

| Range       | Description                              | Example Usage          |
|------------:|-----------------------------------------|-----------------------|
| 1–1023      | Privileged ports (requires root/admin)  | Not used in tests     |
| 1024–49151  | Registered ports                         | Minimal validation    |
| 49152–65535 | Dynamic/Ephemeral ports                  | All socket tests      |
| 50000+      | High ephemeral ports                      | `BASE_TEST_PORT` offset |

---

## Thread Safety & Cleanup

- Socket and subprocess servers are always cleaned up using `finally` blocks.  
- Polling with `wait_for_condition` ensures reliable detection before assertions.  
- Minimal sleep times (`0.1s`) reduce CI runtime while maintaining reliability.

---

## Helper Functions

### `wait_for_condition(condition_func, timeout=2.0, interval=0.1) -> bool`

Polls until `condition_func` returns `True` or timeout occurs. Used for:

- Waiting for ports to be in use or free  
- Waiting for PIDs to appear  

---

### `start_test_server(port: int, duration: int = 3) -> subprocess.Popen`

Starts a lightweight Python TCP server in a subprocess for testing purposes.

- Prints `"READY"` once the server is listening.  
- Runs for `duration` seconds.  

---

### `can_bind_to_port(port: int) -> bool`

Checks whether a port is available for binding.

- Used to verify port release after process termination.

---

## Test Classes

### `TestIsPortInUse`

- Verifies `is_port_in_use()` behavior for free, occupied, and reused ports.  
- Tests multiple checks and multiple ports simultaneously.

---

### `TestFindFreePort`

- Verifies `find_free_port()` across ranges, single-port ranges, and edge cases.  
- Ensures returned ports are actually free.  
- Tests behavior when all ports are taken.  
- Tests sequential calls with `taken_ports` tracking.

---

### `TestPortRangeValidation`

- Validates ports in ranges:

  - Privileged (1–1023)  
  - Registered (1024–49151)  
  - Ephemeral (49152–65535)  

- Ensures invalid ports are correctly identified.

---

### `TestGetPidOnPort`

- Verifies `get_pid_on_port()` returns:

  - `None` for free ports  
  - Integer PID for occupied ports  
  - Correct PID for subprocess servers  

---

### `TestKillProcessOnPort`

- Verifies `kill_process_on_port()`:

  - Returns `False` for unused ports  
  - Returns `True` for killed processes  
  - Frees port for reuse after killing process  

---

### `TestEdgeCases`

- Simulates concurrent port checks.  
- Tests `find_free_port` with mostly taken ports.  
- Tests port reuse after socket close.  
- Tests boundary cases for port ranges.  
- Tests `is_port_in_use` with multiple sockets, only one bound.

---

## CI Considerations

- All tests use ephemeral high ports to avoid conflicts.  
- Sleep times and polling intervals are minimal for fast execution.  
- Subprocess servers have reduced runtime (`3s`) for CI efficiency.  
- Proper cleanup ensures no leftover sockets or processes.  

---

### Base Test Constants

```python
BASE_TEST_PORT = 50000  # Base port for all test operations
TEST_TIMEOUT = 2.0      # Default timeout for wait conditions

