### PR TITLE
MCP-434: MCP JAM phase 2 - Agent chat improvements and UI polish

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -253,8 +253,10 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent
-        agent_result = await choose_tool_with_llm(body.message, tools)
+        # Call the Groq agent, passing chat history for multi-turn context
+        agent_result = await choose_tool_with_llm(
+            body.message, tools, chat_history=body.chat_history or []
+        )
 
         # Validate the response has the expected fields
         tool_name = agent_result.get("tool_name")

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -6,7 +6,8 @@ from loguru import logger
 
 def format_tools_for_prompt(tools):
     """
-    Convert MCP tools into a detailed prompt format.
+    Convert MCP tools into a readable prompt format.
+    This remains dynamic → supports ANY MCP.
     """
 
     formatted = []
@@ -27,14 +28,15 @@ def format_tools_for_prompt(tools):
 
         formatted.append(
             f"""
-            Tool: {name}
-            Description: {description}
-            Parameters:
-            {param_text}
-            """
+Tool: {name}
+Description: {description}
+Parameters:
+{param_text}
+"""
         )
 
     return "\n".join(formatted)
+
 
 async def choose_tool_with_llm(message: str, tools: list):
     """
@@ -69,29 +71,21 @@ async def choose_tool_with_llm(message: str, tools: list):
     tool_description = format_tools_for_prompt(tools)
 
     prompt = f"""
-    You are an AI agent that selects which MCP tool should be executed.
+Available tools:
+{tool_description}
 
-    Available tools:
-    {tool_description}
+User request:
+{message}
 
-    User request:
-    {message}
+Instructions:
+1. Choose the BEST tool to fulfill the request.
+2. Extract parameters from the request.
+3. If parameters are missing:
+   - Infer reasonable defaults OR leave them empty
+   - DO NOT explain anything
 
-    Instructions:
-    1. Choose the BEST tool to fulfill the request.
-    2. Extract parameters from the request.
-    3. Return ONLY JSON.
-
-    Example response:
-
-    {{"tool_name": "convert_time",
-        "params": {{
-            "time": "16:00",
-            "source_timezone": "Asia/Tokyo",
-            "target_timezone": "Europe/London"
-        }}
-    }}
-    """
+Return ONLY JSON.
+"""
 
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking
@@ -100,32 +94,69 @@ async def choose_tool_with_llm(message: str, tools: list):
             return client.chat.completions.create(
                 model="llama-3.1-8b-instant",
                 messages=[
-                    {"role": "system", "content": "You select MCP tools."},
-                    {"role": "user", "content": prompt}
+                    {
+                        "role": "system",
+                        "content": """
+You are a strict JSON API for MCP tool selection.
+
+You MUST return ONLY valid JSON.
+
+Format:
+{
+  "tool_name": string,
+  "params": object
+}
+
+Rules:
+- No explanation
+- No markdown
+- No extra text
+- Always return JSON
+"""
+                    },
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
                 ],
                 temperature=0,
-                max_tokens=120
+                max_tokens=200,
+                stop=["\n\n"]
             )
 
         response = await asyncio.to_thread(_call_llm)
 
         content = response.choices[0].message.content.strip()
 
-        logger.info(f"LLM raw response: {content}")
+        logger.info(f"LLM raw response: {repr(content)}")
 
-        # Try parsing JSON safely
+        # First attempt: direct parse
         try:
             result = json.loads(content)
-        except json.JSONDecodeError:
+            logger.info(f"LLM parsed result (direct): {result}")
+            return result
 
-            # Attempt JSON extraction
+        except json.JSONDecodeError:
+            logger.warning("Direct JSON parse failed, attempting extraction...")
+
+            # Fallback: extract JSON block
             start = content.find("{")
             end = content.rfind("}") + 1
-            result = json.loads(content[start:end])
 
-        logger.info(f"LLM parsed result: {result}")
+            if start == -1 or end == 0:
+                raise ValueError(f"No JSON found in LLM response: {content}")
 
-        return result
+            json_str = content[start:end]
+
+            try:
+                result = json.loads(json_str)
+                logger.info(f"LLM parsed result (extracted): {result}")
+                return result
+
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to parse extracted JSON.\nRaw response: {content}\nExtracted: {json_str}"
+                ) from e
 
     except Exception as e:
         logger.error(f"Groq agent error: {e}")

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -38,7 +38,7 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list):
+async def choose_tool_with_llm(message: str, tools: list, chat_history: list = []):
     """
     Universal MCP agent powered by Groq.
 
@@ -90,6 +90,14 @@ Return ONLY JSON.
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking
         # the event loop.
+        # Build prior turns from chat_history for multi-turn context
+        history_messages = [
+            {"role": "user" if m.get("type") == "user" else "assistant",
+             "content": str(m.get("content", ""))}
+            for m in chat_history
+            if m.get("type") in ("user", "assistant") and m.get("content")
+        ]
+
         def _call_llm():
             return client.chat.completions.create(
                 model="llama-3.1-8b-instant",
@@ -114,6 +122,7 @@ Rules:
 - Always return JSON
 """
                     },
+                    *history_messages,
                     {
                         "role": "user",
                         "content": prompt

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -6,24 +6,35 @@ from loguru import logger
 
 def format_tools_for_prompt(tools):
     """
-    Convert MCP tool schemas into a simple prompt-friendly format.
+    Convert MCP tools into a detailed prompt format.
     """
-    tool_lines = []
+
+    formatted = []
 
     for tool in tools:
         name = tool.get("name")
-        desc = tool.get("description", "")
+        description = tool.get("description", "No description")
+
         schema = tool.get("inputSchema", {})
         props = schema.get("properties", {})
 
-        params = ", ".join(props.keys())
+        params = []
+        for param_name, param_info in props.items():
+            param_type = param_info.get("type", "string")
+            params.append(f"- {param_name} ({param_type})")
 
-        tool_lines.append(
-            f"{name}({params}) - {desc}"
+        param_text = "\n".join(params) if params else "None"
+
+        formatted.append(
+            f"""
+            Tool: {name}
+            Description: {description}
+            Parameters:
+            {param_text}
+            """
         )
 
-    return "\n".join(tool_lines)
-
+    return "\n".join(formatted)
 
 async def choose_tool_with_llm(message: str, tools: list):
     """
@@ -58,19 +69,29 @@ async def choose_tool_with_llm(message: str, tools: list):
     tool_description = format_tools_for_prompt(tools)
 
     prompt = f"""
-You are an AI agent that selects which MCP tool to run.
+    You are an AI agent that selects which MCP tool should be executed.
 
-Available tools:
-{tool_description}
+    Available tools:
+    {tool_description}
 
-User request:
-{message}
+    User request:
+    {message}
 
-Respond ONLY with JSON.
+    Instructions:
+    1. Choose the BEST tool to fulfill the request.
+    2. Extract parameters from the request.
+    3. Return ONLY JSON.
 
-Example:
-{{"tool_name": "get_current_time", "params": {{"timezone": "Asia/Tokyo"}}}}
-"""
+    Example response:
+
+    {{"tool_name": "convert_time",
+        "params": {{
+            "time": "16:00",
+            "source_timezone": "Asia/Tokyo",
+            "target_timezone": "Europe/London"
+        }}
+    }}
+    """
 
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -72,12 +72,30 @@ export default function MCPInspector() {
   const chatRef = useRef<HTMLDivElement>(null);
 
   const handleConnect = async () => {
+
     if (!url) return;
 
-    // Prevent duplicate servers
     if (servers.some(s => s.url === url)) {
       alert("Server already added");
       return;
+    }
+
+    // ✅ Disconnect any currently connected server before adding a new one
+    const activeServer = servers.find(s => s.status === "connected" && s.session_id);
+    if (activeServer) {
+      try {
+        await apiClient.disconnectInspectorServer(activeServer.session_id!);
+        setServers(prev =>
+          prev.map(s =>
+            s.id === activeServer.id
+              ? { ...s, session_id: null, tools: [], status: "disconnected" as const, error: undefined }
+              : s
+          )
+        );
+      } catch (err) {
+        console.warn("Could not disconnect old server:", err);
+        // Non-fatal — continue connecting the new one
+      }
     }
 
     const serverId = generateServerId();
@@ -85,57 +103,44 @@ export default function MCPInspector() {
     try {
       setConnecting(true);
 
-      // Add optimistic "connecting" state
-      setServers((prev) => [
+      setServers(prev => [
         ...prev,
-        {
-          id: serverId,
-          session_id: null,
-          url,
-          transport,
-          tools: [],
-          status: 'connecting' as const,
-        },
+        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const },
       ]);
 
-      const res = await apiClient.connectInspectorServer({
-        url,
-        transport,
-      });
+      const res = await apiClient.connectInspectorServer({ url, transport });
 
-      // Update server with connected state and fetched data
-      setServers((prev) =>
-        prev.map((s) =>
+      setServers(prev =>
+        prev.map(s =>
           s.id === serverId
-            ? {
-                ...s,
-                session_id: res.session_id,
-                server_info: res.server_info,
-                tools: res.tools || [],
-                status: 'connected' as const,
-              }
+            ? { ...s, session_id: res.session_id, server_info: res.server_info, tools: res.tools || [], status: "connected" as const }
             : s
         )
       );
 
-      // Auto-select the newly connected server
       setSelectedServerId(serverId);
+      setSelectedTool(null);
+      setToolResult(null);
+      setToolError(null);
+
+      // ✅ Clear chat and show a welcome message for the new server
+      setChatHistory([{
+        id: crypto.randomUUID(),
+        type: "assistant",
+        content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+        timestamp: Date.now(),
+      }]);
 
       setShowAddModal(false);
       setUrl("");
       setTransport("http");
+
     } catch (err: any) {
       console.error("Failed to connect", err);
-
-      // Update server with failed state
-      setServers((prev) =>
-        prev.map((s) =>
+      setServers(prev =>
+        prev.map(s =>
           s.id === serverId
-            ? {
-                ...s,
-                status: 'failed' as const,
-                error: err?.message || 'Failed to connect to MCP server',
-              }
+            ? { ...s, status: "failed" as const, error: err?.message || "Failed to connect to MCP server" }
             : s
         )
       );
@@ -591,9 +596,22 @@ export default function MCPInspector() {
                             <div
                               key={server.id}
                               onClick={() => {
+                                if (selectedServerId === server.id) return;
+
                                 setSelectedServerId(server.id);
                                 setSelectedTool(null);
                                 setToolResult(null);
+                                setToolError(null);
+                                // Reset chat
+                                setChatHistory([
+                                  {
+                                    id: crypto.randomUUID(),
+                                    type: "assistant",
+                                    content: `Switched to ${server?.server_info?.name || "server"}. Chat cleared.`,
+                                    timestamp: Date.now()
+                                  }
+                                ]);
+                                
                               }}
                               style={{
                                 marginTop: "0.75rem",
@@ -1007,61 +1025,122 @@ export default function MCPInspector() {
                               flex: 1,
                               minHeight: 0,        
                               overflowY: "auto",
-                              overflowX: "hidden",
                               marginBottom: "1rem",
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
-                              paddingRight: "4px"
+                              padding: "0.5rem 0.5rem 0.5rem 0.25rem"
                             }}
                           >
                             {chatHistory.map((msg) => {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px", maxWidth: "75%", wordBreak: "break-word" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
+                                    <div style={{
+                                      background: "#2563eb",
+                                      color: "#fff",
+                                      padding: "0.6rem 0.75rem",
+                                      borderRadius: "12px 12px 4px 12px",
+                                      maxWidth: "70%",
+                                      fontSize: "0.9rem",
+                                      lineHeight: 1.4
+                                    }}>
+                                      {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "thinking") {
                                 return (
-                                  <div key={msg.id} style={{ opacity: 0.6 }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      fontSize: "0.8rem",
+                                      opacity: 0.7,
+                                      fontStyle: "italic",
+                                      padding: "0.3rem 0.5rem"
+                                    }}>
+                                      🤖 {msg.content}...
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "tool_call") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(59,130,246,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    <strong>Calling tool:</strong> {msg.toolName}
-                                    <pre>{JSON.stringify(msg.params, null, 2)}</pre>
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(59,130,246,0.12)",
+                                      border: "1px solid rgba(59,130,246,0.35)",
+                                      borderRadius: "8px",
+                                      padding: "0.6rem",
+                                      maxWidth: "80%",
+                                      fontSize: "0.8rem"
+                                    }}>
+                                      <div style={{ fontWeight: 600, marginBottom: "0.3rem" }}>
+                                        🔧 Tool: {msg.toolName}
+                                      </div>
+
+                                      <div style={{
+                                        fontFamily: "monospace",
+                                        fontSize: "0.75rem",
+                                        background: "rgba(0,0,0,0.3)",
+                                        padding: "0.4rem",
+                                        borderRadius: "6px",
+                                        overflowX: "auto"
+                                      }}>
+                                        {JSON.stringify(msg.params, null, 2)}
+                                      </div>
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "tool_result") {
                                 return (
-                                  <div key={msg.id} style={{ maxWidth: "100%", overflowX: "auto" }}>
-                                    <ToolResult result={msg.result} />
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      borderLeft: "3px solid #22c55e",
+                                      paddingLeft: "0.5rem",
+                                      maxWidth: "85%"
+                                    }}>
+                                      <ToolResult result={msg.result} />
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(99,102,241,0.2)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(99,102,241,0.15)",
+                                      border: "1px solid rgba(99,102,241,0.3)",
+                                      padding: "0.6rem 0.75rem",
+                                      borderRadius: "12px 12px 12px 4px",
+                                      maxWidth: "70%",
+                                      fontSize: "0.9rem"
+                                    }}>
+                                      {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "error") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(239,68,68,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(239,68,68,0.15)",
+                                      border: "1px solid rgba(239,68,68,0.4)",
+                                      padding: "0.6rem",
+                                      borderRadius: "8px",
+                                      color: "#fca5a5",
+                                      maxWidth: "70%"
+                                    }}>
+                                      ❌ {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
@@ -1074,24 +1153,34 @@ export default function MCPInspector() {
                           <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
                             <input
                               value={chatInput}
+                              disabled={chatLoading}
                               onChange={(e) => setChatInput(e.target.value)}
                               placeholder="Ask something..."
-                              onKeyDown={(e) => { if (e.key === "Enter") runChatTool(); }}
+                              onKeyDown={(e) => { 
+                                if (e.key === "Enter" && !e.shiftKey && chatInput.trim()) {
+                                  e.preventDefault(); 
+                                  runChatTool();
+                                } 
+                              }}
                               style={{
                                 flex: 1, minWidth: 0, padding: "0.5rem",
                                 borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
-                                background: "#09090b", color: "#fff",
+                                background: "#09090b", color: "#fff", opacity: chatLoading ? 0.6 : 1,
                               }}
                             />
                             <button
-                              onClick={runChatTool}
-                              disabled={chatLoading}
+                              onClick={()=>{
+                                if (chatInput.trim()) runChatTool();
+                              }}
+                              disabled={chatLoading || !chatInput.trim()}
                               style={{
                                 padding: "0.5rem 0.75rem", borderRadius: "0.35rem",
                                 background: "#fff", color: "#000", fontWeight: "600", flexShrink: 0,
+                                opacity: chatLoading || !chatInput.trim() ? 0.6 : 1,
+                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer"
                               }}
                             >
-                              {chatLoading ? "..." : "Send"}
+                              {chatLoading ? "Thinking..." : "Send"}
                             </button>
                           </div>
                         </>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -911,7 +911,7 @@ export default function MCPInspector() {
             <Panel 
               defaultSize={100 - panelSizes.left} 
               minSize={50}
-              style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+              style={{ overflow: "hidden", display: "flex", flexDirection: "column", minHeight: 0 }}
             >
               <div
                 style={{
@@ -924,6 +924,7 @@ export default function MCPInspector() {
                   display: "flex",
                   flexDirection: "column",
                   overflow: "hidden",
+                  minHeight: 0,
                 }}
               >
                 <h2 style={{ fontSize: "1.1rem", fontWeight: "600", flexShrink: 0 }}>
@@ -959,7 +960,7 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, overflow: "auto", marginTop: "1rem" }}>
+                <div style={{ flex: 1, overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
                     <div>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
@@ -996,7 +997,7 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "300px" }}>
+                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "0", overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
                           {/* Chat History */}
@@ -1004,18 +1005,21 @@ export default function MCPInspector() {
                             ref={chatRef}
                             style={{
                               flex: 1,
-                              overflow: "auto",
+                              minHeight: 0,        
+                              overflowY: "auto",
+                              overflowX: "hidden",
                               marginBottom: "1rem",
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
+                              paddingRight: "4px"
                             }}
                           >
                             {chatHistory.map((msg) => {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px" }}>
+                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px", maxWidth: "75%", wordBreak: "break-word" }}>
                                     {msg.content}
                                   </div>
                                 )
@@ -1040,7 +1044,7 @@ export default function MCPInspector() {
 
                               if (msg.type === "tool_result") {
                                 return (
-                                  <div key={msg.id}>
+                                  <div key={msg.id} style={{ maxWidth: "100%", overflowX: "auto" }}>
                                     <ToolResult result={msg.result} />
                                   </div>
                                 )


### PR DESCRIPTION
## Summary
- Improved agent response formatting and thinking display
- Chat now resets automatically when a new server is selected
- When a new server is added, the current server gets disconnected (clean state management)
- General UI polish and small improvements to the chat experience

## Changes
- `fluidmcp/frontend/src/pages/MCPInspector.tsx` — chat UI improvements, reset on server change, disconnect on new server add
- `fluidmcp/frontend/src/services/api.ts` — related API service updates

## Notes
- Based on `mcp-jam-phase2-chat-basic` (#544) which contains basic chat + agent tool execution
- Final PR in the MCP JAM Phase 2 series
- PR chain: `main` ← `phase1-frontend` (#451) ← `phase2-logs` (#542) ← `phase2-chat-basic` (#544) ← this PR
