### PR TITLE
MCP-298: feat: Add GitHub clone API for fmcp serve mode

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -8,7 +8,7 @@ Provides REST API for:
 - Listing all configured servers
 - Replicate model inference
 """
-from typing import Dict, Any, Optional, Literal, List
+from typing import Dict, Any, Optional, Literal, List, Tuple
 from fastapi import APIRouter, Request, HTTPException, Body, Query, Depends, Response
 from fastapi.responses import StreamingResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -606,7 +606,7 @@ def validate_server_config(config: Dict[str, Any]) -> None:
         )
 
     # Whitelist of allowed commands (can be extended via environment variable)
-    allowed_commands_default = ["npx", "node", "python", "python3", "uvx", "docker"]
+    allowed_commands_default = ["npx", "node", "python", "python3", "uv", "uvx", "docker", "deno", "bun"]
     allowed_commands_env = os.environ.get("FMCP_ALLOWED_COMMANDS", "").split(",")
     allowed_commands = allowed_commands_default + [cmd.strip() for cmd in allowed_commands_env if cmd.strip()]
 
@@ -767,8 +767,7 @@ async def add_server(
             # Store in-memory as fallback
             logger.warning(f"Database save failed for '{name}', storing in-memory only")
     except DuplicateKeyError:
-        # Race condition: another request created the same server concurrently
-        raise HTTPException(409, f"Server with id '{id}' was created concurrently")
+        raise HTTPException(409, f"Server with id '{id}' already exists")
 
     # Always store in configs dict for immediate access
     manager.configs[id] = config
@@ -779,6 +778,262 @@ async def add_server(
         "id": id,
         "name": name
     }
+
+
+# ==================== GitHub Clone Helper ====================
+
+async def _validate_server_with_manager(
+    manager: Any,
+    server_id: str,
+    config: Dict[str, Any],
+    timeout: int = 5,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Validate a server configuration by test-starting it through the manager lifecycle.
+
+    This ensures we exercise the EXACT same runtime path as a real server start
+    (env merging, working_dir resolution, MCP handshake, etc.).
+
+    The server is added temporarily to the manager's in-memory registry, started,
+    waited on for ``timeout`` seconds, then stopped and removed.  It is NOT saved
+    to the database at any point during validation.
+
+    Args:
+        manager: ServerManager instance
+        server_id: Server identifier (used as a temporary key)
+        config: Flat server configuration dict
+        timeout: Seconds to wait before checking if the server is still alive
+
+    Returns:
+        Tuple of (success: bool, error_message: Optional[str])
+    """
+    try:
+        # 1. Register temporarily in manager (NOT in database)
+        manager.configs[server_id] = config
+
+        # 2. Start through manager (uses real lifecycle)
+        logger.info(f"[validate] Test-starting server '{server_id}'...")
+        success = await manager.start_server(server_id, config, user_id="validation")
+        if not success:
+            return False, "Server failed to start during validation"
+
+        # 3. Wait for startup
+        await asyncio.sleep(timeout)
+
+        # 4. Check if still running
+        status = await manager.get_server_status(server_id)
+        is_running = status.get("state") == "running"
+
+        # 5. Stop server
+        logger.info(f"[validate] Stopping test server '{server_id}'...")
+        await manager.stop_server(server_id, force=False)
+
+        # 6. Remove temporary entry
+        manager.configs.pop(server_id, None)
+
+        if not is_running:
+            return False, "Server crashed immediately after startup"
+
+        return True, None
+
+    except Exception as e:
+        logger.error(f"[validate] Validation failed for '{server_id}': {e}")
+        # Best-effort cleanup
+        try:
+            await manager.stop_server(server_id, force=True)
+        except Exception:
+            pass
+        manager.configs.pop(server_id, None)
+        return False, str(e)
+
+
+@router.post("/servers/from-github")
+async def add_server_from_github(
+    request: Request,
+    config: Dict[str, Any] = Body(
+        ...,
+        example={
+            "github_repo": "anthropics/mcp-server-example",
+            "branch": "main",
+            "server_id": "example-server",
+            "env": {},
+            "enabled": True,
+            "restart_policy": "on-failure",
+            "test_before_save": True,
+        },
+    ),
+    token: str = Depends(get_token),
+):
+    """
+    Clone a GitHub repository and add the MCP server(s) it contains.
+
+    **Authentication**: Requires ``X-GitHub-Token`` header with a valid GitHub PAT
+    in addition to the usual ``Authorization: Bearer`` token.
+
+    **Workflow**:
+    1. Clone / update repository from GitHub
+    2. Extract metadata (``metadata.json`` or README fallback)
+    3. Validate each server's command against the allowlist
+    4. Optionally test-start each server through the manager lifecycle
+    5. Save to database
+
+    **Single-server repos**: the provided ``server_id`` is used directly.
+
+    **Multi-server repos**: IDs are generated as ``{server_id}-{slugified-name}``.
+    Use ``server_name`` to select a single server.
+
+    **Headers**:
+    - ``X-GitHub-Token``: GitHub personal access token (required)
+
+    **Request body fields**:
+    - ``github_repo``: ``owner/repo`` or full URL
+    - ``branch``: branch to clone (default: ``"main"``)
+    - ``server_id``: base server identifier (lowercase alphanumeric + hyphens)
+    - ``server_name``: select a specific server from a multi-server repo
+    - ``env``: additional environment variables
+    - ``enabled``: whether to enable the server(s) (default: ``true``)
+    - ``restart_policy``: ``never`` | ``on-failure`` | ``always``
+    - ``max_restarts``: max restart attempts (0–10)
+    - ``test_before_save``: validate via test-start before persisting (default: ``true``)
+    """
+    from ..services.github_utils import GitHubService
+    from ..services.validators import validate_command_allowlist  # noqa: F401 – used inside GitHubService
+
+    manager = get_server_manager(request)
+    user_id = get_current_user(request)
+
+    # 1. Require GitHub token in header (never in request body to avoid logging)
+    github_token = request.headers.get("X-GitHub-Token")
+    if not github_token:
+        raise HTTPException(
+            400,
+            "X-GitHub-Token header is required. "
+            "Provide your GitHub personal access token in the request header.",
+        )
+
+    # 2. Sanitise input to prevent MongoDB injection
+    config = sanitize_input(config)
+
+    # 3. Validate required fields
+    github_repo = config.get("github_repo")
+    base_server_id = config.get("server_id")
+
+    if not github_repo:
+        raise HTTPException(400, "github_repo is required")
+    if not base_server_id:
+        raise HTTPException(400, "server_id is required")
+
+    branch = config.get("branch", "main")
+    server_name = config.get("server_name")
+    subdirectory = config.get("subdirectory")
+    env = config.get("env", {})
+    restart_policy = config.get("restart_policy", "never")
+    max_restarts = int(config.get("max_restarts", 3))
+    enabled = bool(config.get("enabled", True))
+    test_before_save = bool(config.get("test_before_save", True))
+
+    # Validate env variables if provided
+    if env:
+        validate_env_variables(env)
+
+    # Pre-flight: fail fast if the base server_id already exists.
+    # This avoids a 60-second clone only to get a 409 at the end.
+    if base_server_id in manager.configs or await manager.db.get_server_config(base_server_id):
+        raise HTTPException(
+            409,
+            f"Server with id '{base_server_id}' already exists. "
+            f"Choose a different Server ID and try again.",
+        )
+
+    try:
+        # 4. Clone / update and build server config(s)
+        logger.info(f"Building server config(s) from {github_repo}@{branch}"
+                    + (f" subdirectory={subdirectory}" if subdirectory else ""))
+        server_configs, clone_path = GitHubService.build_server_configs(
+            repo_path=github_repo,
+            token=github_token,
+            base_server_id=base_server_id,
+            branch=branch,
+            server_name=server_name,
+            subdirectory=subdirectory,
+            env=env,
+            restart_policy=restart_policy,
+            max_restarts=max_restarts,
+            enabled=enabled,
+            created_by=user_id,
+        )
+        logger.info(f"Built {len(server_configs)} server config(s) from {github_repo}")
+
+        # 5. Validate, optionally test-start, and persist each server
+        results = []
+        for server_config in server_configs:
+            sid = server_config["id"]
+            display_name = server_config.get("name", sid)
+
+            # Duplicate check – in-memory and database
+            if sid in manager.configs or await manager.db.get_server_config(sid):
+                raise HTTPException(
+                    409,
+                    f"Server with id '{sid}' already exists. "
+                    f"Choose a different Server ID and try again.",
+                )
+
+            # Validate command and args for security (env is skipped here because
+            # metadata.json from GitHub repos may use non-uppercase env key names,
+            # e.g. Google service account fields like "type", "project_id").
+            # The command allowlist is already enforced by GitHubService.
+            command_only = {k: v for k, v in server_config.items() if k != "env"}
+            validate_server_config(command_only)
+
+            # Optional test-start through manager lifecycle
+            if test_before_save:
+                logger.info(f"Test-starting '{sid}' for validation...")
+                ok, err = await _validate_server_with_manager(manager, sid, server_config, timeout=5)
+                if not ok:
+                    raise HTTPException(
+                        400,
+                        f"Server '{display_name}' failed validation: {truncate_error(err or 'unknown error')}",
+                    )
+                logger.info(f"Server '{sid}' validated successfully")
+
+            # Persist to database
+            try:
+                await manager.db.save_server_config(server_config)
+            except DuplicateKeyError:
+                raise HTTPException(
+                    409,
+                    f"Server with id '{sid}' already exists. "
+                    f"Choose a different Server ID and try again.",
+                )
+
+            # Register in manager's in-memory configs for immediate availability
+            manager.configs[sid] = server_config
+
+            results.append({
+                "id": sid,
+                "name": display_name,
+                "status": "validated" if test_before_save else "added",
+            })
+            logger.info(f"Added GitHub server: {display_name} (id: {sid})")
+
+        # 6. Return response
+        return {
+            "message": f"Successfully added {len(results)} server(s) from GitHub repository",
+            "servers": results,
+            "repository": github_repo,
+            "branch": branch,
+            "clone_path": str(clone_path),
+        }
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(400, truncate_error(str(e)))
+    except RuntimeError as e:
+        raise HTTPException(502, truncate_error(str(e)))
+    except Exception as e:
+        logger.exception(f"Unexpected error adding server from GitHub: {e}")
+        raise HTTPException(500, f"Internal error: {truncate_error(str(e))}")
 
 
 @router.get("/servers")

--- a/fluidmcp/cli/repositories/database.py
+++ b/fluidmcp/cli/repositories/database.py
@@ -456,7 +456,10 @@ class DatabaseManager(PersistenceBackend):
             Server config dict in flat format (for backend compatibility)
         """
         try:
-            config = await self.db.fluidmcp_servers.find_one({"id": id}, {"_id": 0})  # Exclude MongoDB _id
+            config = await self.db.fluidmcp_servers.find_one(
+                {"id": id, "deleted_at": {"$exists": False}},
+                {"_id": 0},
+            )
 
             # Convert nested MongoDB format to flat format for backend
             if config:

--- a/fluidmcp/cli/services/server_builder.py
+++ b/fluidmcp/cli/services/server_builder.py
@@ -1,0 +1,148 @@
+"""
+Server configuration builder for GitHub-sourced MCP servers.
+
+Handles ID normalisation (slugification) and config assembly for both
+single-server and multi-server repositories.
+
+The produced config dict uses the FLAT format expected by:
+- ServerManager._spawn_mcp_process()  (reads command/args/env at top level)
+- DatabaseManager.save_server_config() (converts flat -> nested for MongoDB)
+"""
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class ServerBuilder:
+    """Builds normalised MCP server configurations from repository metadata."""
+
+    @staticmethod
+    def slugify(text: str) -> str:
+        """
+        Normalise text to a URL-friendly slug.
+
+        Examples:
+            "My Server"   -> "my-server"
+            "API v2.0"    -> "api-v2-0"
+            "file_system" -> "file-system"
+
+        Args:
+            text: Text to slugify
+
+        Returns:
+            Lowercase hyphenated slug
+        """
+        text = text.lower()
+        # Replace spaces and underscores with hyphens
+        text = re.sub(r'[\s_]+', '-', text)
+        # Remove non-alphanumeric characters (except hyphens)
+        text = re.sub(r'[^a-z0-9-]', '', text)
+        # Collapse consecutive hyphens
+        text = re.sub(r'-+', '-', text)
+        return text.strip('-')
+
+    @staticmethod
+    def generate_server_id(base_id: str, server_name: str, is_multi_server: bool) -> str:
+        """
+        Generate a normalised server ID.
+
+        Single-server repo:
+            base_id="my-server", name="filesystem"  -> "my-server"
+
+        Multi-server repo:
+            base_id="tools", name="filesystem"       -> "tools-filesystem"
+            base_id="tools", name="API Server"       -> "tools-api-server"
+
+        Args:
+            base_id: Base identifier provided by the user
+            server_name: Server name as it appears in metadata.json
+            is_multi_server: True when the repository defines more than one server
+
+        Returns:
+            Normalised server ID string
+        """
+        if not is_multi_server:
+            return base_id
+
+        name_slug = ServerBuilder.slugify(server_name)
+        return f"{base_id}-{name_slug}"
+
+    @staticmethod
+    def build_config(
+        base_id: str,
+        server_name: str,
+        server_config: Dict,
+        clone_path: Path,
+        repo_path: str,
+        branch: str,
+        env: Optional[Dict[str, str]],
+        restart_policy: str,
+        max_restarts: int,
+        enabled: bool,
+        is_multi_server: bool,
+        install_path: Optional[Path] = None,
+        created_by: Optional[str] = None,
+    ) -> Dict:
+        """
+        Build a complete flat server configuration ready for MongoDB.
+
+        Uses flat format (command/args/env at top-level) so that it works
+        directly with ServerManager._spawn_mcp_process() and
+        DatabaseManager.save_server_config().
+
+        Args:
+            base_id: User-provided base identifier
+            server_name: Server name from metadata.json
+            server_config: Individual server block from metadata (command, args, env, ...)
+            clone_path: Repo root — used as ``working_dir`` (cwd for subprocess).
+                For monorepos with ``uv --directory <subdir>`` style args this
+                must be the repo root, not the subdirectory.
+            repo_path: Original GitHub repo path (owner/repo)
+            branch: Branch that was cloned
+            env: Additional environment variables merged on top of repo defaults
+            restart_policy: "never", "on-failure", or "always"
+            max_restarts: Maximum restart attempts
+            enabled: Whether the server should be enabled after creation
+            is_multi_server: True when repo has more than one server
+            install_path: Optional override for install_path (e.g. the resolved
+                subdirectory in a monorepo).  Defaults to ``clone_path``.
+            created_by: User performing the operation (for audit)
+
+        Returns:
+            Flat config dict compatible with ServerManager and DatabaseManager
+        """
+        server_id = ServerBuilder.generate_server_id(base_id, server_name, is_multi_server)
+
+        # Merge env: metadata env is the base, user-supplied env takes precedence
+        merged_env = {**server_config.get("env", {}), **(env or {})}
+
+        effective_install_path = install_path if install_path is not None else clone_path
+
+        return {
+            "id": server_id,
+            "name": server_config.get("name", server_name),
+            "description": server_config.get(
+                "description", f"MCP server cloned from GitHub: {repo_path}"
+            ),
+            "enabled": enabled,
+            # Flat format expected by ServerManager._spawn_mcp_process()
+            "command": server_config["command"],
+            "args": server_config.get("args", []),
+            "env": merged_env,
+            # working_dir = repo root so that --directory <subdir> args resolve correctly
+            "working_dir": str(clone_path),
+            "install_path": str(effective_install_path),
+            # Restart configuration
+            "restart_policy": restart_policy,
+            "max_restarts": max_restarts,
+            # GitHub provenance metadata (stored alongside the config in MongoDB)
+            "source": "github",
+            "github_repo": repo_path,
+            "github_branch": branch,
+            "github_server_name": server_name,  # original key in metadata.json
+            # Audit fields
+            "created_by": created_by,
+            "created_at": datetime.now(timezone.utc),
+        }


### PR DESCRIPTION
## Summary

- Adds `POST /api/servers/from-github` endpoint that clones a GitHub repo, extracts `metadata.json`, and persists the MCP server config to MongoDB
- New `ServerBuilder` service for ID generation, slug normalisation, and flat-format config assembly
- `GitHubService.build_server_configs()` orchestrates clone → metadata extraction → config building
- Command allowlist (`npx`, `node`, `python`, `python3`, `uv`, `uvx`, `docker`, `deno`, `bun`) blocks malicious repos from executing arbitrary commands
- Pre-flight duplicate check returns 409 instantly before starting a 60s clone
- Soft-deleted server records excluded from duplicate checks so re-cloning a deleted server works

## Changed files

| File | Change |
|------|--------|
| `management.py` | `POST /api/servers/from-github` endpoint + `_validate_server_with_manager()` helper |
| `models/api.py` | `AddServerFromGitHubRequest`, `GitHubServerResult`, `AddServerFromGitHubResponse` |
| `github_utils.py` | `clone_or_update_repo()` + `GitHubService` class |
| `services/server_builder.py` | **New** — `ServerBuilder` with `slugify()`, ID generation, flat config assembly |
| `validators.py` | `validate_command_allowlist()` |
| `repositories/database.py` | Exclude soft-deleted records from duplicate checks |

## Key design decisions

- **Token in header only** — `X-GitHub-Token` header, never request body, never logged, never persisted
- **Flat config format** — `command/args/env` at top level to match `ServerManager._spawn_mcp_process()` expectations
- **`working_dir` = repo root** — supports `uv --directory src/subdir` pattern used by monorepos
- **`subdirectory` param** — targets a specific subdir in monorepos (e.g. `awslabs/mcp`)
- **`test_before_save=true`** — validates via real manager lifecycle before persisting to MongoDB

## Test plan

- [ ] Start server with `fluidmcp serve --allow-insecure --allow-all-origins --port 8100`
- [ ] `POST /api/servers/from-github` with a public GitHub repo and valid `X-GitHub-Token`
- [ ] Verify server appears in `GET /api/servers`
- [ ] Verify 409 on duplicate `server_id`
- [ ] Verify 400 on blocked command in `metadata.json`

🤖 Generated with [Claude Code]