### PR TITLE
MCP-327: feat: add MCP instance lifecycle management (idle shutdown, env resta…

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1180,6 +1180,34 @@ async def update_server(
     # Always update in-memory
     manager.configs[id] = config
 
+    # Check if server is running and env vars changed - restart if needed
+    if id in manager.processes:
+        process = manager.processes[id]
+        if process.poll() is None:  # Server is running
+            # Get current instance state to compare env vars
+            instance = await manager.db.get_instance_state(id)
+            if instance:
+                current_env = instance.get("env", {})
+                new_env = config.get("mcp_config", {}).get("env", {})
+
+                # Compare env vars (simple dict comparison)
+                if current_env != new_env:
+                    logger.info(f"Environment variables changed for running server '{id}', restarting...")
+                    try:
+                        # Stop the server
+                        stop_success = await manager.stop_server(id)
+                        if stop_success:
+                            # Start with new config
+                            start_success = await manager.start_server(id, config)
+                            if start_success:
+                                logger.info(f"Successfully restarted server '{id}' with new environment")
+                            else:
+                                logger.error(f"Failed to restart server '{id}' after env change")
+                        else:
+                            logger.error(f"Failed to stop server '{id}' for env update")
+                    except Exception as e:
+                        logger.error(f"Error restarting server '{id}' for env change: {e}")
+
     logger.info(f"Updated server configuration: {config['name']} (id: {id})")
     return {
         "message": f"Server '{id}' updated successfully",

--- a/fluidmcp/cli/models/models.py
+++ b/fluidmcp/cli/models/models.py
@@ -53,6 +53,7 @@ class ServerInstanceDocument:
     started_by: str = "system"               # User who started instance
     updated_at: Optional[datetime] = None    # Last state update
     env: Optional[Dict[str, str]] = None     # Instance-specific environment variables
+    last_used_at: Optional[datetime] = None  # Last activity timestamp for idle cleanup
 
 
 @dataclass

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -540,7 +540,11 @@ async def main(args):
     logger.info("Creating ServerManager...")
     server_manager = ServerManager(persistence)
 
-    # 3. Create FastAPI app (without MCP servers)
+    # 3. Start background tasks
+    logger.info("Starting background tasks...")
+    server_manager.start_idle_cleanup_task()
+
+    # 4. Create FastAPI app (without MCP servers)
     app = await create_app(
         db_manager=persistence,
         server_manager=server_manager,
@@ -608,6 +612,13 @@ async def main(args):
 
     # Graceful cleanup
     logger.info("Initiating graceful shutdown...")
+
+    try:
+        # Stop idle cleanup task
+        logger.info("Stopping idle cleanup task...")
+        await server_manager.stop_idle_cleanup_task()
+    except Exception as e:
+        logger.error(f"Error stopping idle cleanup task: {e}")
 
     try:
         # Stop all MCP servers with timeout

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -651,7 +651,12 @@ def create_dynamic_router(server_manager):
 
                 # Read response (non-blocking with asyncio.to_thread)
                 response_line = await asyncio.to_thread(process.stdout.readline)
-                return JSONResponse(content=json.loads(response_line))
+                response_data = json.loads(response_line)
+
+                # Update last_used_at for idle cleanup
+                await server_manager.update_last_used(server_name)
+
+                return JSONResponse(content=response_data)
 
             except HTTPException:
                 raise
@@ -668,6 +673,9 @@ def create_dynamic_router(server_manager):
         """
         Server-Sent Events streaming endpoint for long-running MCP operations.
         """
+        # Update last_used_at for idle cleanup when SSE connection is opened
+        await server_manager.update_last_used(server_name)
+
         # Initialize metrics collector
         collector = MetricsCollector(server_name)
 
@@ -898,9 +906,25 @@ def create_dynamic_router(server_manager):
             except (BrokenPipeError, OSError) as e:
                 raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
 
-            # Non-blocking I/O with asyncio.to_thread
-            response_line = await asyncio.to_thread(process.stdout.readline)
+            # Tool execution with timeout
+            try:
+                response_line = await asyncio.wait_for(
+                    asyncio.to_thread(process.stdout.readline),
+                    timeout=60.0  # 60 second tool execution timeout
+                )
+            except asyncio.TimeoutError:
+                # Log timeout failure
+                await server_manager.db.save_log_entry({
+                    "server_name": server_name,
+                    "stream": "error",
+                    "content": f"Tool '{request_body.get('name', 'unknown')}' execution timed out after 60 seconds"
+                })
+                raise HTTPException(504, "Tool execution timed out")
+
             response_data = json.loads(response_line)
+
+            # Update last_used_at for idle cleanup
+            await server_manager.update_last_used(server_name)
 
             return JSONResponse(content=response_data)
 

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -12,7 +12,7 @@ import time
 import atexit
 from typing import Dict, Any, Optional, List
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from loguru import logger
 
 from ..repositories.database import DatabaseManager
@@ -55,6 +55,11 @@ class ServerManager:
         # 30s provides quick feedback (max 30s delay) while preventing excessive writes
         # when repeatedly checking the same stale server
         self._stale_pid_cache_ttl = 30.0  # seconds
+
+        # Idle cleanup configuration
+        self.idle_timeout_seconds = int(os.getenv("FMCP_IDLE_TIMEOUT", "3600"))  # Default 1 hour
+        self.cleanup_interval_seconds = 300  # Run cleanup every 5 minutes
+        self._cleanup_task: Optional[asyncio.Task] = None
 
         # Register cleanup handlers
         atexit.register(self._cleanup_on_exit)
@@ -168,9 +173,25 @@ class ServerManager:
             # Get display name from config
             name = config.get("name", id)
 
-            # Spawn the MCP process
+            # Spawn the MCP process with timeout
             logger.info(f"Starting server '{name}' (id: {id})...")
-            process = await self._spawn_mcp_process(id, config)
+            try:
+                process = await asyncio.wait_for(
+                    self._spawn_mcp_process(id, config),
+                    timeout=30.0  # 30 second startup timeout
+                )
+            except asyncio.TimeoutError:
+                logger.error(f"Server '{name}' (id: {id}) startup timed out after 30 seconds")
+                # Update metrics - server failed to start (status code: 3)
+                collector.set_server_status(3)  # 3 = error
+                collector.record_error("startup_timeout")
+                # Save error to instance state
+                await self.db.save_instance_state({
+                    "server_id": id,
+                    "state": "failed",
+                    "last_error": "Server startup timed out after 30 seconds"
+                })
+                return False
 
             if not process:
                 logger.error(f"Failed to spawn process for server '{name}' (id: {id})")
@@ -199,7 +220,8 @@ class ServerManager:
                 "restart_count": 0,
                 "last_health_check": datetime.utcnow(),
                 "health_check_failures": 0,
-                "started_by": user_id  # Track who started this instance
+                "started_by": user_id,  # Track who started this instance
+                "last_used_at": datetime.utcnow()  # Initialize last_used_at when server starts
             }, expected_pid=existing_pid)
 
             if not success:
@@ -518,6 +540,9 @@ class ServerManager:
                     if not success:
                         logger.debug(f"Server {id} PID changed during stale check, re-fetching status")
                         return await self.get_server_status(id)
+
+                    # Check for auto-restart on crash
+                    await self._check_auto_restart_on_crash(id, instance)
 
                     # Cache the update timestamp
                     self._stale_pid_updates[id] = current_time
@@ -1005,3 +1030,157 @@ class ServerManager:
         ]
 
         return any(placeholder_indicators)
+
+    # ==================== Idle Cleanup Methods ====================
+
+    def start_idle_cleanup_task(self) -> None:
+        """
+        Start the background idle cleanup task.
+        Should be called when the server starts.
+        """
+        if self._cleanup_task is not None:
+            logger.warning("Idle cleanup task already running")
+            return
+
+        self._cleanup_task = asyncio.create_task(self._idle_cleanup_loop())
+        logger.info(f"Started idle cleanup task (interval: {self.cleanup_interval_seconds}s, timeout: {self.idle_timeout_seconds}s)")
+
+    async def stop_idle_cleanup_task(self) -> None:
+        """
+        Stop the background idle cleanup task.
+        Should be called when the server shuts down.
+        """
+        if self._cleanup_task is not None:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+            self._cleanup_task = None
+            logger.info("Stopped idle cleanup task")
+
+    async def _idle_cleanup_loop(self) -> None:
+        """
+        Background task that periodically checks for and stops idle servers.
+        """
+        while True:
+            try:
+                await asyncio.sleep(self.cleanup_interval_seconds)
+                await self._perform_idle_cleanup()
+            except asyncio.CancelledError:
+                logger.info("Idle cleanup loop cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Error in idle cleanup loop: {e}")
+                # Continue running despite errors
+
+    async def _perform_idle_cleanup(self) -> None:
+        """
+        Check for idle servers and stop them if they exceed the idle timeout.
+        """
+        try:
+            # Get all running instances from database
+            running_instances = await self.db.list_instances_by_state("running")
+
+            if not running_instances:
+                return
+
+            current_time = datetime.utcnow()
+            idle_cutoff = current_time - timedelta(seconds=self.idle_timeout_seconds)
+
+            stopped_count = 0
+
+            for instance in running_instances:
+                server_id = instance.get("server_id")
+                last_used_at = instance.get("last_used_at")
+
+                if last_used_at is None:
+                    # Server has never been used, skip for now
+                    # Could add a separate grace period for newly started servers
+                    continue
+
+                if isinstance(last_used_at, str):
+                    last_used_at = datetime.fromisoformat(last_used_at.replace('Z', '+00:00'))
+
+                if last_used_at < idle_cutoff:
+                    logger.info(f"Stopping idle server '{server_id}' (last used: {last_used_at}, idle for {self.idle_timeout_seconds}s)")
+                    await self.stop_server(server_id)
+                    stopped_count += 1
+
+            if stopped_count > 0:
+                logger.info(f"Idle cleanup: stopped {stopped_count} server(s)")
+
+        except Exception as e:
+            logger.error(f"Error during idle cleanup: {e}")
+
+    async def update_last_used(self, server_id: str) -> None:
+        """
+        Update the last_used_at timestamp for a server.
+        Called when the server is actively used.
+
+        Args:
+            server_id: Server identifier
+        """
+        try:
+            await self.db.save_instance_state({
+                "server_id": server_id,
+                "last_used_at": datetime.utcnow()
+            })
+        except Exception as e:
+            logger.warning(f"Failed to update last_used_at for server '{server_id}': {e}")
+
+    async def _check_auto_restart_on_crash(self, server_id: str, instance: Dict[str, Any]) -> None:
+        """
+        Check if a crashed server should be automatically restarted based on restart policy.
+
+        Args:
+            server_id: Server identifier
+            instance: Current instance state from database
+        """
+        try:
+            # Get server configuration
+            config = await self.db.get_server_config(server_id)
+            if not config:
+                logger.debug(f"No config found for server '{server_id}', skipping auto-restart")
+                return
+
+            restart_policy = config.get("restart_policy", "never")
+            max_restarts = config.get("max_restarts", 3)
+            restart_window_sec = config.get("restart_window_sec", 300)
+
+            # Check if restart policy allows auto-restart
+            if restart_policy not in ["on-failure", "always"]:
+                logger.debug(f"Server '{server_id}' restart policy '{restart_policy}' does not allow auto-restart")
+                return
+
+            current_restart_count = instance.get("restart_count", 0)
+            last_start_time = instance.get("start_time")
+
+            # Check restart count limit
+            if current_restart_count >= max_restarts:
+                logger.warning(f"Server '{server_id}' has reached max restarts ({max_restarts}), not auto-restarting")
+                return
+
+            # Check restart window
+            if last_start_time and restart_window_sec > 0:
+                if isinstance(last_start_time, str):
+                    last_start_time = datetime.fromisoformat(last_start_time.replace('Z', '+00:00'))
+
+                time_since_start = (datetime.utcnow() - last_start_time).total_seconds()
+                if time_since_start < restart_window_sec:
+                    logger.debug(f"Server '{server_id}' still within restart window ({time_since_start:.1f}s < {restart_window_sec}s)")
+                    return
+
+            # Attempt auto-restart
+            logger.info(f"Auto-restarting crashed server '{server_id}' (restart {current_restart_count + 1}/{max_restarts})")
+
+            # Use internal method to avoid lock contention since we're already in a status check
+            success = await self._start_server_unlocked(server_id, config)
+
+            if success:
+                logger.info(f"Successfully auto-restarted server '{server_id}'")
+            else:
+                logger.error(f"Failed to auto-restart server '{server_id}'")
+
+        except Exception as e:
+            logger.error(f"Error during auto-restart check for server '{server_id}': {e}")


### PR DESCRIPTION
I have raised a PR implementing improvements to MCP instance lifecycle management.

Changes include:

server_manager.py – Idle instance cleanup, MCP startup timeout, and auto-restart on crash

package_launcher.py – Tool execution timeout and activity tracking

management.py – Detect ENV changes and restart the instance if needed

server.py – Background task lifecycle for idle cleanup

All changes compile successfully and keep the existing architecture intact while adding better stability and lifecycle handling.