### PR TITLE
[MCP-424]-Fix/mcp stability tests

### DIFF
--- a/tests/test_server_manager_cleanup.py
+++ b/tests/test_server_manager_cleanup.py
@@ -543,7 +543,13 @@ class TestResourceLimits:
     """Tests for _create_preexec_fn subprocess memory limits."""
 
     def test_returns_none_when_disabled(self):
-        result = ServerManager._create_preexec_fn(0) if False else None
+        # Call site: preexec_fn = _create_preexec_fn(mb) if mb > 0 else None
+        # When mb=0 the call site never calls _create_preexec_fn — result is None
+        import os
+        if os.name == "nt":
+            pytest.skip("Not applicable on Windows")
+        memory_limit_mb = 0
+        result = ServerManager._create_preexec_fn(memory_limit_mb) if memory_limit_mb > 0 else None
         assert result is None
 
     def test_returns_callable_on_linux(self):
@@ -557,13 +563,14 @@ class TestResourceLimits:
         import sys
         if sys.platform == "win32":
             pytest.skip("Not applicable on Windows")
-        with patch("resource.setrlimit") as mock_rlimit:
-            with patch("resource.RLIMIT_AS", 9):
-                fn = ServerManager._create_preexec_fn(256)
-                with patch.dict("sys.modules", {"resource": __import__("unittest.mock").mock.MagicMock(
-                    setrlimit=mock_rlimit, RLIMIT_AS=9
-                )}):
-                    fn()
+        import resource as resource_module
+        with patch.object(resource_module, "setrlimit") as mock_rlimit:
+            fn = ServerManager._create_preexec_fn(256)
+            fn()
+            mock_rlimit.assert_called_once_with(
+                resource_module.RLIMIT_AS,
+                (256 * 1024 * 1024, 256 * 1024 * 1024)
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_server_manager_cleanup.py
+++ b/tests/test_server_manager_cleanup.py
@@ -8,9 +8,17 @@ import asyncio
 import subprocess
 from unittest.mock import Mock, AsyncMock, patch, MagicMock
 from datetime import datetime
+from loguru import logger
 
 from fluidmcp.cli.services.server_manager import ServerManager
 from fluidmcp.cli.repositories import InMemoryBackend
+
+
+@pytest.fixture(autouse=True)
+def silence_loguru():
+    """Remove loguru handlers during tests to prevent I/O errors on closed streams."""
+    logger.remove()
+    yield
 
 
 @pytest.fixture

--- a/tests/test_server_manager_cleanup.py
+++ b/tests/test_server_manager_cleanup.py
@@ -359,5 +359,212 @@ class TestMultipleProcessCleanup:
             process.terminate.assert_called_once()
 
 
+class TestMCPHealthMonitor:
+    """Tests for MCPHealthMonitor — crash detection, restart policy, dedup."""
+
+    @pytest.fixture
+    def monitor(self, server_manager):
+        from fluidmcp.cli.services.server_manager import MCPHealthMonitor
+        return MCPHealthMonitor(server_manager, check_interval=30)
+
+    @pytest.mark.asyncio
+    async def test_detects_crash_and_restarts(self, monitor, server_manager, backend):
+        """Health monitor detects dead process and triggers restart."""
+        await backend.connect()
+        await backend.save_server_config({
+            "id": "srv1", "name": "srv1", "restart_policy": "on-failure", "max_restarts": 3
+        })
+        dead = Mock(spec=subprocess.Popen)
+        dead.poll = Mock(return_value=1)
+        dead.returncode = 1
+        server_manager.processes["srv1"] = dead
+        server_manager._start_server_unlocked = AsyncMock(return_value=True)
+        server_manager._cleanup_server = AsyncMock()
+        monitor._calculate_restart_delay = Mock(return_value=0)
+
+        await monitor._check_server("srv1", dead)
+        await asyncio.sleep(0.05)
+
+        server_manager._cleanup_server.assert_called_once()
+        server_manager._start_server_unlocked.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_restart_on_clean_exit(self, monitor, server_manager, backend):
+        """on-failure policy: clean exit (code=0) should not restart."""
+        await backend.connect()
+        await backend.save_server_config({
+            "id": "srv2", "name": "srv2", "restart_policy": "on-failure", "max_restarts": 3
+        })
+        dead = Mock(spec=subprocess.Popen)
+        dead.poll = Mock(return_value=0)
+        dead.returncode = 0
+        server_manager.processes["srv2"] = dead
+        server_manager._start_server_unlocked = AsyncMock(return_value=True)
+        server_manager._cleanup_server = AsyncMock()
+
+        await monitor._check_server("srv2", dead)
+
+        server_manager._start_server_unlocked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_respects_never_policy(self, monitor, server_manager, backend):
+        """restart_policy=never: crashed process should not be restarted."""
+        await backend.connect()
+        await backend.save_server_config({
+            "id": "srv3", "name": "srv3", "restart_policy": "never", "max_restarts": 3
+        })
+        dead = Mock(spec=subprocess.Popen)
+        dead.poll = Mock(return_value=1)
+        dead.returncode = 1
+        server_manager.processes["srv3"] = dead
+        server_manager._start_server_unlocked = AsyncMock(return_value=True)
+        server_manager._cleanup_server = AsyncMock()
+
+        await monitor._check_server("srv3", dead)
+
+        server_manager._start_server_unlocked.assert_not_called()
+        server_manager._cleanup_server.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_max_restarts_not_exceeded(self, monitor, server_manager, backend):
+        """Monitor stops restarting after max_restarts is reached."""
+        await backend.connect()
+        await backend.save_server_config({
+            "id": "srv4", "name": "srv4", "restart_policy": "on-failure", "max_restarts": 2
+        })
+        dead = Mock(spec=subprocess.Popen)
+        dead.poll = Mock(return_value=1)
+        dead.returncode = 1
+        server_manager.processes["srv4"] = dead
+        server_manager._start_server_unlocked = AsyncMock(return_value=True)
+        server_manager._cleanup_server = AsyncMock()
+        monitor._restart_counts["srv4"] = 2  # already at max
+
+        await monitor._check_server("srv4", dead)
+
+        server_manager._start_server_unlocked.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_duplicate_restart(self, monitor, server_manager, backend):
+        """_restarts_in_progress prevents duplicate restarts across cycles."""
+        await backend.connect()
+        await backend.save_server_config({
+            "id": "srv5", "name": "srv5", "restart_policy": "on-failure", "max_restarts": 3
+        })
+        dead = Mock(spec=subprocess.Popen)
+        dead.poll = Mock(return_value=1)
+        dead.returncode = 1
+        server_manager.processes["srv5"] = dead
+        server_manager._start_server_unlocked = AsyncMock(return_value=True)
+        server_manager._cleanup_server = AsyncMock()
+        monitor._restarts_in_progress.add("srv5")  # simulate in-progress
+
+        await monitor._check_server("srv5", dead)
+
+        server_manager._start_server_unlocked.assert_not_called()
+
+
+class TestCleanupServerState:
+    """Tests for _cleanup_server intentional flag and crash event persistence."""
+
+    @pytest.mark.asyncio
+    async def test_intentional_stop_sets_stopped_state(self, server_manager, backend):
+        """Intentional stop saves state=stopped regardless of exit code."""
+        await backend.connect()
+        await backend.save_instance_state({"server_id": "s1", "state": "running", "pid": 1})
+        server_manager.start_times["s1"] = asyncio.get_event_loop().time()
+
+        await server_manager._cleanup_server("s1", exit_code=1, intentional=True)
+
+        state = await backend.get_instance_state("s1")
+        assert state["state"] == "stopped"
+
+    @pytest.mark.asyncio
+    async def test_crash_sets_failed_state_and_saves_event(self, server_manager, backend):
+        """Non-intentional non-zero exit saves state=failed and a crash event."""
+        await backend.connect()
+        await backend.save_instance_state({"server_id": "s2", "state": "running", "pid": 2})
+        server_manager.start_times["s2"] = asyncio.get_event_loop().time()
+
+        await server_manager._cleanup_server("s2", exit_code=137, intentional=False)
+
+        state = await backend.get_instance_state("s2")
+        assert state["state"] == "failed"
+        events = await backend.list_crash_events("s2")
+        assert len(events) == 1
+        assert events[0]["exit_code"] == 137
+
+    @pytest.mark.asyncio
+    async def test_no_crash_event_on_intentional_stop(self, server_manager, backend):
+        """Intentional stop must not save a crash event."""
+        await backend.connect()
+        server_manager.start_times["s3"] = asyncio.get_event_loop().time()
+
+        await server_manager._cleanup_server("s3", exit_code=0, intentional=True)
+
+        events = await backend.list_crash_events("s3")
+        assert len(events) == 0
+
+
+class TestCrashEventPersistence:
+    """Tests for in-memory crash event save/list ordering and limit."""
+
+    @pytest.mark.asyncio
+    async def test_events_stored_most_recent_first(self, backend):
+        await backend.connect()
+        await backend.save_crash_event({"server_id": "x", "exit_code": 1, "timestamp": "t1"})
+        await backend.save_crash_event({"server_id": "x", "exit_code": 2, "timestamp": "t2"})
+
+        events = await backend.list_crash_events("x")
+        assert events[0]["exit_code"] == 2
+        assert events[1]["exit_code"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_respects_limit(self, backend):
+        await backend.connect()
+        for i in range(10):
+            await backend.save_crash_event({"server_id": "y", "exit_code": i})
+
+        events = await backend.list_crash_events("y", limit=3)
+        assert len(events) == 3
+
+    @pytest.mark.asyncio
+    async def test_crash_events_cleared_on_disconnect(self, backend):
+        await backend.connect()
+        await backend.save_crash_event({"server_id": "z", "exit_code": 1})
+        await backend.disconnect()
+        await backend.connect()
+
+        events = await backend.list_crash_events("z")
+        assert len(events) == 0
+
+
+class TestResourceLimits:
+    """Tests for _create_preexec_fn subprocess memory limits."""
+
+    def test_returns_none_when_disabled(self):
+        result = ServerManager._create_preexec_fn(0) if False else None
+        assert result is None
+
+    def test_returns_callable_on_linux(self):
+        import sys
+        if sys.platform == "win32":
+            pytest.skip("Not applicable on Windows")
+        fn = ServerManager._create_preexec_fn(256)
+        assert callable(fn)
+
+    def test_preexec_fn_sets_rlimit(self):
+        import sys
+        if sys.platform == "win32":
+            pytest.skip("Not applicable on Windows")
+        with patch("resource.setrlimit") as mock_rlimit:
+            with patch("resource.RLIMIT_AS", 9):
+                fn = ServerManager._create_preexec_fn(256)
+                with patch.dict("sys.modules", {"resource": __import__("unittest.mock").mock.MagicMock(
+                    setrlimit=mock_rlimit, RLIMIT_AS=9
+                )}):
+                    fn()
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Unit tests for the new MCPHealthMonitor, crash event persistence, and subprocess resource limit code added in the preceding PR. Tests cover crash detection and auto-restart, restart policy enforcement (never/on-failure/max-restarts), duplicate restart prevention via `_restarts_in_progress`, intentional vs crash state classification in `_cleanup_server`, crash event ordering and limit in the in-memory backend, and `_create_preexec_fn` returning a callable on Linux.

## How to Test
```bash
pytest tests/test_server_manager_cleanup.py -v
