### PR TITLE
MCP-203: fix: Allow starting servers with 'not_found' status

### DIFF
--- a/fluidmcp/frontend/src/components/ServerCard.tsx
+++ b/fluidmcp/frontend/src/components/ServerCard.tsx
@@ -16,6 +16,7 @@ export default function ServerCard({
   const isStopped =
     server.status?.state === "stopped" ||
     server.status?.state === "failed" ||
+    server.status?.state === "not_found" ||
     !server.status;
 
   const toolCount = server.tools?.length || 0;

--- a/fluidmcp/frontend/src/hooks/useServerDetails.ts
+++ b/fluidmcp/frontend/src/hooks/useServerDetails.ts
@@ -119,7 +119,8 @@ export function useServerDetails(serverId: string) {
   const isRunning = serverDetails?.status.state === "running";
   const isStopped = !serverDetails?.status ||
                     serverDetails.status.state === "stopped" ||
-                    serverDetails.status.state === "failed";
+                    serverDetails.status.state === "failed" ||
+                    serverDetails.status.state === "not_found";
 
   return {
     serverDetails,

--- a/fluidmcp/frontend/src/hooks/useServers.ts
+++ b/fluidmcp/frontend/src/hooks/useServers.ts
@@ -94,7 +94,8 @@ export function useServers() {
     (server) =>
       !server.status ||
       server.status.state === "stopped" ||
-      server.status.state === "failed"
+      server.status.state === "failed" ||
+      server.status.state === "not_found"
   );
 
   return {


### PR DESCRIPTION
## Problem

When the `fluidmcp_server_instances` collection is cleared or empty, servers display a `not_found` status in the dashboard. However, the Start button was not appearing for these servers, preventing first-time users and users with cleared instances from starting their servers.

### Root Cause

The frontend `isStopped` check only included `stopped`, `failed`, and missing status states, but did not include `not_found` as a valid startable state.

## Solution

Updated the frontend UI to treat `not_found` as a startable state by adding it to the `isStopped` condition in two files:

### Changes Made

1. **ServerCard.tsx** (lines 16-20)
   - Added `server.status?.state === "not_found"` to the `isStopped` check
   - Allows Start button to appear for servers with `not_found` status

2. **useServerDetails.ts** (lines 120-123)
   - Added `serverDetails.status.state === "not_found"` to the `isStopped` computed property
   - Ensures consistency across all components using this hook

### Why This Works

The backend **already supports** starting servers without existing instances:
- Loads server configuration from `fluidmcp_servers` collection
- Spawns the server process
- Creates a new instance document in `fluidmcp_server_instances` after successful spawn
- Records `started_by` field for tracking which user started the instance

The `not_found` state simply means the server config exists but no instance document is present - a perfectly valid startable state. This fix aligns the frontend UI with existing backend capability.

## Testing

✅ Verified servers with `not_found` status now display Start button  
✅ Clicking Start successfully launches the server and creates instance document  
✅ Frontend built and tested with `npm run build`

## Future Auth Considerations

We **intentionally kept this simple** for now. When user authentication is added:

- `started_by` field in `server_instances` already tracks which user started each instance
- This will enable user-specific instance tracking (user_id + server_id)
- Authorization logic can be added to control who can start/stop specific instances

For now, all users can start any configured server, which is appropriate for the current non-authenticated setup.

## Related Issues

Fixes issue where first-time users cannot start servers after clearing the instances collection.

---

🤖 Generated with [Claude Code]