### PR TITLE
MCP-329: feat: Add upsert capability, auto-reclone, and server ID display

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -860,6 +860,7 @@ async def add_server_from_github(
             "enabled": True,
             "restart_policy": "on-failure",
             "test_before_save": True,
+            "upsert": False,
         },
     ),
     token: str = Depends(get_token),
@@ -883,6 +884,9 @@ async def add_server_from_github(
     **Multi-server repos**: IDs are generated as ``{server_id}-{slugified-name}``.
     Use ``server_name`` to select a single server.
 
+    **Updating existing servers**: Set ``upsert=true`` to update servers with the same ID
+    instead of receiving a 409 conflict. Useful for re-importing or pulling latest changes.
+
     **Headers**:
     - ``X-GitHub-Token``: GitHub personal access token (required)
 
@@ -896,6 +900,7 @@ async def add_server_from_github(
     - ``restart_policy``: ``never`` | ``on-failure`` | ``always``
     - ``max_restarts``: max restart attempts (0–10)
     - ``test_before_save``: validate via test-start before persisting (default: ``true``)
+    - ``upsert``: update existing servers instead of rejecting with 409 (default: ``false``)
     """
     from ..services.github_utils import GitHubService
     from ..services.validators import validate_command_allowlist  # noqa: F401 – used inside GitHubService
@@ -931,6 +936,7 @@ async def add_server_from_github(
     max_restarts = int(config.get("max_restarts", 3))
     enabled = bool(config.get("enabled", True))
     test_before_save = bool(config.get("test_before_save", True))
+    upsert = bool(config.get("upsert", False))
 
     # Validate env variables if provided
     if env:
@@ -940,11 +946,12 @@ async def add_server_from_github(
     # This avoids a 60-second clone only to get a 409 at the end.
     # We check DB only (not in-memory) because a previous failed attempt may
     # have left a stale in-memory entry for the same ID without a DB record.
-    if await manager.db.get_server_config(base_server_id):
+    # Skip this check if upsert=True (user wants to update existing servers).
+    if not upsert and await manager.db.get_server_config(base_server_id):
         raise HTTPException(
             409,
             f"Server with id '{base_server_id}' already exists. "
-            f"Choose a different Server ID and try again.",
+            f"Choose a different Server ID and try again, or set upsert=True to update.",
         )
 
     # Track IDs registered in-memory this request so we can roll back on error
@@ -980,11 +987,12 @@ async def add_server_from_github(
             # failed attempt for the same repo may have left a stale entry in
             # manager.configs without a corresponding DB record, causing a false
             # 409 on retry. Evict any such stale entry before proceeding.
-            if await manager.db.get_server_config(sid):
+            existing_config = await manager.db.get_server_config(sid)
+            if existing_config and not upsert:
                 raise HTTPException(
                     409,
                     f"Server with id '{sid}' already exists. "
-                    f"Choose a different Server ID and try again.",
+                    f"Choose a different Server ID and try again, or set upsert=True to update.",
                 )
             manager.configs.pop(sid, None)  # evict stale in-memory entry if present
 

--- a/fluidmcp/cli/cli.py
+++ b/fluidmcp/cli/cli.py
@@ -559,8 +559,17 @@ def main():
     Main function to handle command line arguments and execute the appropriate action.
     '''
     # Load environment variables from .env file
-    env_path = Path(__file__).parent / '.env'
-    load_dotenv(dotenv_path=env_path)
+    # Try root .env first, then fall back to cli/.env for backward compatibility
+    # Use override=True to ensure .env values take precedence over shell environment
+    root_env_path = Path(__file__).parent.parent.parent / '.env'
+    cli_env_path = Path(__file__).parent / '.env'
+    
+    if root_env_path.exists():
+        load_dotenv(dotenv_path=root_env_path, override=True)
+        logger.debug(f"Loaded environment from {root_env_path}")
+    elif cli_env_path.exists():
+        load_dotenv(dotenv_path=cli_env_path, override=True)
+        logger.debug(f"Loaded environment from {cli_env_path}")
 
     # Parse command line arguments with the commands given in setup.py
     parser = argparse.ArgumentParser(description="FluidAI MCP CLI")

--- a/fluidmcp/cli/models/api.py
+++ b/fluidmcp/cli/models/api.py
@@ -288,6 +288,13 @@ class AddServerFromGitHubRequest(BaseModel):
             "to the database.  Recommended: True."
         ),
     )
+    upsert: bool = Field(
+        default=False,
+        description=(
+            "If True, update existing servers with the same ID instead of rejecting "
+            "with a 409 conflict. Useful for re-importing or updating GitHub servers."
+        ),
+    )
 
     class Config:
         json_schema_extra = {

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -687,7 +687,60 @@ class ServerManager:
             env_vars = config.get("env", {})
             working_dir = config.get("working_dir", ".")
             install_path = config.get("install_path", ".")
+            working_dir_path = Path(working_dir)
 
+            # 🔹 Auto-reclone if directory missing (Railway ephemeral container fix)
+            if not working_dir_path.exists():
+                logger.warning(f"Working directory missing for server '{id}': {working_dir}")
+
+                if config.get("source") == "github":
+                    from .github_utils import clone_github_repo
+                    
+                    repo = config.get("github_repo")
+                    branch = config.get("github_branch", "main")
+
+                    logger.info(f"Auto-recloning repository {repo}@{branch} to {working_dir}")
+
+                    try:
+                        # Get GitHub token from environment
+                        github_token = os.getenv("FMCP_GITHUB_TOKEN") or os.getenv("GITHUB_TOKEN")
+                        if not github_token:
+                            logger.error(
+                                "GitHub token not found in environment. "
+                                "Available env vars: FMCP_GITHUB_TOKEN={}, GITHUB_TOKEN={}".format(
+                                    "SET" if os.getenv("FMCP_GITHUB_TOKEN") else "NOT SET",
+                                    "SET" if os.getenv("GITHUB_TOKEN") else "NOT SET"
+                                )
+                            )
+                            raise RuntimeError(
+                                "GitHub token required for auto-reclone. "
+                                "Set FMCP_GITHUB_TOKEN or GITHUB_TOKEN environment variable."
+                            )
+                        
+                        # Determine install_dir from the working_dir path structure
+                        # e.g., /app/.fmcp-packages/Fluid-AI/fluid-ai-mcp-servers/main
+                        # install_dir = /app/.fmcp-packages
+                        parent_path = working_dir_path.parent.parent.parent
+                        
+                        # Re-clone to the original path using the proper function
+                        clone_github_repo(
+                            repo_path=repo,
+                            branch=branch,
+                            github_token=github_token,
+                            install_dir=parent_path
+                        )
+
+                        # Persist config to database after successful reclone
+                        await self.db.save_server_config(config)
+                        logger.info(f"Repository auto-recloned successfully to {working_dir}")
+
+                    except Exception as e:
+                        logger.error(f"Failed to auto-reclone repository: {e}")
+                        return None
+                else:
+                    logger.error(f"Working directory missing and source is not GitHub")
+                    return None
+                
             # Load instance-specific env vars (user's API keys, etc.)
             # These override config env vars
             instance_env = await self.db.get_instance_env(id)
@@ -873,7 +926,9 @@ class ServerManager:
 
         url = config.get("url", "http://127.0.0.1:8000").rstrip("/")
         name = config.get("name", id)
-        health_url = f"{url}/sse"
+        # Use custom health endpoint if specified, otherwise default to /sse
+        health_endpoint = config.get("health_endpoint", "/sse")
+        health_url = f"{url}{health_endpoint}"
 
         logger.info(
             f"[{id}] SSE server '{name}' spawned (PID {process.pid}), "

--- a/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
+++ b/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
@@ -67,6 +67,7 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
   const [subdirectory, setSubdirectory] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [envText, setEnvText] = useState('');
+  const [upsert, setUpsert] = useState(false);
 
   // Validation errors
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -177,6 +178,7 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
           subdirectory: subdirectory.trim() || undefined,
           env: Object.keys(env).length > 0 ? env : undefined,
           test_before_save: false,
+          upsert: upsert,
         },
         token.trim()
       );
@@ -198,13 +200,13 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
       progressRunning.current = false;
 
       if (err instanceof ApiHttpError && err.status === 409) {
-        // Server ID already taken — bump the suffix and let the user retry
+        // Server ID already taken — offer two solutions
         const suggested = bumpServerId(serverId.trim());
         setServerId(suggested);
         setServerIdTouched(true);
         setApiError(
-          `Server ID "${serverId.trim()}" is already taken. ` +
-          `We've suggested "${suggested}" — hit Clone & Register to try again.`,
+          `Server ID "${serverId.trim()}" already exists. ` +
+          `Either use a different ID like "${suggested}", or enable "Update existing servers" to overwrite it.`,
         );
       } else {
         setApiError(err instanceof Error ? err.message : 'Clone failed');
@@ -490,6 +492,22 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
               />
               <p className="mt-1 text-xs text-zinc-500">
                 KEY=value, one per line. These merge on top of the repo's own defaults.
+              </p>
+            </div>
+
+            <div className="border-t border-zinc-700 pt-4">
+              <label className="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={upsert}
+                  onChange={(e) => setUpsert(e.target.checked)}
+                  className="w-4 h-4 bg-zinc-800 border border-zinc-700 rounded checked:bg-blue-600 checked:border-blue-600 cursor-pointer"
+                />
+                <span className="text-sm font-medium text-zinc-300">Update existing servers</span>
+              </label>
+              <p className="mt-2 text-xs text-zinc-500">
+                If checked, servers with the same ID will be updated instead of being rejected. 
+                Useful for re-importing repositories or pulling latest changes.
               </p>
             </div>
           </div>

--- a/fluidmcp/frontend/src/components/ServerCard.tsx
+++ b/fluidmcp/frontend/src/components/ServerCard.tsx
@@ -62,6 +62,7 @@ function ServerCard({
             <h3 className="text-xl font-bold text-white truncate">
               {server.name}
             </h3>
+            <p className="text-xs text-zinc-400 font-mono mt-1">{server.id}</p>
           </div>
 
           {/* Status indicator */}

--- a/fluidmcp/frontend/src/pages/ServerDetails.tsx
+++ b/fluidmcp/frontend/src/pages/ServerDetails.tsx
@@ -217,6 +217,7 @@ export default function ServerDetails() {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <div>
               <h1>{serverDetails.name}</h1>
+              <p style={{ margin: '4px 0 8px 0', fontSize: '0.875rem', fontFamily: 'monospace', color: '#a1a1a1' }}>{serverId}</p>
               <p className="subtitle">
                 {serverDetails.description || "No description available"}
               </p>

--- a/fluidmcp/frontend/src/types/server.ts
+++ b/fluidmcp/frontend/src/types/server.ts
@@ -151,6 +151,7 @@ export interface CloneFromGithubRequest {
   restart_policy?: 'never' | 'on-failure' | 'always';
   max_restarts?: number;
   test_before_save?: boolean;
+  upsert?: boolean;          // update existing servers instead of rejecting with 409
 }
 
 export interface CloneFromGithubServerResult {


### PR DESCRIPTION
## Summary

This PR implements a complete suite of improvements for Railway deployment and server management:

1. **Upsert Capability** - Allow updating existing servers without 409 conflicts
2. **Auto-Reclone for Ephemeral Containers** - Automatically re-clone missing repositories during process spawn (critical for Railway)
3. **Environment Variable Priority Fix** - Ensure `.env` file values override shell environment variables
4. **Server ID Visibility** - Display server IDs in dashboard for easier reference and debugging

## Changes Made

### Backend
- **API Enhancement** (`management.py`): Added `upsert` parameter to GitHub server import endpoint
- **Auto-Reclone Logic** (`server_manager.py`): 
  - Detects missing working directories during process spawn
  - Extracts GitHub repo and branch from server config
  - Intelligently loads GitHub token from environment (supports both `FMCP_GITHUB_TOKEN` and `GITHUB_TOKEN`)
  - Re-clones to proper persistent path (`.fmcp-packages/Owner/repo/branch/`)
  - Persists updated config to MongoDB after successful reclone
- **Environment Loading** (`cli.py`): Added `override=True` to `load_dotenv()` to prioritize `.env` file values

### Frontend
- **API Model** (`api.py`): Added `upsert` field to `GitHubServerCreateRequest`
- **CloneFromGithubForm** (`CloneFromGithubForm.tsx`): Added checkbox and error messaging for upsert
- **Server Cards** (`ServerCard.tsx`): Display server ID below server name in small monospace text
- **Server Details** (`ServerDetails.tsx`): Display server ID right below server name with monospace font

## Testing

### Test Auto Reclone 
```bash
# 1. Start fmcp serve and import a GitHub server
# 2. a. Delete the working directory (for codespace)
rm -rf /workspaces/fluidmcp/.fmcp-packages/Owner/repo/branch/
# 2. b. Redeploy railway container 
# 3. Try to start the server 
# 4. Check logs - should show auto-recloning message and server should start successfully
```

## Breaking Changes
None. All changes are backward compatible.

## Notes for Reviewers
- Auto-reclone uses the existing clone_github_repo() utility for consistency
- Server ID display uses same styling as ManageServers table for UI consistency