### PR TITLE
MCP-441: MCP JAM Phase 3A - Inspector observability, per-server chat memory, and execution tracking

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -11,7 +11,6 @@ from loguru import logger
 
 from ..services.inspector_session import InspectorSession
 from ..auth import verify_token
-from ..services.inspector_agent import choose_tool_with_llm
 
 router = APIRouter(dependencies=[Depends(verify_token)])
 
@@ -258,6 +257,15 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
         agent_result = await choose_tool_with_llm(
             body.message, tools, chat_history=body.chat_history or []
         )
+
+        # Validate the response has the expected fields
+        tool_name = agent_result.get("tool_name")
+        available_names = {t["name"] for t in tools}
+        if not tool_name or not isinstance(tool_name, str) or tool_name not in available_names:
+            return {
+                "clarification_needed": True,
+                "message": "Could not determine which tool to run."
+            }
 
         # Validate the response has the expected fields
         tool_name = agent_result.get("tool_name")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from ..services.inspector_session import InspectorSession
 from ..auth import verify_token
+from ..services.inspector_agent import choose_tool_with_llm
 
 router = APIRouter(dependencies=[Depends(verify_token)])
 

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -267,15 +267,6 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "Could not determine which tool to run."
             }
 
-        # Validate the response has the expected fields
-        tool_name = agent_result.get("tool_name")
-        available_names = {t["name"] for t in tools}
-        if not tool_name or not isinstance(tool_name, str) or tool_name not in available_names:
-            return {
-                "clarification_needed": True,
-                "message": "Could not determine which tool to run."
-            }
-
         session.add_log(
             "chat",
             f"User: {body.message} → tool selected: {tool_name}"

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -74,8 +74,12 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-    User request:
-    {message}
+Instructions:
+1. Choose the BEST tool to fulfill the request.
+2. Extract parameters from the request.
+3. If parameters are missing:
+   - Infer reasonable defaults OR leave them empty
+   - DO NOT explain anything
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -74,8 +74,8 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-User request:
-{message}
+    User request:
+    {message}
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -82,7 +82,7 @@ User request: {message}
 Instructions:
 1. Choose the BEST tool to fulfill the request.
 2. Extract parameters from the request.
-3. If parameters are missing, infer reasonable defaults or leave them empty.
+3. If parameters are missing, infer reasonable defaults or leave them empty. DO NOT explain anything.
 
 Return ONLY JSON.
 """

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -38,7 +38,7 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list = []):
+async def choose_tool_with_llm(message: str, tools: list, chat_history: list | None = None):
     """
     Universal MCP agent powered by Groq.
 
@@ -46,6 +46,9 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
     even when GROQ_API_KEY is absent — the error surfaces only when the chat
     endpoint is actually called.
     """
+
+    if chat_history is None:
+        chat_history = []
 
     if not tools:
         raise RuntimeError("No tools available")
@@ -74,19 +77,12 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-Instructions:
-1. Choose the BEST tool to fulfill the request.
-2. Extract parameters from the request.
-3. If parameters are missing:
-   - Infer reasonable defaults OR leave them empty
-   - DO NOT explain anything
+User request: {message}
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.
 2. Extract parameters from the request.
-3. If parameters are missing:
-   - Infer reasonable defaults OR leave them empty
-   - DO NOT explain anything
+3. If parameters are missing, infer reasonable defaults or leave them empty.
 
 Return ONLY JSON.
 """

--- a/fluidmcp/frontend/src/index.css
+++ b/fluidmcp/frontend/src/index.css
@@ -353,6 +353,11 @@ button:disabled {
   to { transform: rotate(360deg); }
 }
 
+@keyframes thinking-blink {
+  0%, 80%, 100% { opacity: 0.15; }
+  40% { opacity: 1; }
+}
+
 .loading-message {
   margin-top: 1rem;
   color: #94a3b8;

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,10 +1,72 @@
 // import React from "react";
 import { useState, useEffect, useRef } from "react";
+
+// Compact collapsible result bubble for chat mode
+function ChatResultBubble({ result }: { result: unknown }) {
+  const [expanded, setExpanded] = useState(true);
+  const [viewMode, setViewMode] = useState<"formatted" | "raw">("formatted");
+  const isMcp = typeof result === "object" && result !== null &&
+    "content" in result && Array.isArray((result as any).content);
+  const isMcpArray = Array.isArray(result) && result.length > 0 &&
+    (result as any[]).every((i: any) => typeof i === "object" && i !== null && "type" in i);
+  const preview = typeof result === "object" && result !== null
+    ? `{${Object.keys(result as object).length} keys}`
+    : String(result).slice(0, 60);
+
+  const tabStyle = (active: boolean) => ({
+    padding: "0.2rem 0.5rem", borderRadius: "0.25rem", border: "none",
+    fontSize: "0.75rem", fontWeight: 500 as const, cursor: "pointer",
+    background: active ? "#fff" : "transparent",
+    color: active ? "#000" : "rgba(255,255,255,0.6)"
+  });
+
+  return (
+    <div style={{ fontSize: "0.8rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <button
+          onClick={() => setExpanded(v => !v)}
+          style={{
+            background: "none", border: "none", cursor: "pointer",
+            color: "#22c55e", fontWeight: 600, padding: "0.25rem 0",
+            fontSize: "0.8rem", display: "flex", alignItems: "center", gap: "0.3rem"
+          }}
+        >
+          {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
+        </button>
+        {expanded && (
+          <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
+            <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
+            <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+          </div>
+        )}
+      </div>
+      {expanded && (
+        <div style={{
+          maxHeight: "260px", overflowY: "auto",
+          background: "rgba(0,0,0,0.3)",
+          border: "1px solid rgba(63,63,70,0.5)",
+          borderRadius: "0.5rem",
+          padding: "0.75rem",
+          marginTop: "0.25rem"
+        }}>
+          {viewMode === "raw"
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace" }}>{JSON.stringify(result, null, 2)}</pre>
+            : (isMcp || isMcpArray)
+              ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
+              : <JsonResultView data={result} />
+          }
+        </div>
+      )}
+    </div>
+  );
+}
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
 import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
 import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
 
 // Type for server object
@@ -72,16 +134,33 @@ export default function MCPInspector() {
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
   const [chatInput, setChatInput] = useState("")
-  // const [chatHistory, setChatHistory] = useState<any[]>([])
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
+  // 3A-2: Per-server logs
+  const [logsByServer, setLogsByServer] = useState<Record<string, LogEntry[]>>({})
+  const logs = logsByServer[selectedServerId ?? ""] ?? []
+
+  // 3A-3: Per-server chat memory
+  const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
+  const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
+
+  // Helper to update chat for the currently selected server
+  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
+    if (!selectedServerId) return;
+    setChatHistoryByServer(prev => ({
+      ...prev,
+      [selectedServerId]: typeof updater === "function"
+        ? updater(prev[selectedServerId] ?? [])
+        : updater
+    }));
+  };
+
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
     left: 25,     // percentage (right auto-calculated as 100-left)
     logs: 35      // percentage of left panel height
   })
-  const [logs, setLogs] = useState<LogEntry[]>([])
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
+  const chatBottomRef = useRef<HTMLDivElement>(null);
 
   const handleConnect = async () => {
 
@@ -164,13 +243,16 @@ export default function MCPInspector() {
       setToolResult(null);
       setToolError(null);
 
-      // Clear chat and show a welcome message for the new server
-      setChatHistory([{
-        id: crypto.randomUUID(),
-        type: "assistant",
-        content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
-        timestamp: Date.now(),
-      }]);
+      // Set welcome message for this server (preserve other servers' histories)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [{
+          id: crypto.randomUUID(),
+          type: "assistant",
+          content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+          timestamp: Date.now(),
+        }]
+      }));
 
       setAuthType("none")
       setToken("")
@@ -281,6 +363,19 @@ export default function MCPInspector() {
             : s
         )
       );
+      // Append reconnect notice to existing chat history (don't wipe it)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [
+          ...(prev[serverId] ?? []),
+          {
+            id: crypto.randomUUID(),
+            type: "assistant" as const,
+            content: `Reconnected to ${res.server_info?.name || "server"}.`,
+            timestamp: Date.now(),
+          }
+        ]
+      }));
     } catch (err: any) {
       console.error("Failed to reconnect", err);
 
@@ -301,10 +396,10 @@ export default function MCPInspector() {
 
   const handleRemove = (serverId: string) => {
     setServers((prev) => prev.filter((s) => s.id !== serverId));
-
-    if (selectedServerId === serverId) {
-      setSelectedServerId(null);
-    }
+    // Clean up per-server state
+    setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
   const runTool = async (params: any) => {
@@ -368,7 +463,7 @@ export default function MCPInspector() {
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
 
-  setChatHistory(prev => [...prev, userMsg])
+  updateChat(prev => [...prev, userMsg])
 
   try {
     setChatLoading(true)
@@ -381,14 +476,14 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, thinkingMsg])
+    updateChat(prev => [...prev, thinkingMsg])
 
     // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
         message,
-        chat_history: nextHistory.slice(-8).map(m => ({
+        chat_history: nextHistory.slice(-8).map((m: ChatMessage) => ({
           type: m.type,
           content: m.content
         }))
@@ -396,7 +491,7 @@ export default function MCPInspector() {
     )
 
     // Remove thinking message
-    setChatHistory(prev => prev.filter(m => m.id !== thinkingMsg.id))
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
@@ -406,7 +501,7 @@ export default function MCPInspector() {
         timestamp: Date.now()
       }
 
-      setChatHistory(prev => [...prev, assistantMsg])
+      updateChat(prev => [...prev, assistantMsg])
       return
     }
 
@@ -419,7 +514,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, toolCallMsg])
+    updateChat(prev => [...prev, toolCallMsg])
 
     // Execute tool
     const result = await apiClient.runInspectorTool(
@@ -435,7 +530,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, resultMsg])
+    updateChat(prev => [...prev, resultMsg])
 
   } catch (err: any) {
 
@@ -446,7 +541,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, errorMsg])
+    updateChat(prev => [...prev, errorMsg])
   } finally {
     setChatLoading(false)
   }
@@ -507,18 +602,19 @@ export default function MCPInspector() {
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
+  // Uses rAF so scroll runs after the DOM (including dynamic result content) has painted
   useEffect(() => {
-    if (chatRef.current) {
-      chatRef.current.scrollTop = chatRef.current.scrollHeight;
-    }
-  }, [chatHistory]);
+    requestAnimationFrame(() => {
+      chatBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  }, [chatHistoryByServer, selectedServerId]);
 
-  // Fetch logs from the server
+  // Fetch logs from the server (3A-2: stored per-server)
   const fetchLogs = async () => {
-    if (!selectedServer?.session_id) return;
+    if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogs(res.logs || []);
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -526,21 +622,9 @@ export default function MCPInspector() {
 
   // Poll for logs every 2 seconds when a session is active
   useEffect(() => {
-    if (!selectedServer?.session_id) {
-      return;
-    }
-    // NOTE FOR REVIEW: When a new server connects, its logs replace the previous server's logs.
-    // Decision needed: Should we accumulate logs across all servers (keyed by session_id)?
-    // Or is replacing on new connection acceptable?
-    // Options:
-    //   A) Current behaviour — replace logs on new connection (simple, clean)
-    //   B) Accumulate all logs — merge new logs into existing, tag each entry with server name
-    //   C) Per-server log history — store logs[serverId] map, show logs for selected server
-    // Leaning towards C if inspector gets heavy usage, but A is fine for now.
-    fetchLogs();     // Fetch immediately
-
-    const interval = setInterval(fetchLogs, 2000);     // Set up polling interval
-
+    if (!selectedServer?.session_id) return;
+    fetchLogs();
+    const interval = setInterval(fetchLogs, 2000);
     return () => clearInterval(interval);
   }, [selectedServer?.session_id]);
 
@@ -711,15 +795,7 @@ export default function MCPInspector() {
                                 setSelectedTool(null);
                                 setToolResult(null);
                                 setToolError(null);
-                                // Reset chat
-                                setChatHistory([
-                                  {
-                                    id: crypto.randomUUID(),
-                                    type: "assistant",
-                                    content: `Switched to ${server?.server_info?.name || "server"}. Chat cleared.`,
-                                    timestamp: Date.now()
-                                  }
-                                ]);
+                                // 3A-3: preserve chat history on switch (no reset)
                                 
                               }}
                               style={{
@@ -948,14 +1024,24 @@ export default function MCPInspector() {
                     }}
                   >
                     {/* Logs header */}
-                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
-                      <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
-                        LOGS
-                      </span>
-                      {logs.length > 0 && (
-                        <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
-                          {logs.length} entries
+                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                      <div>
+                        <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
+                          LOGS
                         </span>
+                        {logs.length > 0 && (
+                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
+                            {logs.length} entries
+                          </span>
+                        )}
+                      </div>
+                      {logs.length > 0 && selectedServerId && (
+                        <button
+                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                        >
+                          Clear
+                        </button>
                       )}
                     </div>
 
@@ -1087,7 +1173,7 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
+                <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
                     <div>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
@@ -1124,21 +1210,19 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "0", overflow: "hidden" }}>
+                    <div style={{ display: "grid", gridTemplateRows: "1fr auto", flex: 1, minHeight: 0, overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
-                          {/* Chat History */}
+                          {/* Chat History — grid row 1 (1fr = all remaining space) */}
                           <div
                             ref={chatRef}
                             style={{
-                              flex: 1,
-                              minHeight: 0,        
                               overflowY: "auto",
-                              marginBottom: "1rem",
+                              minHeight: 0,
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
-                              padding: "0.5rem 0.5rem 0.5rem 0.25rem"
+                              padding: "0.5rem 0.5rem 0.75rem 0.25rem"
                             }}
                           >
                             {chatHistory.map((msg) => {
@@ -1211,10 +1295,10 @@ export default function MCPInspector() {
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
                                     <div style={{
                                       borderLeft: "3px solid #22c55e",
-                                      paddingLeft: "0.5rem",
+                                      paddingLeft: "0.6rem",
                                       maxWidth: "85%"
                                     }}>
-                                      <ToolResult result={msg.result} />
+                                      <ChatResultBubble result={msg.result} />
                                     </div>
                                   </div>
                                 )
@@ -1256,10 +1340,22 @@ export default function MCPInspector() {
 
                               return null
                             })}
+                            <div ref={chatBottomRef} />
                           </div>
 
-                          {/* Chat Input */}
-                          <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
+                          {/* Chat Input — grid row 2 (auto height, always at bottom) */}
+                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem" }}>
+                          {chatHistory.length > 1 && selectedServerId && (
+                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                              <button
+                                onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                                style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                              >
+                                Clear Chat
+                              </button>
+                            </div>
+                          )}
+                          <div style={{ display: "flex", gap: "0.5rem" }}>
                             <input
                               value={chatInput}
                               disabled={chatLoading}
@@ -1291,6 +1387,7 @@ export default function MCPInspector() {
                             >
                               {chatLoading ? "Thinking..." : "Send"}
                             </button>
+                          </div>
                           </div>
                         </>
                       ) : (

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -645,9 +645,9 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
-  // Auto-scroll logs to bottom when new entries arrive
+  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
   useEffect(() => {
-    logsRef.current?.scrollTo({ top: logsRef.current.scrollHeight });
+    logsRef.current?.scrollTo({ top: 0 });
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
@@ -1123,11 +1123,12 @@ export default function MCPInspector() {
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log, i) => {
+                          {[...logs].reverse().map((log) => {
                             const color = logColors[log.type] || "#9ca3af";
+                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
                             return (
                               <div
-                                key={i}
+                                key={logKey}
                                 style={{
                                   display: "grid",
                                   // Fixed columns: time | type | message

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -96,12 +96,22 @@ interface LogEntry {
 
 type ChatMessage = {
   id: string
+  runId?: string       // groups thinking + tool_call + tool_result for one agent turn
   type: "user" | "thinking" | "tool_call" | "tool_result" | "assistant" | "error"
   content?: string
   toolName?: string
   params?: any
   result?: any
   timestamp: number
+  perfMark?: number    // high-res mark for duration math (performance.now())
+}
+
+type ExecutionRun = {
+  runId: string
+  serverId: string
+  startTime: number    // Date.now() — wall time
+  endTime?: number     // set on completion or error
+  steps: ChatMessage[] // thinking + tool_call + tool_result in order
 }
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
@@ -129,7 +139,9 @@ export default function MCPInspector() {
   const [toolError, setToolError] = useState<string | null>(null)
   const [executing, setExecuting] = useState(false)
   const [executionTime, setExecutionTime] = useState<number | null>(null)
-  const [executionHistory, setExecutionHistory] = useState<any[]>([])
+  // 3A-4: typed per-server execution history
+  const [executionHistoryByServer, setExecutionHistoryByServer] = useState<Record<string, ExecutionRun[]>>({})
+  const executionHistory = executionHistoryByServer[selectedServerId ?? ""] ?? []
 
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
@@ -399,6 +411,7 @@ export default function MCPInspector() {
     // Clean up per-server state
     setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setExecutionHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
@@ -421,16 +434,20 @@ export default function MCPInspector() {
 
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
-      setExecutionHistory((prev) => [
-        {
-          id: Date.now(),
-          tool: selectedTool,
-          params,
-          result: res,
-          time: new Date().toLocaleTimeString(),
-        },
-        ...prev,
-      ]);
+      if (selectedServerId) {
+        const runId = crypto.randomUUID();
+        const run: ExecutionRun = {
+          runId,
+          serverId: selectedServerId,
+          startTime: Date.now() - Math.round(end - start),
+          endTime: Date.now(),
+          steps: [
+            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+          ]
+        };
+        setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
+      }
     } catch (err: any) {
       console.error(err);
       setToolError(err?.message || "Tool execution failed");
@@ -447,7 +464,7 @@ export default function MCPInspector() {
 
  const runChatTool = async () => {
   // Guard against concurrent requests
-  if (!chatInput || !selectedServer?.session_id || chatLoading) return
+  if (!chatInput || !selectedServer?.session_id || chatLoading || !selectedServerId) return
 
   const message = chatInput
   setChatInput("")
@@ -456,7 +473,8 @@ export default function MCPInspector() {
     id: generateId(),
     type: "user",
     content: message,
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    perfMark: performance.now()
   }
 
   // Capture history with userMsg before any state updates — used below to
@@ -465,20 +483,27 @@ export default function MCPInspector() {
 
   updateChat(prev => [...prev, userMsg])
 
+  // 3A-4: start an ExecutionRun for this agent turn
+  const runId = crypto.randomUUID()
+  const runStartTime = Date.now()
+  const runSteps: ChatMessage[] = []
+  const capturedServerId = selectedServerId
+
   try {
     setChatLoading(true)
 
-    // Show thinking
     const thinkingMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "thinking",
       content: "Deciding which tool to use...",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, thinkingMsg])
+    runSteps.push(thinkingMsg)
 
-    // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
@@ -490,33 +515,39 @@ export default function MCPInspector() {
       }
     )
 
-    // Remove thinking message
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
-        id: generateId(),
+        id: crypto.randomUUID(),
+        runId,
         type: "assistant",
         content: res.message,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        perfMark: performance.now()
       }
-
       updateChat(prev => [...prev, assistantMsg])
+      // save run (no tool call — just clarification)
+      setExecutionHistoryByServer(prev => ({
+        ...prev,
+        [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+      }))
       return
     }
 
-    // Tool call message
     const toolCallMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "tool_call",
       toolName: res.tool_name,
       params: res.params,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, toolCallMsg])
+    runSteps.push(toolCallMsg)
 
-    // Execute tool
     const result = await apiClient.runInspectorTool(
       selectedServer.session_id,
       res.tool_name,
@@ -524,24 +555,42 @@ export default function MCPInspector() {
     )
 
     const resultMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "tool_result",
       result,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, resultMsg])
+    runSteps.push(resultMsg)
+
+    // save completed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
 
   } catch (err: any) {
 
     const errorMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "error",
       content: err?.message || "Chat error",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, errorMsg])
+    runSteps.push(errorMsg)
+
+    // save failed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
   } finally {
     setChatLoading(false)
   }
@@ -949,7 +998,7 @@ export default function MCPInspector() {
                       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
                         <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
                         <button
-                          onClick={() => setExecutionHistory([])}
+                          onClick={() => selectedServerId && setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
                           style={{
                             fontSize: "0.7rem", padding: "0.2rem 0.5rem",
                             borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
@@ -966,26 +1015,34 @@ export default function MCPInspector() {
                           maxHeight: "160px", overflowY: "auto",
                         }}
                       >
-                        {executionHistory.map((item) => (
-                          <div
-                            key={item.id}
-                            onClick={() => {
-                              setToolResult(item.result);
-                              setSelectedTool(item.tool);
-                              setToolError(null);
-                            }}
-                            style={{
-                              padding: "0.4rem 0.5rem",
-                              borderRadius: "0.35rem",
-                              border: "1px solid rgba(63,63,70,0.6)",
-                              cursor: "pointer",
-                              background: "rgba(255,255,255,0.04)",
-                            }}
-                          >
-                            <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{item.tool.name}</div>
-                            <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>{item.time}</div>
-                          </div>
-                        ))}
+                        {executionHistory.map((item: ExecutionRun) => {
+                          const toolCall = item.steps.find(s => s.type === "tool_call");
+                          const toolResult = item.steps.find(s => s.type === "tool_result");
+                          const duration = item.endTime ? item.endTime - item.startTime : null;
+                          return (
+                            <div
+                              key={item.runId}
+                              onClick={() => {
+                                if (toolResult) setToolResult(toolResult.result);
+                                if (toolCall?.toolName) setSelectedTool(selectedServer?.tools.find((t: any) => t.name === toolCall.toolName) || null);
+                                setToolError(null);
+                              }}
+                              style={{
+                                padding: "0.4rem 0.5rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                cursor: "pointer",
+                                background: "rgba(255,255,255,0.04)",
+                              }}
+                            >
+                              <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{toolCall?.toolName || "run"}</div>
+                              <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+                                {new Date(item.startTime).toLocaleTimeString()}
+                                {duration !== null && <span style={{ marginLeft: "0.4rem", color: "rgba(99,102,241,0.8)" }}>{duration}ms</span>}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -645,9 +645,9 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
-  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
+  // Auto-scroll logs to bottom when new entries arrive
   useEffect(() => {
-    logsRef.current?.scrollTo({ top: 0 });
+    logsRef.current?.scrollTo({ top: logsRef.current.scrollHeight });
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
@@ -1123,12 +1123,11 @@ export default function MCPInspector() {
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log) => {
+                          {[...logs].reverse().map((log, i) => {
                             const color = logColors[log.type] || "#9ca3af";
-                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
                             return (
                               <div
-                                key={logKey}
+                                key={i}
                                 style={{
                                   display: "grid",
                                   // Fixed columns: time | type | message

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -221,6 +221,7 @@ function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: Executi
     </div>
   );
 }
+
 // Type for server object
 interface MCPServer {
   id: string;
@@ -533,6 +534,8 @@ export default function MCPInspector() {
             : s
         )
       );
+      // Reset log offset so new logs from the restarted server aren't hidden
+      logsClearedOffsetRef.current[serverId] = 0;
       // Append reconnect notice to existing chat history (don't wipe it)
       setChatHistoryByServer(prev => ({
         ...prev,

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,5 +1,12 @@
-// import React from "react";
 import { useState, useEffect, useRef } from "react";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { apiClient } from "@/services/api";
+import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
+import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
+import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 
 // Compact collapsible result bubble for chat mode
 function ChatResultBubble({ result }: { result: unknown }) {
@@ -60,15 +67,160 @@ function ChatResultBubble({ result }: { result: unknown }) {
     </div>
   );
 }
-import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
-import { apiClient } from "@/services/api";
-import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
-import { ToolResult } from '../components/result/ToolResult';
-import { JsonResultView } from '../components/result/JsonResultView';
-import { McpContentView } from '../components/result/McpContentView';
-import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
+// ── Animated thinking indicator ──────────────────────────────────────────────
+function ThinkingDots() {
+  return (
+    <span style={{ display: "inline-flex", gap: "3px", alignItems: "center", marginLeft: "4px" }}>
+      {[0, 1, 2].map(i => (
+        <span key={i} style={{
+          width: "4px", height: "4px", borderRadius: "50%",
+          background: "rgba(255,255,255,0.55)", display: "inline-block",
+          animation: `thinking-blink 1.4s infinite ${i * 0.2}s`,
+        }} />
+      ))}
+    </span>
+  );
+}
 
+// ── Group flat chat messages into standalone + run blocks ─────────────────────
+type DisplayGroup =
+  | { kind: "standalone"; msg: ChatMessage }
+  | { kind: "run"; runId: string; steps: ChatMessage[]; run?: ExecutionRun }
+
+function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): DisplayGroup[] {
+  const runMap = new Map(execHistory.map(r => [r.runId, r]));
+  const seen = new Set<string>();
+  return messages.reduce<DisplayGroup[]>((acc, msg) => {
+    if (!msg.runId) {
+      acc.push({ kind: "standalone", msg });
+    } else if (!seen.has(msg.runId)) {
+      seen.add(msg.runId);
+      acc.push({
+        kind: "run",
+        runId: msg.runId,
+        steps: messages.filter(m => m.runId === msg.runId),
+        run: runMap.get(msg.runId),
+      });
+    }
+    return acc;
+  }, []);
+}
+
+// ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
+function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const thinking  = steps.find(s => s.type === "thinking");
+  const toolCall  = steps.find(s => s.type === "tool_call");
+  const toolResult = steps.find(s => s.type === "tool_result");
+  const errorStep = steps.find(s => s.type === "error");
+  const isActive  = !toolResult && !errorStep; // run still in progress
+
+  const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
+  const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
+    ? Math.round(toolCall.perfMark - thinking.perfMark) : null;
+  const toolMs     = (toolResult?.perfMark && toolCall?.perfMark)
+    ? Math.round(toolResult.perfMark - toolCall.perfMark) : null;
+
+  const dot = (color: string) => (
+    <div style={{ width: "7px", height: "7px", borderRadius: "50%", background: color, marginTop: "4px", flexShrink: 0 }} />
+  );
+
+  return (
+    <div style={{ maxWidth: "90%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px", overflow: "hidden" }}>
+      {/* Header */}
+      <div
+        onClick={() => setCollapsed(v => !v)}
+        style={{
+          display: "flex", alignItems: "center", gap: "0.5rem",
+          padding: "0.45rem 0.75rem",
+          background: "rgba(255,255,255,0.04)", cursor: "pointer",
+          borderBottom: collapsed ? "none" : "1px solid rgba(63,63,70,0.25)",
+        }}
+      >
+        <span style={{ fontSize: "0.7rem", opacity: 0.45 }}>{collapsed ? "▶" : "▼"}</span>
+        <span style={{ fontSize: "0.8rem", fontWeight: 600 }}>
+          {toolCall ? `🔧 ${toolCall.toolName}` : errorStep ? "❌ Error" : "🤖 Thinking"}
+        </span>
+        {isActive && <ThinkingDots />}
+        {totalMs !== null && (
+          <span style={{ marginLeft: "auto", fontSize: "0.7rem", color: "rgba(99,102,241,0.7)", fontFamily: "monospace" }}>
+            {totalMs}ms
+          </span>
+        )}
+      </div>
+
+      {!collapsed && (
+        <div style={{ padding: "0.6rem 0.75rem", display: "flex", flexDirection: "column", gap: "0.55rem" }}>
+          {/* Thinking step */}
+          {thinking && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#3b82f6")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#60a5fa", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Thinking
+                  {thinkingMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{thinkingMs}ms</span>}
+                  {isActive && <ThinkingDots />}
+                </div>
+                <div style={{ fontSize: "0.73rem", opacity: 0.6, fontStyle: "italic", marginTop: "0.15rem" }}>
+                  {thinking.content}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Tool call step */}
+          {toolCall && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#f59e0b")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fbbf24", fontWeight: 600 }}>
+                  Tool: {toolCall.toolName}
+                </div>
+                <pre style={{
+                  margin: "0.2rem 0 0", padding: "0.35rem 0.5rem",
+                  background: "rgba(0,0,0,0.3)", borderRadius: "6px",
+                  fontSize: "0.7rem", overflowX: "auto", whiteSpace: "pre-wrap",
+                  wordBreak: "break-all", color: "#e5e7eb", fontFamily: "ui-monospace,monospace",
+                }}>
+                  {JSON.stringify(toolCall.params, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          {/* Result step */}
+          {toolResult && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#22c55e")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#4ade80", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Result
+                  {toolMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{toolMs}ms</span>}
+                </div>
+                <div style={{ marginTop: "0.2rem" }}>
+                  <ChatResultBubble result={toolResult.result} />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Error step */}
+          {errorStep && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#ef4444")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fca5a5", fontWeight: 600 }}>Error</div>
+                <div style={{ fontSize: "0.73rem", color: "#fca5a5", marginTop: "0.15rem" }}>
+                  {errorStep.content}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 // Type for server object
 interface MCPServer {
   id: string;
@@ -154,13 +306,17 @@ export default function MCPInspector() {
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
   const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
 
-  // Helper to update chat for the currently selected server
-  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
-    if (!selectedServerId) return;
+  // Helper to update chat — accepts explicit serverId so async flows
+  // (runChatTool) stay pinned to the originating server even if the user
+  // switches selection while the request is in-flight.
+  const updateChat = (
+    serverId: string,
+    updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])
+  ) => {
     setChatHistoryByServer(prev => ({
       ...prev,
-      [selectedServerId]: typeof updater === "function"
-        ? updater(prev[selectedServerId] ?? [])
+      [serverId]: typeof updater === "function"
+        ? updater(prev[serverId] ?? [])
         : updater
     }));
   };
@@ -173,6 +329,8 @@ export default function MCPInspector() {
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const chatBottomRef = useRef<HTMLDivElement>(null);
+  // Tracks how many backend log entries existed when the user last cleared, per server
+  const logsClearedOffsetRef = useRef<Record<string, number>>({});
 
   const handleConnect = async () => {
 
@@ -259,7 +417,7 @@ export default function MCPInspector() {
       setChatHistoryByServer(prev => ({
         ...prev,
         [serverId]: [{
-          id: crypto.randomUUID(),
+          id: generateId(),
           type: "assistant",
           content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
           timestamp: Date.now(),
@@ -381,7 +539,7 @@ export default function MCPInspector() {
         [serverId]: [
           ...(prev[serverId] ?? []),
           {
-            id: crypto.randomUUID(),
+            id: generateId(),
             type: "assistant" as const,
             content: `Reconnected to ${res.server_info?.name || "server"}.`,
             timestamp: Date.now(),
@@ -415,6 +573,12 @@ export default function MCPInspector() {
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
+  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
+  const generateId = () =>
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+
   const runTool = async (params: any) => {
     if (!selectedServer?.session_id || !selectedTool || executing) return;
 
@@ -435,15 +599,15 @@ export default function MCPInspector() {
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
       if (selectedServerId) {
-        const runId = crypto.randomUUID();
+        const runId = generateId();
         const run: ExecutionRun = {
           runId,
           serverId: selectedServerId,
           startTime: Date.now() - Math.round(end - start),
           endTime: Date.now(),
           steps: [
-            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
-            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+            { id: generateId(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: generateId(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
           ]
         };
         setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
@@ -455,12 +619,6 @@ export default function MCPInspector() {
       setExecuting(false);
     }
   };
-
-  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
-  const generateId = () =>
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
  const runChatTool = async () => {
   // Guard against concurrent requests
@@ -480,20 +638,20 @@ export default function MCPInspector() {
   // Capture history with userMsg before any state updates — used below to
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
+  const capturedServerId = selectedServerId
 
-  updateChat(prev => [...prev, userMsg])
+  updateChat(capturedServerId, prev => [...prev, userMsg])
 
   // 3A-4: start an ExecutionRun for this agent turn
-  const runId = crypto.randomUUID()
+  const runId = generateId()
   const runStartTime = Date.now()
   const runSteps: ChatMessage[] = []
-  const capturedServerId = selectedServerId
 
   try {
     setChatLoading(true)
 
     const thinkingMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "thinking",
       content: "Deciding which tool to use...",
@@ -501,7 +659,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, thinkingMsg])
+    updateChat(capturedServerId, prev => [...prev, thinkingMsg])
     runSteps.push(thinkingMsg)
 
     const res = await apiClient.chatWithInspector(
@@ -515,18 +673,18 @@ export default function MCPInspector() {
       }
     )
 
-    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+    updateChat(capturedServerId, prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         runId,
         type: "assistant",
         content: res.message,
         timestamp: Date.now(),
         perfMark: performance.now()
       }
-      updateChat(prev => [...prev, assistantMsg])
+      updateChat(capturedServerId, prev => [...prev, assistantMsg])
       // save run (no tool call — just clarification)
       setExecutionHistoryByServer(prev => ({
         ...prev,
@@ -536,7 +694,7 @@ export default function MCPInspector() {
     }
 
     const toolCallMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "tool_call",
       toolName: res.tool_name,
@@ -545,7 +703,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, toolCallMsg])
+    updateChat(capturedServerId, prev => [...prev, toolCallMsg])
     runSteps.push(toolCallMsg)
 
     const result = await apiClient.runInspectorTool(
@@ -555,7 +713,7 @@ export default function MCPInspector() {
     )
 
     const resultMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "tool_result",
       result,
@@ -563,7 +721,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, resultMsg])
+    updateChat(capturedServerId, prev => [...prev, resultMsg])
     runSteps.push(resultMsg)
 
     // save completed run
@@ -575,7 +733,7 @@ export default function MCPInspector() {
   } catch (err: any) {
 
     const errorMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "error",
       content: err?.message || "Chat error",
@@ -583,7 +741,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, errorMsg])
+    updateChat(capturedServerId, prev => [...prev, errorMsg])
     runSteps.push(errorMsg)
 
     // save failed run
@@ -626,9 +784,13 @@ export default function MCPInspector() {
     if (savedSelectedId) setSelectedServerId(savedSelectedId)
   }, [])
 
-  // Persist servers list whenever it changes
+  // Persist servers list — strip auth secrets (tokens/header values) before writing
   useEffect(() => {
-    sessionStorage.setItem('inspector-servers', JSON.stringify(servers))
+    const safeServers = servers.map(s => ({
+      ...s,
+      auth: s.auth ? { type: s.auth.type } : undefined,
+    }));
+    sessionStorage.setItem('inspector-servers', JSON.stringify(safeServers))
   }, [servers])
 
   // Persist selected server ID whenever it changes
@@ -663,7 +825,9 @@ export default function MCPInspector() {
     if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
+      const allLogs: LogEntry[] = res.logs || [];
+      const offset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: allLogs.slice(offset) }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -1094,7 +1258,11 @@ export default function MCPInspector() {
                       </div>
                       {logs.length > 0 && selectedServerId && (
                         <button
-                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          onClick={() => {
+                            const currentTotal = (logsClearedOffsetRef.current[selectedServerId] ?? 0) + logs.length;
+                            logsClearedOffsetRef.current[selectedServerId] = currentTotal;
+                            setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
+                          }}
                           style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
                         >
                           Clear


### PR DESCRIPTION
## Summary
- Per-server logs, chat history, and execution history — switching servers no longer clobbers state
- Typed \`ExecutionRun\` store with per-step timing for each agent turn
- \`ChatResultBubble\` component: collapsible formatted/raw view for tool results in chat mode
- Fix: cleared logs reappearing after poll cycle

## Changes
- \`fluidmcp/frontend/src/pages/MCPInspector.tsx\` — per-server state stores, execution run tracking, chat result bubble

## Test plan
- [ ] Connect to two servers, switch between them — logs and chat history should be independent
- [ ] Run a chat tool call and verify execution run is recorded with timing
- [ ] Chat with a tool and expand/collapse the result bubble in chat mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)