### PR TITLE
MCP-159: feat: Add toast notifications and improve dev workflow scripts

### DIFF
--- a/fluidmcp/frontend/package-lock.json
+++ b/fluidmcp/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.11.0"
       },
       "devDependencies": {
@@ -1991,8 +1992,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2415,6 +2416,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/has-flag": {
@@ -2862,6 +2872,23 @@
       },
       "peerDependencies": {
         "react": "^19.2.3"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-refresh": {

--- a/fluidmcp/frontend/package.json
+++ b/fluidmcp/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.11.0"
   },
   "devDependencies": {

--- a/fluidmcp/frontend/src/App.tsx
+++ b/fluidmcp/frontend/src/App.tsx
@@ -1,16 +1,27 @@
 import { Routes, Route, Navigate } from "react-router-dom";
+import { Toaster } from "react-hot-toast";
 import Dashboard from "./pages/Dashboard";
 import ServerDetails from "./pages/ServerDetails";
 import { ToolRunner } from "./pages/ToolRunner";
 
 function App() {
   return (
-    <Routes>
-      <Route path="/dashboard" element={<Dashboard />} />
-      <Route path="/servers/:serverId" element={<ServerDetails />} />
-      <Route path="/servers/:serverId/tools/:toolName" element={<ToolRunner />} />
-      <Route path="*" element={<Navigate to="/dashboard" />} />
-    </Routes>
+    <>
+      <Toaster
+        position="top-right"
+        reverseOrder={false}
+        gutter={8}
+        toastOptions={{
+          duration: 4000,
+        }}
+      />
+      <Routes>
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/servers/:serverId" element={<ServerDetails />} />
+        <Route path="/servers/:serverId/tools/:toolName" element={<ToolRunner />} />
+        <Route path="*" element={<Navigate to="/dashboard" />} />
+      </Routes>
+    </>
   );
 }
 

--- a/fluidmcp/frontend/src/components/result/ToolResult.tsx
+++ b/fluidmcp/frontend/src/components/result/ToolResult.tsx
@@ -5,6 +5,7 @@ import { TextResultView } from './TextResultView';
 import { TableResultView } from './TableResultView';
 import { McpContentView } from './McpContentView';
 import { ErrorBoundary } from '../ErrorBoundary';
+import { showError } from '../../services/toast';
 
 const ResultFormat = {
   MCP_CONTENT: 'mcp_content',
@@ -170,7 +171,7 @@ export const ToolResult: React.FC<ToolResultProps> = ({
       URL.revokeObjectURL(url);
     } catch (err) {
       console.error('Failed to download:', err);
-      alert('Failed to download result. It may contain circular references.');
+      showError('Failed to download result. It may contain circular references.');
     }
   };
 

--- a/fluidmcp/frontend/src/pages/Dashboard.tsx
+++ b/fluidmcp/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import ServerCard from "../components/ServerCard";
 import LoadingSpinner from "../components/LoadingSpinner";
 import ErrorMessage from "../components/ErrorMessage";
 import { useServers } from "../hooks/useServers";
+import { showSuccess, showError, showLoading } from "../services/toast";
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -18,12 +19,18 @@ export default function Dashboard() {
     // Silent guard - prevent concurrent operations
     if (actionState.type !== null) return;
 
+    const server = servers.find(s => s.id === serverId);
+    const serverName = server?.name || serverId;
+    const toastId = `server-${serverId}`;
+
     setActionState({ serverId, type: 'starting' });
+    showLoading(`Starting server "${serverName}"...`, toastId);
 
     try {
       await startServer(serverId);
+      showSuccess(`Server "${serverName}" started successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to start server');
+      showError(err instanceof Error ? err.message : 'Failed to start server', toastId);
     } finally {
       setActionState({ serverId: null, type: null });
     }
@@ -33,12 +40,18 @@ export default function Dashboard() {
     // Silent guard - prevent concurrent operations
     if (actionState.type !== null) return;
 
+    const server = servers.find(s => s.id === serverId);
+    const serverName = server?.name || serverId;
+    const toastId = `server-${serverId}`;
+
     setActionState({ serverId, type: 'stopping' });
+    showLoading(`Stopping server "${serverName}"...`, toastId);
 
     try {
       await stopServer(serverId);
+      showSuccess(`Server "${serverName}" stopped successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to stop server');
+      showError(err instanceof Error ? err.message : 'Failed to stop server', toastId);
     } finally {
       setActionState({ serverId: null, type: null });
     }
@@ -48,12 +61,18 @@ export default function Dashboard() {
     // Silent guard - prevent concurrent operations
     if (actionState.type !== null) return;
 
+    const server = servers.find(s => s.id === serverId);
+    const serverName = server?.name || serverId;
+    const toastId = `server-${serverId}`;
+
     setActionState({ serverId, type: 'restarting' });
+    showLoading(`Restarting server "${serverName}"...`, toastId);
 
     try {
       await restartServer(serverId);
+      showSuccess(`Server "${serverName}" restarted successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to restart server');
+      showError(err instanceof Error ? err.message : 'Failed to restart server', toastId);
     } finally {
       setActionState({ serverId: null, type: null });
     }

--- a/fluidmcp/frontend/src/pages/ServerDetails.tsx
+++ b/fluidmcp/frontend/src/pages/ServerDetails.tsx
@@ -6,6 +6,7 @@ import LoadingSpinner from "../components/LoadingSpinner";
 import ErrorMessage from "../components/ErrorMessage";
 import { ServerEnvForm } from "../components/ServerEnvForm";
 import apiClient from "../services/api";
+import { showSuccess, showError, showInfo, showLoading } from "../services/toast";
 
 export default function ServerDetails() {
   const { serverId } = useParams<{ serverId: string }>();
@@ -57,33 +58,51 @@ export default function ServerDetails() {
   const shouldExpandEnvForm = needsEnv && !hasInstanceEnv;
 
   const handleStartServer = async () => {
+    const toastId = `server-${serverId}`;
+    const serverName = serverDetails?.name || serverId;
+
     setActionLoading('start');
+    showLoading(`Starting server "${serverName}"...`, toastId);
+
     try {
       await startServer();
+      showSuccess(`Server "${serverName}" started successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to start server');
+      showError(err instanceof Error ? err.message : 'Failed to start server', toastId);
     } finally {
       setActionLoading(null);
     }
   };
 
   const handleStopServer = async () => {
+    const toastId = `server-${serverId}`;
+    const serverName = serverDetails?.name || serverId;
+
     setActionLoading('stop');
+    showLoading(`Stopping server "${serverName}"...`, toastId);
+
     try {
       await stopServer();
+      showSuccess(`Server "${serverName}" stopped successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to stop server');
+      showError(err instanceof Error ? err.message : 'Failed to stop server', toastId);
     } finally {
       setActionLoading(null);
     }
   };
 
   const handleRestartServer = async () => {
+    const toastId = `server-${serverId}`;
+    const serverName = serverDetails?.name || serverId;
+
     setActionLoading('restart');
+    showLoading(`Restarting server "${serverName}"...`, toastId);
+
     try {
       await restartServer();
+      showSuccess(`Server "${serverName}" restarted successfully`, toastId);
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to restart server');
+      showError(err instanceof Error ? err.message : 'Failed to restart server', toastId);
     } finally {
       setActionLoading(null);
     }
@@ -92,7 +111,10 @@ export default function ServerDetails() {
   const handleEnvSubmit = async (env: Record<string, string>) => {
     if (!serverId) return;
 
+    const toastId = `env-${serverId}`;
+
     setEnvSubmitting(true);
+    showLoading('Saving environment variables and restarting server...', toastId);
 
     try {
       await updateEnv(env);
@@ -125,13 +147,13 @@ export default function ServerDetails() {
       // Collapse form after successful update
       setEnvFormExpanded(false);
 
-      if (toolsFound) {
-        alert('Environment variables saved and server restarted successfully. Tools are now available!');
-      } else {
-        alert('Environment variables saved and server restarted successfully. Tools may take a moment to appear.');
-      }
+      // Show success toast
+      showSuccess('Environment variables saved and server restarted successfully', toastId);
+
+      // Show info toast about tools
+      showInfo('Tools may take a few seconds to appear.');
     } catch (err) {
-      alert(err instanceof Error ? err.message : 'Failed to update environment variables');
+      showError(err instanceof Error ? err.message : 'Failed to update environment variables', toastId);
       throw err; // Re-throw so form knows it failed
     } finally {
       setEnvSubmitting(false);

--- a/fluidmcp/frontend/src/services/toast.ts
+++ b/fluidmcp/frontend/src/services/toast.ts
@@ -1,0 +1,90 @@
+import toast from 'react-hot-toast';
+
+/**
+ * Toast utility service for FluidMCP
+ * Wrapper around react-hot-toast with pre-configured styling
+ */
+
+const baseStyle = {
+  background: '#1e293b',
+  color: '#f1f5f9',
+  borderRadius: '8px',
+  padding: '12px 16px',
+  fontSize: '14px',
+  boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+};
+
+export const showSuccess = (message: string, id?: string) => {
+  return toast.success(message, {
+    id,
+    duration: 4000,
+    style: baseStyle,
+    iconTheme: {
+      primary: '#22c55e',
+      secondary: '#1e293b',
+    },
+  });
+};
+
+export const showError = (message: string, id?: string) => {
+  return toast.error(message, {
+    id,
+    duration: 5000, // Slightly longer for errors
+    style: baseStyle,
+    iconTheme: {
+      primary: '#ef4444',
+      secondary: '#1e293b',
+    },
+  });
+};
+
+export const showInfo = (message: string, id?: string) => {
+  return toast(message, {
+    id,
+    duration: 4000,
+    style: baseStyle,
+    icon: 'ℹ️',
+  });
+};
+
+export const showWarning = (message: string, id?: string) => {
+  return toast(message, {
+    id,
+    duration: 4000,
+    style: {
+      ...baseStyle,
+      borderLeft: '4px solid #eab308',
+    },
+    icon: '⚠️',
+  });
+};
+
+export const showLoading = (message: string, id?: string) => {
+  return toast.loading(message, {
+    id,
+    style: baseStyle,
+  });
+};
+
+export const dismissToast = (id?: string) => {
+  if (id) {
+    toast.dismiss(id);
+  } else {
+    toast.dismiss();
+  }
+};
+
+export const dismissAll = () => {
+  toast.dismiss();
+};
+
+// Default export for convenience
+export default {
+  success: showSuccess,
+  error: showError,
+  info: showInfo,
+  warning: showWarning,
+  loading: showLoading,
+  dismiss: dismissToast,
+  dismissAll,
+};

--- a/package.json
+++ b/package.json
@@ -2,9 +2,8 @@
   "name": "fluidmcp",
   "private": true,
   "scripts": {
-    "airbnb-dev": "concurrently -n MCP,Frontend \"fmcp run Airbnb/airbnb@0.1.0 --start-server\" \"npm run dev --prefix fluidmcp/frontend\""
-  },
-  "dependencies": {
-    "concurrently": "^9.2.1"
+    "dev": "fmcp serve --allow-insecure",
+    "build:frontend": "npm run build --prefix fluidmcp/frontend",
+    "prod": "npm run build:frontend && fmcp serve --allow-insecure"
   }
 }


### PR DESCRIPTION
## Summary
- Replace all browser alert() calls with react-hot-toast notifications
- Add success feedback for server start/stop/restart operations
- Implement loading states with toast IDs to prevent duplicates
- Toast notifications positioned top-right with dark theme styling
- Include server names in toast messages for better UX

Dev Scripts Improvements:
- Remove unused concurrently dependency
- Add npm run dev (backend only, frontend served through backend)
- Add npm run build:frontend (build frontend for production)
- Add npm run prod (single-port production mode)

Toast Features:
- Non-blocking notifications with 4s auto-dismiss
- Consistent styling matching FluidMCP dark theme
- Loading → Success/Error state transitions
- Environment variable save shows success + info toast
- Download failures show error toast