### PR TITLE
MCP-453: Add onboarding tutorials and architecture diagrams for fmcp serve MongoDB workflow

### DIFF
--- a/onboarding-tutorials/code-flow/fmcp-serve/architecture-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/architecture-diagram.md
@@ -305,6 +305,8 @@ The CLI entry point is `fluidmcp/cli/cli.py`. The `serve` subparser (registered 
 
 `create_app()` constructs the FastAPI application and attaches all middleware and routers. Two security-oriented middleware layers are applied to every request before route handlers execute: `CORSMiddleware` enforces origin policy, and `limit_request_size` rejects bodies exceeding the configured size limit (default 10 MB, set via `MAX_REQUEST_SIZE_MB`). The `/health` endpoint is intentionally public and un-instrumented to avoid metric pollution from load-balancer probes.
 
+> **Security note:** `limit_request_size` only enforces the body-size limit when a `Content-Length` header is present. Requests that use chunked transfer encoding (no `Content-Length`) bypass this check. For production deployments, configure a server-level limit in addition: Uvicorn `--limit-max-requests`, Nginx `client_max_body_size`, or an equivalent CDN/proxy setting.
+
 ### Auth (Cross-cutting)
 
 `auth.py · verify_token()` is a FastAPI dependency injected with `Depends()`. It is stateless and reads two environment variables at call-time: `FMCP_SECURE_MODE` and `FMCP_BEARER_TOKEN`. When secure mode is off, it is a no-op. When on, it delegates to `_validate_bearer_token()` which performs a constant-time comparison (`secrets.compare_digest`) to prevent timing attacks.

--- a/onboarding-tutorials/code-flow/fmcp-serve/architecture-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/architecture-diagram.md
@@ -1,0 +1,376 @@
+# fmcp serve — Architecture Diagram
+
+> Standalone FluidMCP backend: CLI dispatches to an async FastAPI gateway that manages MCP server subprocesses and LLM models through layered routers, authenticated via bearer token, and persisted to MongoDB or in-memory storage.
+
+## System Architecture
+
+`fmcp serve` starts an always-on FastAPI server that exposes a management REST API for dynamically adding, starting, stopping, and proxying MCP server subprocesses. Persistence is provided by either a Motor-async MongoDB client or a purely in-memory backend, selected at startup.
+
+```
+┌── LAYER 1: ENTRY / CLI ──────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│   ┌─────────────────────────────────────────┐                                                │
+│   │  fmcp serve  (user invocation)          │                                                │
+│   │  cli/cli.py · serve_parser (argparse)   │                                                │
+│   │  Flags: --secure --port --mongodb-uri   │                                                │
+│   │         --in-memory --require-persist.. │                                                │
+│   └──────────────────┬──────────────────────┘                                                │
+│                      │ asyncio.run()                                                          │
+│                      ▼                                                                        │
+│   ┌─────────────────────────────────────────┐                                                │
+│   │  server.py · main(args)                 │                                                │
+│   │  1. Choose persistence backend          │                                                │
+│   │  2. Create ServerManager                │                                                │
+│   │  3. Start background tasks              │                                                │
+│   │  4. Call create_app()                   │                                                │
+│   │  5. Load models from persistence        │                                                │
+│   │  6. Run uvicorn Server                  │                                                │
+│   └─────────────────────────────────────────┘                                                │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │ await create_app(db_manager, server_manager, ...)
+        ▼
+┌── LAYER 2: FASTAPI APP ──────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│   ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│   │  server.py · create_app()  →  FastAPI(title="FluidMCP Gateway", version="2.0.0")   │    │
+│   │                                                                                     │    │
+│   │  Middleware stack (outermost → innermost):                                          │    │
+│   │  ┌───────────────────────────────────────────────────────────────────────────────┐ │    │
+│   │  │  CORSMiddleware  (fastapi.middleware.cors)                                     │ │    │
+│   │  │  Origins: localhost only by default; wildcard allowed via --allow-all-origins  │ │    │
+│   │  └───────────────────────────────────────────────────────────────────────────────┘ │    │
+│   │  ┌───────────────────────────────────────────────────────────────────────────────┐ │    │
+│   │  │  limit_request_size  (@app.middleware("http"))                                 │ │    │
+│   │  │  Content-Length check; default 10 MB; env MAX_REQUEST_SIZE_MB                 │ │    │
+│   │  │  Returns HTTP 413 on violation                                                 │ │    │
+│   │  └───────────────────────────────────────────────────────────────────────────────┘ │    │
+│   │                                                                                     │    │
+│   │  Built-in endpoints:                                                                │    │
+│   │  ┌──────────────┐   ┌───────────────────────────────────────┐                     │    │
+│   │  │ GET /health  │   │ GET /metrics  (auth: verify_token)     │                     │    │
+│   │  │ (public)     │   │ Prometheus text/plain v0.0.4           │                     │    │
+│   │  └──────────────┘   └───────────────────────────────────────┘                     │    │
+│   │  ┌──────────────┐                                                                  │    │
+│   │  │ GET /        │  (root info endpoint, public)                                    │    │
+│   │  └──────────────┘                                                                  │    │
+│   │                                                                                     │    │
+│   │  Lifespan (asynccontextmanager):                                                    │    │
+│   │  • startup  →  Inspector session cleanup task                                      │    │
+│   │  • shutdown →  HTTP client cleanup, Redis cleanup, DB disconnect                   │    │
+│   └─────────────────────────────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │                         │                              │
+        ▼                         ▼                              ▼
+┌── LAYER 3: AUTH (cross-cutting dependency) ──────────────────────────────────────────────────┐
+│                                                                                               │
+│   ┌─────────────────────────────────────────────────────────────────────────────────────┐    │
+│   │  auth.py · verify_token(credentials: HTTPAuthorizationCredentials)                  │    │
+│   │                                                                                     │    │
+│   │  • FastAPI Depends() injected into any protected route                              │    │
+│   │  • Reads env: FMCP_SECURE_MODE, FMCP_BEARER_TOKEN                                  │    │
+│   │  • If secure mode OFF  →  passes through (public access)                           │    │
+│   │  • If secure mode ON   →  delegates to _validate_bearer_token()                    │    │
+│   │    - scheme must be "bearer"                                                        │    │
+│   │    - secrets.compare_digest() for constant-time comparison (timing-attack safe)    │    │
+│   │    - HTTP 401 + WWW-Authenticate header on failure                                  │    │
+│   │    - HTTP 500 if FMCP_BEARER_TOKEN not configured                                  │    │
+│   │                                                                                     │    │
+│   │  Also available: get_token() — same flow but returns token string                  │    │
+│   └─────────────────────────────────────────────────────────────────────────────────────┘    │
+│                                                                                               │
+│   Applied to:  /metrics  ·  inspector_router (all routes)  ·  mgmt_router (per-route)        │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │                         │                              │
+        ▼                         ▼                              ▼
+┌── LAYER 4: ROUTERS ──────────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│  ┌─────────────────────────────────────────┐  ┌──────────────────────────────────────────┐  │
+│  │  api/management.py · mgmt_router        │  │  api/inspector.py · inspector_router      │  │
+│  │  prefix: /api   tag: management         │  │  prefix: /api   tag: inspector            │  │
+│  │                                         │  │  global dep: Depends(verify_token)        │  │
+│  │  MCP Server CRUD:                       │  │                                           │  │
+│  │   POST   /api/servers                   │  │  POST   /api/inspector/connect            │  │
+│  │   POST   /api/servers/from-github       │  │  GET    /api/inspector/{id}/tools         │  │
+│  │   GET    /api/servers                   │  │  POST   /api/inspector/{id}/tools/{name}  │  │
+│  │   GET    /api/servers/{id}              │  │         /run                              │  │
+│  │   PUT    /api/servers/{id}              │  │  DELETE /api/inspector/{id}               │  │
+│  │   DELETE /api/servers/{id}              │  └──────────────────────────────────────────┘  │
+│  │                                         │                                                 │
+│  │  Lifecycle:                             │  ┌──────────────────────────────────────────┐  │
+│  │   POST /api/servers/{id}/start          │  │  Dynamic MCP proxy router                 │  │
+│  │   POST /api/servers/{id}/stop           │  │  services/package_launcher.py             │  │
+│  │   POST /api/servers/{id}/restart        │  │  create_dynamic_router(server_manager)    │  │
+│  │   POST /api/servers/start-all           │  │                                           │  │
+│  │   POST /api/servers/stop-all            │  │  Mounted at root (no prefix)              │  │
+│  │                                         │  │  Routes: /{server_name}/mcp               │  │
+│  │  Proxy / SSE:                           │  │  Forwards JSON-RPC to running subprocess  │  │
+│  │   GET  /api/servers/{id}/sse            │  └──────────────────────────────────────────┘  │
+│  │   POST /api/servers/{id}/messages       │                                                 │
+│  │                                         │                                                 │
+│  │  Status / Logs / Env:                   │                                                 │
+│  │   GET  /api/servers/{id}/status         │                                                 │
+│  │   GET  /api/servers/{id}/logs           │                                                 │
+│  │   GET  /api/servers/{id}/tools          │                                                 │
+│  │   POST /api/servers/{id}/tools/*/run    │                                                 │
+│  │   GET/PUT/DELETE  .../instance/env      │                                                 │
+│  │                                         │                                                 │
+│  │  LLM sub-routes (within mgmt_router):   │                                                 │
+│  │   POST /api/llm/models                  │                                                 │
+│  │   GET  /api/llm/models                  │                                                 │
+│  │   GET  /api/llm/models/{id}             │                                                 │
+│  │   POST /api/llm/models/{id}/start|stop  │                                                 │
+│  │        /restart /health-check /logs     │                                                 │
+│  │   PATCH/DELETE /api/llm/models/{id}     │                                                 │
+│  │   POST /api/llm/models/{id}/rollback    │                                                 │
+│  │                                         │                                                 │
+│  │  OpenAI-compatible inference:           │                                                 │
+│  │   POST /api/llm/v1/chat/completions     │                                                 │
+│  │   POST /api/llm/v1/completions          │                                                 │
+│  │   GET  /api/llm/v1/models[/{id}]        │                                                 │
+│  │                                         │                                                 │
+│  │  Multimodal (Omni / Replicate):         │                                                 │
+│  │   POST /api/llm/v1/generate/image       │                                                 │
+│  │   POST /api/llm/v1/generate/video       │                                                 │
+│  │   POST /api/llm/v1/animate              │                                                 │
+│  │   GET  /api/llm/predictions/{id}        │                                                 │
+│  │                                         │                                                 │
+│  │  Metrics:                               │                                                 │
+│  │   GET  /api/metrics                     │                                                 │
+│  │   GET  /api/metrics/json                │                                                 │
+│  │   POST /api/metrics/reset               │                                                 │
+│  └─────────────────────────────────────────┘                                                 │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │                                          │
+        ▼                                          ▼
+┌── LAYER 5: SERVICES ─────────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│  ┌──────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  services/server_manager.py · ServerManager                                          │    │
+│  │                                                                                      │    │
+│  │  Responsibilities:                                                                   │    │
+│  │  • Process registry: Dict[server_id → subprocess.Popen]                             │    │
+│  │  • start / stop / restart individual servers (async, per-server lock)               │    │
+│  │  • shutdown_all() — graceful SIGTERM then SIGKILL fallback                          │    │
+│  │  • get_uptime(server_id)  — monotonic clock tracking                                │    │
+│  │  • start_idle_cleanup_task()  — auto-stop servers idle > FMCP_IDLE_TIMEOUT          │    │
+│  │  • _cleanup_on_exit()  — atexit handler                                             │    │
+│  │  • Delegates persistence calls to db (PersistenceBackend)                           │    │
+│  │  • Stderr captured to log files (file handles in _stderr_logs)                      │    │
+│  └──────────────────────────────────────────────────────────────────────────────────────┘    │
+│            - - ►  (background asyncio.Task)                                                   │
+│  ┌──────────────────────────────────────────────────────────────────────────────────────┐    │
+│  │  services/server_manager.py · MCPHealthMonitor                                       │    │
+│  │                                                                                      │    │
+│  │  • Wraps ServerManager                                                               │    │
+│  │  • _monitor_loop() runs every FMCP_HEALTH_CHECK_INTERVAL seconds (default 30s)      │    │
+│  │  • Detects crashed processes (poll() != None)                                        │    │
+│  │  • Exponential-backoff auto-restart (MAX_BACKOFF_EXPONENT=5, base delay 5s)         │    │
+│  │  • Tracks _restart_counts per server_id                                             │    │
+│  │  • start() / stop() control the asyncio.Task lifecycle                              │    │
+│  └──────────────────────────────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │ await db.*                               │ await db.*
+        ▼                                          ▼
+┌── LAYER 6: PERSISTENCE ──────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│  Selected at startup by --persistence-mode / --in-memory flag                                │
+│                                                                                               │
+│  ┌────────────────────────────────────────────┐  ┌────────────────────────────────────────┐  │
+│  │  repositories/database.py · DatabaseManager│  │  repositories/memory.py                │  │
+│  │  (implements PersistenceBackend)            │  │  · InMemoryBackend                     │  │
+│  │                                             │  │  (implements PersistenceBackend)       │  │
+│  │  __init__(mongodb_uri, database_name)       │  │                                        │  │
+│  │  • Motor async client (AsyncIOMotorClient)  │  │  • Pure Python dicts / deques          │  │
+│  │  • init_db() — creates indexes             │  │  • connect() → always True             │  │
+│  │  • connect_with_retry() — 3 attempts,       │  │  • disconnect() → clears all dicts     │  │
+│  │    exp backoff 2s/4s/8s (server.py)         │  │  • No network I/O                      │  │
+│  │  • disconnect() — graceful Motor close      │  │  • _servers / _instances / _logs       │  │
+│  │  • save/get/list/delete server configs      │  │    / _llm_models / _crash_events       │  │
+│  │  • log writes → LogBuffer on failure        │  │  • Data lost on process restart        │  │
+│  │  • _sanitize_mongodb_input() — strips $     │  │  • Suitable for dev / testing          │  │
+│  │    operators (injection prevention)         │  └────────────────────────────────────────┘  │
+│  └────────────────────────────────────────────┘                                               │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+        │ Motor async TCP                                   │ (no I/O)
+        ▼                                                   ▼
+┌── LAYER 7: EXTERNAL ─────────────────────────────────────────────────────────────────────────┐
+│                                                                                               │
+│  ┌────────────────────────────────────────┐   ┌──────────────────────────────────────────┐  │
+│  │  MongoDB (Motor async client)          │   │  MCP subprocesses                         │  │
+│  │  • Connection string: MONGODB_URI      │   │  (npx / python / custom command)          │  │
+│  │  • Default: mongodb://localhost:27017  │   │                                           │  │
+│  │  • Database: "fluidmcp" (configurable) │   │  • Spawned by ServerManager via           │  │
+│  │  • Collections:                        │   │    subprocess.Popen                       │  │
+│  │    - server_configs                    │   │  • Communicate via stdin/stdout (MCP      │  │
+│  │    - instances                         │   │    JSON-RPC protocol) or SSE              │  │
+│  │    - logs                              │   │  • stderr → file (~/.fluidmcp/logs/)      │  │
+│  │    - llm_models                        │   │  • Monitored by MCPHealthMonitor          │  │
+│  │    - crash_events                      │   │  • Auto-restarted on crash                │  │
+│  └────────────────────────────────────────┘   └──────────────────────────────────────────┘  │
+│                                                                                               │
+│  ┌────────────────────────────────────────┐   ┌──────────────────────────────────────────┐  │
+│  │  Replicate Cloud API                   │   │  Sentry (opt-in)                          │  │
+│  │  • HTTP polling client                 │   │  • SENTRY_DSN env var                     │  │
+│  │  • Used for: chat completions,         │   │  • FastApiIntegration + AsyncioIntegration│  │
+│  │    image/video generation, animation   │   │  • /health and /metrics excluded          │  │
+│  └────────────────────────────────────────┘   └──────────────────────────────────────────┘  │
+└──────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Request flow — example: POST /api/servers/{id}/start
+
+```
+HTTP client
+    │
+    │  POST /api/servers/{id}/start
+    │  Authorization: Bearer <token>
+    ▼
+CORSMiddleware  ───►  limit_request_size middleware
+    │
+    ▼
+mgmt_router  (api/management.py)
+    │
+    ├── Depends(verify_token)  ────►  auth.py · verify_token()
+    │       │                              │
+    │       │  FMCP_SECURE_MODE=true       │  secrets.compare_digest()
+    │       │                              │  HTTP 401 on mismatch
+    │       ▼ (pass)                       ▼ (pass / raise)
+    │
+    ├── Rate limit check  (utils/rate_limiter.py)
+    │
+    ▼
+POST /api/servers/{id}/start handler
+    │
+    ├── db_manager.get_server_config(id)   - - ►  DatabaseManager / InMemoryBackend
+    │
+    └── server_manager.start_server(id)   ───►   ServerManager
+              │
+              ├── subprocess.Popen(command, args, env)  ────►  MCP subprocess
+              │
+              └── db_manager.save_instance(...)         - - ►  DatabaseManager
+```
+
+### Startup sequence (server.py · main())
+
+```
+main(args)
+  │
+  ├─1─ Choose backend ──────────────────────────────────────────────────────────
+  │       --in-memory  →  InMemoryBackend().connect()
+  │       default      →  DatabaseManager(uri) → connect_with_retry(3 attempts)
+  │                         attempt 1 ──►  MongoDB ping
+  │                         attempt 2 (2s delay) ──►  MongoDB ping
+  │                         attempt 3 (4s delay) ──►  MongoDB ping
+  │                         failure + --require-persistence  →  RuntimeError (exit)
+  │                         failure                           →  ephemeral mode
+  │
+  ├─2─ Create ServerManager(persistence)
+  │
+  ├─3─ Start background tasks
+  │       server_manager.start_idle_cleanup_task()       - - ►  asyncio.Task (300s loop)
+  │       MCPHealthMonitor(server_manager).start()       - - ►  asyncio.Task (30s loop)
+  │
+  ├─4─ create_app(db_manager, server_manager, ...)
+  │       → registers CORSMiddleware
+  │       → registers limit_request_size middleware
+  │       → app.include_router(mgmt_router,      prefix="/api")
+  │       → app.include_router(inspector_router, prefix="/api")
+  │       → app.include_router(create_dynamic_router(server_manager))
+  │       → setup_frontend_routes(app)
+  │       → defines GET /health, GET /metrics, GET /
+  │
+  ├─5─ load_models_from_persistence(persistence)
+  │       → list_llm_models() from backend
+  │       → for each model: ReplicateClient(id, cfg).health_check()
+  │           or launch_single_llm_model(id, cfg) for vllm/ollama/lmstudio
+  │
+  ├─6─ Register signal handlers  (SIGINT, SIGTERM, SIGHUP)
+  │
+  ├─7─ uvicorn.Server(Config(app, host, port)).serve()  - - ►  asyncio.Task
+  │
+  └─8─ await shutdown_event  →  graceful teardown
+            stop MCPHealthMonitor
+            stop idle cleanup task
+            server_manager.shutdown_all() (10s timeout)
+            persistence.disconnect()
+```
+
+## Layer Breakdown
+
+### Entry / CLI Layer
+
+The CLI entry point is `fluidmcp/cli/cli.py`. The `serve` subparser (registered as `serve_parser`) validates authentication flags and then calls `asyncio.run(server_main(args))`. The `server.py · main()` function is the true async entry point: it wires together the persistence backend, `ServerManager`, background tasks, and the FastAPI app, then runs uvicorn in a background asyncio task, blocking on a `shutdown_event`.
+
+### FastAPI App Layer
+
+`create_app()` constructs the FastAPI application and attaches all middleware and routers. Two security-oriented middleware layers are applied to every request before route handlers execute: `CORSMiddleware` enforces origin policy, and `limit_request_size` rejects bodies exceeding the configured size limit (default 10 MB, set via `MAX_REQUEST_SIZE_MB`). The `/health` endpoint is intentionally public and un-instrumented to avoid metric pollution from load-balancer probes.
+
+### Auth (Cross-cutting)
+
+`auth.py · verify_token()` is a FastAPI dependency injected with `Depends()`. It is stateless and reads two environment variables at call-time: `FMCP_SECURE_MODE` and `FMCP_BEARER_TOKEN`. When secure mode is off, it is a no-op. When on, it delegates to `_validate_bearer_token()` which performs a constant-time comparison (`secrets.compare_digest`) to prevent timing attacks.
+
+### Routers Layer
+
+Three routers are registered at app creation time:
+
+- **mgmt_router** (`api/management.py`) — the primary API surface. Covers full server CRUD and lifecycle, SSE/message proxying, environment variable management, LLM model registration, OpenAI-compatible inference endpoints, and metrics endpoints.
+- **inspector_router** (`api/inspector.py`) — tool inspection sessions; router-level `Depends(verify_token)` protects all routes.
+- **Dynamic MCP proxy router** (created by `services/package_launcher.py · create_dynamic_router`) — mounted without a prefix; routes JSON-RPC calls to the correct running subprocess.
+
+### Services Layer
+
+`ServerManager` owns the subprocess lifecycle. It maintains an in-memory `processes` dict, acquires per-server async locks for concurrent safety, and surfaces `start_server / stop_server / restart_server / shutdown_all`. `MCPHealthMonitor` runs as a separate asyncio task, polling process state every 30 seconds and triggering auto-restarts with exponential backoff.
+
+### Persistence Layer
+
+Two backends implement the `PersistenceBackend` protocol:
+
+- **DatabaseManager** — Motor-async MongoDB client. Handles server configs, instance records, logs (with a `LogBuffer` for write failures), LLM model configs, and crash events. Includes MongoDB injection sanitisation.
+- **InMemoryBackend** — plain Python dicts and deques; zero network I/O; data is lost on restart; intended for development and CI.
+
+### External Dependencies
+
+- **MongoDB** — persistent store for server state and LLM model configs, accessed via the Motor async driver.
+- **MCP subprocesses** — the actual MCP server processes (e.g., `npx -y @modelcontextprotocol/server-filesystem`) spawned by `ServerManager` via `subprocess.Popen`. Communication uses stdin/stdout (JSON-RPC) or SSE.
+- **Replicate Cloud API** — HTTP polling client for cloud-based LLM and multimodal inference.
+- **Sentry** — optional error tracking, enabled via `SENTRY_DSN` env var.
+
+## Dependency Map
+
+| Component | Imports / Calls | Purpose |
+|---|---|---|
+| `cli.py` | `server.py · main()` | Dispatch `fmcp serve` to async entry point |
+| `server.py · main()` | `DatabaseManager`, `InMemoryBackend`, `ServerManager`, `MCPHealthMonitor`, `create_app()` | Orchestrate startup sequence |
+| `server.py · create_app()` | `mgmt_router`, `inspector_router`, `create_dynamic_router`, `verify_token`, `CORSMiddleware` | Build FastAPI app |
+| `auth.py · verify_token()` | `os.environ`, `secrets.compare_digest` | Stateless bearer token gate |
+| `api/management.py` | `ServerManager` (via `request.app.state`), `DatabaseManager`, `ReplicateClient`, `llm_provider_registry`, `omni_adapter`, `rate_limiter` | MCP CRUD, lifecycle, inference |
+| `api/inspector.py` | `verify_token` (router-level dep), MCP subprocess stdio | Interactive tool inspection sessions |
+| `services/server_manager.py · ServerManager` | `DatabaseManager`, `package_launcher.initialize_mcp_server`, `MetricsCollector`, `HealthChecker` | Process lifecycle and state persistence |
+| `services/server_manager.py · MCPHealthMonitor` | `ServerManager` | Background health polling and auto-restart |
+| `repositories/database.py · DatabaseManager` | `motor.motor_asyncio.AsyncIOMotorClient`, `pymongo.errors`, `repositories.base.PersistenceBackend` | Async MongoDB persistence |
+| `repositories/memory.py · InMemoryBackend` | `repositories.base.PersistenceBackend` | Ephemeral in-process persistence |
+
+## Component Summary
+
+| Component | File | Class / Function | Role |
+|---|---|---|---|
+| CLI serve dispatcher | `fluidmcp/cli/cli.py` | `serve_parser` + `args.command == "serve"` block | Parse flags, validate auth, call `asyncio.run(server_main(args))` |
+| Async entry point | `fluidmcp/cli/server.py` | `main(args)` | Orchestrate persistence, services, app, uvicorn |
+| App factory | `fluidmcp/cli/server.py` | `create_app()` | Build FastAPI app, attach middleware and routers |
+| Lifespan context | `fluidmcp/cli/server.py` | `lifespan()` | Graceful DB disconnect on shutdown |
+| Health endpoint | `fluidmcp/cli/server.py` | `GET /health` | Public status; pings MongoDB, counts models |
+| Metrics endpoint | `fluidmcp/cli/server.py` | `GET /metrics` | Prometheus text format; auth-protected |
+| CORS middleware | `fastapi.middleware.cors` | `CORSMiddleware` | Origin policy enforcement |
+| Size limit middleware | `fluidmcp/cli/server.py` | `limit_request_size` | Reject oversized request bodies (HTTP 413) |
+| Auth dependency | `fluidmcp/cli/auth.py` | `verify_token()` | Constant-time bearer token validation |
+| Auth helper | `fluidmcp/cli/auth.py` | `_validate_bearer_token()` | Inner validation logic with timing-safe compare |
+| Management router | `fluidmcp/cli/api/management.py` | `router` (mgmt_router) | Full MCP server CRUD, lifecycle, LLM, inference, metrics |
+| Inspector router | `fluidmcp/cli/api/inspector.py` | `router` (inspector_router) | Interactive MCP tool inspection sessions |
+| Dynamic proxy router | `fluidmcp/cli/services/package_launcher.py` | `create_dynamic_router()` | JSON-RPC proxy to MCP subprocesses |
+| Server lifecycle | `fluidmcp/cli/services/server_manager.py` | `ServerManager` | Subprocess registry, start/stop/restart, idle cleanup |
+| Health monitor | `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor` | Background crash detection and auto-restart |
+| MongoDB backend | `fluidmcp/cli/repositories/database.py` | `DatabaseManager` | Async Motor MongoDB persistence with injection sanitisation |
+| In-memory backend | `fluidmcp/cli/repositories/memory.py` | `InMemoryBackend` | Ephemeral dict-based persistence for dev/test |
+| Persistence interface | `fluidmcp/cli/repositories/base.py` | `PersistenceBackend` | Abstract protocol implemented by both backends |
+| MongoDB retry | `fluidmcp/cli/server.py` | `connect_with_retry()` | 3-attempt exponential-backoff connection |
+| Model loader | `fluidmcp/cli/server.py` | `load_models_from_persistence()` | Re-hydrate LLM models from DB on startup |

--- a/onboarding-tutorials/code-flow/fmcp-serve/health-check-data-flow-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/health-check-data-flow-diagram.md
@@ -1,0 +1,256 @@
+# GET /health — Data Flow Diagram
+
+> Public health check endpoint that verifies MongoDB connectivity, counts registered models, and returns a structured status JSON used by load balancers and Docker HEALTHCHECK.
+
+## Overview
+
+`GET /health` is an unauthenticated FastAPI endpoint defined in `server.py`. On every call it performs a live MongoDB `ping`, reads two in-memory registries for model counts, derives an overall status string, and returns a single JSON document. It is intentionally excluded from request-counter instrumentation to avoid metric pollution from frequent health-check probes.
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  INPUT                                                                       │
+│                                                                              │
+│   HTTP client (load balancer / Docker / curl)                                │
+│                                                                              │
+│   GET /health                                                                │
+│   No Authorization header required                                           │
+│   No request body                                                            │
+└───────────────────────────────┬─────────────────────────────────────────────┘
+                                │
+                                │  HTTP GET (no auth, no body)
+                                ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  HANDLER                                                                     │
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │  health_check()                                                       │   │
+│  │  fluidmcp/cli/server.py · FastAPI @app.get("/health")                │   │
+│  └──────────────┬────────────────────┬──────────────────────────────────┘   │
+└─────────────────┼────────────────────┼────────────────────────────────────--┘
+                  │                    │
+     ┌────────────┘                    └────────────────────┐
+     │  branch A                                            │  branch B
+     ▼                                                      ▼
+┌────────────────────────────────────────┐   ┌─────────────────────────────────────────┐
+│  PROCESSING — branch A                 │   │  PROCESSING — branch B                  │
+│  MongoDB Liveness Ping                 │   │  In-Memory Registry Reads               │
+│                                        │   │                                         │
+│  Precondition check:                   │   │  ┌───────────────────────────────────┐  │
+│  hasattr(db_manager, 'client')         │   │  │  len(_replicate_clients)          │  │
+│    AND db_manager.client is not None   │   │  │  fluidmcp/cli/services/           │  │
+│                                        │   │  │  replicate_client.py              │  │
+│  ┌─────────────────────────────────┐   │   │  │  · module-level dict              │  │
+│  │  db_manager.client              │   │   │  └──────────────┬────────────────────┘  │
+│  │  .admin.command('ping')         │   │   │                 │ ──[int]──►             │
+│  │  (async, motor driver)          │   │   │                 │  replicate_count       │
+│  │  fluidmcp/cli/repositories/     │   │   │                 │                        │
+│  │  database.py · DatabaseManager  │   │   │  ┌───────────────────────────────────┐  │
+│  └──────────┬──────────────────────┘   │   │  │  len(_llm_models_config)          │  │
+│             │                          │   │  │  fluidmcp/cli/services/           │  │
+│     success │  exception               │   │  │  llm_provider_registry.py         │  │
+│     ────────┼─────────────────────     │   │  │  · module-level dict              │  │
+│             │             │            │   │  └──────────────┬────────────────────┘  │
+│             ▼             ▼            │   │                 │ ──[int]──►             │
+│         "connected"    "error"         │   │                 │  total_models          │
+│          db_status     db_status       │   └─────────────────┼───────────────────────┘
+│          db_error=None db_error=str(e) │                     │
+└───────────────────────────────────────┘                     │
+                  │  ──[str, str|None]──►                      │  ──[int, int]──►
+                  │  (db_status, db_error)                     │  (replicate_count,
+                  └──────────────────┬─────────────────────────┘   total_models)
+                                     │
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  STATUS DETERMINATION                                                        │
+│                                                                              │
+│  fluidmcp/cli/server.py · health_check() — lines 311-319                    │
+│                                                                              │
+│         < db_status == "error" ? >                                           │
+│                YES │         NO │                                            │
+│                    │            └──────► < db_status == "disconnected" ? >  │
+│                    │                           YES │           NO │          │
+│                    │                               │              │          │
+│                    │              < total_models == 0 ? >         │          │
+│                    │                 YES │        NO │            │          │
+│                    │                    │           │             │          │
+│                    ▼                    ▼           ▼             ▼          │
+│               "degraded"          "starting"  "degraded"     "healthy"      │
+│         (DB error, service up)   (fresh boot,  (DB lost,    (DB connected,  │
+│                                  no models)   models live)  persistence on) │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                     │
+                                     │  ──[str]──► overall_status
+                                     ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  RESPONSE ASSEMBLY                                                           │
+│                                                                              │
+│  fluidmcp/cli/server.py · health_check() — lines 321-337                    │
+│                                                                              │
+│  {                                                                           │
+│    "status":    overall_status,           // "healthy"|"degraded"|"starting"│
+│    "timestamp": datetime.utcnow() + "Z",  // ISO-8601 UTC                   │
+│    "database": {                                                             │
+│       "status":              db_status,   // "connected"|"error"|"disconn." │
+│       "type":                db_type,     // e.g. "DatabaseManager"         │
+│       "error":               db_error,    // null or exception message      │
+│       "persistence_enabled": bool         // True only when "connected"     │
+│    },                                                                        │
+│    "models": {                                                               │
+│       "total":   total_models,            // len(_llm_models_config)        │
+│       "by_type": { "replicate": int }     // len(_replicate_clients)        │
+│    },                                                                        │
+│    "version":   app.version               // "2.0.0"                        │
+│  }                                                                           │
+└───────────────────────────────┬─────────────────────────────────────────────┘
+                                │
+                                │  HTTP 200 JSON
+                                ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  OUTPUT                                                                      │
+│                                                                              │
+│   Caller / Docker HEALTHCHECK / Railway load balancer                        │
+│                                                                              │
+│   HTTP 200 OK (always — unhealthy state is reported in body, not status)    │
+│   Content-Type: application/json                                             │
+│                                                                              │
+│   Docker HEALTHCHECK (Dockerfile lines 66-67):                               │
+│     curl -f http://localhost:${PORT}/health || exit 1                        │
+│     --interval=30s  --timeout=10s  --start-period=40s  --retries=3          │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Phase Breakdown
+
+### Input
+
+| Property | Value |
+|---|---|
+| Method | `GET` |
+| Path | `/health` |
+| Auth required | No — intentionally public |
+| Request body | None |
+| Query params | None |
+
+The endpoint is registered inside `create_server()` in `server.py` and is deliberately **not** wrapped in the `RequestTimer` dependency to avoid polluting `fluidmcp_requests_total` metrics with high-frequency load-balancer probes (see comment at line 274).
+
+### Processing
+
+Three independent data-gathering operations run sequentially in the handler (no concurrency primitives needed — each is either a single `await` or a `len()` call):
+
+**1. MongoDB liveness ping (async I/O)**
+
+- Guard: checks `hasattr(db_manager, 'client') and db_manager.client` before attempting the ping. If the guard fails, `db_status` stays `"disconnected"`.
+- Live wire: `await db_manager.client.admin.command('ping')` — this is a real network round-trip to MongoDB, not a cached connection flag.
+- Success path → `db_status = "connected"`, `db_error = None`
+- Exception path → `db_status = "error"`, `db_error = str(e)` (exception message surfaced in response)
+- The `ping` command is also used internally by `DatabaseManager.connect()` during startup, but the health endpoint calls it directly on the `client` object rather than through a dedicated `ping()` helper method.
+- Source: `fluidmcp/cli/repositories/database.py · DatabaseManager`
+
+**2. Replicate client count (in-memory)**
+
+- `from .services.replicate_client import _replicate_clients`
+- `replicate_count = len(_replicate_clients)` — module-level `Dict[str, ReplicateClient]`
+- O(1), no I/O
+- Source: `fluidmcp/cli/services/replicate_client.py`
+
+**3. Total LLM model count (in-memory)**
+
+- `from .services.llm_provider_registry import _llm_models_config`
+- `total_models = len(_llm_models_config)` — module-level `Dict[str, dict]` populated by `initialize_llm_registry()`
+- O(1), no I/O
+- Source: `fluidmcp/cli/services/llm_provider_registry.py`
+
+### Status Determination Logic
+
+```
+if db_status == "error":
+    overall_status = "degraded"          # DB threw an exception
+elif db_status == "disconnected":
+    if total_models == 0:
+        overall_status = "starting"      # No DB AND no models → still booting
+    else:
+        overall_status = "degraded"      # Models loaded but DB lost → persistence gone
+else:  # db_status == "connected"
+    overall_status = "healthy"
+```
+
+The three possible values map to operational states:
+
+| `status` | Meaning |
+|---|---|
+| `healthy` | MongoDB is reachable; persistence is fully operational |
+| `degraded` | Service is running and serving requests, but MongoDB is unreachable or erroring |
+| `starting` | No database and no models — container is still initialising |
+
+### Output
+
+The handler always returns HTTP 200. Callers must inspect the `status` field in the body to distinguish healthy from degraded states. The Docker `HEALTHCHECK` uses `curl -f` which only fails on non-2xx responses, so a `"degraded"` body still keeps the container marked healthy at the infrastructure layer.
+
+## Response Structure
+
+```json
+{
+  "status": "healthy",
+  "timestamp": "2026-04-08T12:34:56.789Z",
+  "database": {
+    "status": "connected",
+    "type": "DatabaseManager",
+    "error": null,
+    "persistence_enabled": true
+  },
+  "models": {
+    "total": 3,
+    "by_type": {
+      "replicate": 2
+    }
+  },
+  "version": "2.0.0"
+}
+```
+
+| Field | Type | Source | Description |
+|---|---|---|---|
+| `status` | `string` | Derived | Overall health: `"healthy"`, `"degraded"`, or `"starting"` |
+| `timestamp` | `string` | `datetime.utcnow()` | ISO-8601 UTC timestamp of this response |
+| `database.status` | `string` | MongoDB ping result | `"connected"`, `"error"`, or `"disconnected"` |
+| `database.type` | `string` | `type(db_manager).__name__` | Class name of the backend (e.g. `"DatabaseManager"`, `"InMemoryBackend"`) |
+| `database.error` | `string\|null` | Exception message | `null` on success; exception string on error |
+| `database.persistence_enabled` | `bool` | `db_status == "connected"` | `true` only when MongoDB ping succeeded |
+| `models.total` | `int` | `len(_llm_models_config)` | Total registered LLM models across all provider types |
+| `models.by_type.replicate` | `int` | `len(_replicate_clients)` | Count of initialised Replicate provider clients |
+| `version` | `string` | `app.version` | FluidMCP server version (default `"2.0.0"`) |
+
+## Docker HEALTHCHECK
+
+Defined in `Dockerfile` lines 63-67:
+
+```dockerfile
+# Health check for Railway monitoring
+# Start period: 40s (allows MongoDB connection retry: 2s + 4s + 8s + startup time)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost:${PORT}/health || exit 1
+```
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| `--interval` | 30s | Checks every 30 seconds after the start period |
+| `--timeout` | 10s | Kills the check if it takes longer than 10 seconds |
+| `--start-period` | 40s | Grace period for MongoDB retry backoff (2 s + 4 s + 8 s + startup overhead) |
+| `--retries` | 3 | Container marked unhealthy only after 3 consecutive failures |
+
+## Data Flow Summary
+
+| Step | Component | File | Function / Symbol | Data In | Data Out |
+|---|---|---|---|---|---|
+| 1 | FastAPI router | `fluidmcp/cli/server.py` | `@app.get("/health")` | HTTP GET request | Invokes `health_check()` |
+| 2 | Health handler | `fluidmcp/cli/server.py` | `health_check()` | None (no params) | Orchestrates all sub-steps |
+| 3 | MongoDB guard | `fluidmcp/cli/server.py` | `health_check()` lines 298-305 | `db_manager.client` reference | `True` / `False` (proceed or skip) |
+| 4 | MongoDB ping | `fluidmcp/cli/repositories/database.py` | `db_manager.client.admin.command('ping')` | None | Raises or returns (success/failure) |
+| 5 | DB status set | `fluidmcp/cli/server.py` | `health_check()` | Ping result or exception | `db_status: str`, `db_error: str\|None` |
+| 6 | Replicate count | `fluidmcp/cli/services/replicate_client.py` | `_replicate_clients` | Module-level dict | `replicate_count: int` |
+| 7 | LLM model count | `fluidmcp/cli/services/llm_provider_registry.py` | `_llm_models_config` | Module-level dict | `total_models: int` |
+| 8 | Status logic | `fluidmcp/cli/server.py` | `health_check()` lines 311-319 | `db_status`, `total_models` | `overall_status: str` |
+| 9 | Response build | `fluidmcp/cli/server.py` | `health_check()` lines 321-337 | All collected values | JSON dict |
+| 10 | HTTP response | FastAPI / Starlette | — | JSON dict | HTTP 200 `application/json` |

--- a/onboarding-tutorials/code-flow/fmcp-serve/mongodb-connection-sequence-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/mongodb-connection-sequence-diagram.md
@@ -1,0 +1,211 @@
+# MongoDB Connection — Sequence Diagram
+
+> Traces the full lifecycle of a MongoDB connection attempt inside `fmcp serve`: from `main()` through the retry loop in `connect_with_retry()`, into `DatabaseManager.connect()` / `init_db()`, down to the Motor async client ping, collection creation, and both the success path and the failure/fallback path.
+
+---
+
+## Participants
+
+| Actor | File | Key Function / Role |
+|---|---|---|
+| **main()** | `fluidmcp/cli/server.py` | Entry point; constructs `DatabaseManager`, calls `connect_with_retry()` |
+| **connect_with_retry()** | `fluidmcp/cli/server.py` | Retry loop with exponential backoff; decides fallback vs. hard-exit |
+| **DatabaseManager** | `fluidmcp/cli/repositories/database.py` | Owns `init_db()` → `connect()` → `_init_collections()`; Motor client lifecycle |
+| **MongoDB** | External (Motor async client) | Receives `ping` command and index/collection creation commands |
+
+---
+
+## Sequence
+
+```
+     main()                connect_with_retry()          DatabaseManager               MongoDB
+     server.py             server.py                     repositories/                 External
+                                                         database.py                   Motor client
+
+       │                          │                             │                          │
+       │                          │                             │                          │
+       │  1. connect_with_retry(  │                             │                          │
+       │     db_manager,          │                             │                          │
+       │     max_retries=3,       │                             │                          │
+       │     require_persistence) │                             │                          │
+       │─────────────────────────►│                             │                          │
+       │                          │                             │                          │
+       │                          │  ╔══════════════════════════════════════════════════╗  │
+       │                          │  ║  RETRY LOOP  (attempt = 1 … max_retries)        ║  │
+       │                          │  ╚══════════════════════════════════════════════════╝  │
+       │                          │                             │                          │
+       │                          │  2. await db_manager        │                          │
+       │                          │        .init_db()           │                          │
+       │                          │  [attempt 1 / 3]            │                          │
+       │                          │────────────────────────────►│                          │
+       │                          │                             │                          │
+       │                          │                             │  3. AsyncIOMotorClient(  │
+       │                          │                             │     uri, serverSelection │
+       │                          │                             │     TimeoutMS,           │
+       │                          │                             │     connectTimeoutMS,    │
+       │                          │                             │     socketTimeoutMS,     │
+       │                          │                             │     maxPoolSize,         │
+       │                          │                             │     minPoolSize,         │
+       │                          │                             │     retryWrites=True,    │
+       │                          │                             │     w="majority")        │
+       │                          │                             │- - - - - - - - - - - - ►│
+       │                          │                             │  [Motor client created]  │
+       │                          │                             │◄- - - - - - - - - - - - │
+       │                          │                             │                          │
+       │                          │                             │  4. await admin          │
+       │                          │                             │       .command('ping')   │
+       │                          │                             │- - - - - - - - - - - - ►│
+       │                          │                             │                          │
+       │                          │        ╔════════════════════╧══════════════════════════╧═══╗
+       │                          │        ║  BRANCH: ping result                              ║
+       │                          │        ╚════════════════════╤══════════════════════════╤═══╝
+       │                          │                             │                          │
+       │   ╔═══════════════════════════════════════════════════════════════════════════════╗
+       │   ║  SUCCESS PATH                                      │                          ║
+       │   ╚═══════════════════════════════════════════════════════════════════════════════╝
+       │                          │                             │   ping OK                │
+       │                          │                             │◄- - - - - - - - - - - - │
+       │                          │                             │                          │
+       │                          │                             │  5a. self.db =           │
+       │                          │                             │      client[db_name]     │
+       │                          │                             │      (assign db handle)  │
+       │                          │                             │                          │
+       │                          │                             │  5b. await client        │
+       │                          │                             │       .server_info()     │
+       │                          │                             │  (check change-stream    │
+       │                          │                             │   / replica-set support) │
+       │                          │                             │- - - - - - - - - - - - ►│
+       │                          │                             │◄- - - - - - - - - - - - │
+       │                          │                             │                          │
+       │                          │                             │  5c. _migrate_collection │
+       │                          │                             │      _names()            │
+       │                          │                             │  (rename old→new         │
+       │                          │                             │   fluidmcp_* prefix)     │
+       │                          │                             │- - - - - - - - - - - - ►│
+       │                          │                             │◄- - - - - - - - - - - - │
+       │                          │                             │                          │
+       │                          │                             │  5d. _init_collections() │
+       │                          │                             │  ┌───────────────────────┴─────────────────────┐
+       │                          │                             │  │ fluidmcp_servers                            │
+       │                          │                             │  │   create_index("id", unique=True)           │
+       │                          │                             │  │                                             │
+       │                          │                             │  │ fluidmcp_server_instances                   │
+       │                          │                             │  │   create_index("server_id")                 │
+       │                          │                             │  │                                             │
+       │                          │                             │  │ fluidmcp_server_logs                        │
+       │                          │                             │  │   capped collection (100 MB)                │
+       │                          │                             │  │   create_index([server_name, timestamp])    │
+       │                          │                             │  │                                             │
+       │                          │                             │  │ fluidmcp_llm_models                         │
+       │                          │                             │  │   create_index("model_id", unique=True)     │
+       │                          │                             │  │                                             │
+       │                          │                             │  │ fluidmcp_llm_model_versions                 │
+       │                          │                             │  │   create_index([model_id, archived_at])     │
+       │                          │                             │  │                                             │
+       │                          │                             │  │ fluidmcp_crash_events                       │
+       │                          │                             │  │   create_index([server_id, timestamp])      │
+       │                          │                             │  │   TTL index on "timestamp"                  │
+       │                          │                             │  │   expireAfterSeconds = 30 days × 86400      │
+       │                          │                             │  └───────────────────────┬─────────────────────┘
+       │                          │                             │- - - (all create_index)- ►│
+       │                          │                             │◄- - - - - - - - - - - - │
+       │                          │                             │                          │
+       │                          │  6.  returns True           │                          │
+       │                          │◄────────────────────────────│                          │
+       │                          │                             │                          │
+       │  7.  returns True        │                             │                          │
+       │◄─────────────────────────│                             │                          │
+       │                          │                             │                          │
+       │  [main() continues:      │                             │                          │
+       │   create ServerManager,  │                             │                          │
+       │   build FastAPI app,     │                             │                          │
+       │   load LLM models …]     │                             │                          │
+       │                          │                             │                          │
+       │   ╔═══════════════════════════════════════════════════════════════════════════════╗
+       │   ║  FAILURE PATH  (ping raises ConnectionFailure or any Exception)              ║
+       │   ╚═══════════════════════════════════════════════════════════════════════════════╝
+       │                          │                             │                          │
+       │                          │                             │   ping FAILS             │
+       │                          │                             │◄ × × × × × × × × × × × ×│
+       │                          │                             │                          │
+       │                          │  8a. returns False          │                          │
+       │                          │◄────────────────────────────│                          │
+       │                          │                             │                          │
+       │                          │  ┌──────────────────────────────────────────────────┐  │
+       │                          │  │  attempt < max_retries?                          │  │
+       │                          │  │  YES → wait_time = 2 ** attempt                  │  │
+       │                          │  │          attempt 1 → wait 2 s                    │  │
+       │                          │  │          attempt 2 → wait 4 s                    │  │
+       │                          │  │          attempt 3 → wait 8 s (last; no sleep)   │  │
+       │                          │  │  then loop back to step 2 with attempt + 1       │  │
+       │                          │  └──────────────────────────────────────────────────┘  │
+       │                          │                             │                          │
+       │                          │  ┌──────────────────────────────────────────────────┐  │
+       │                          │  │  All retries exhausted                           │  │
+       │                          │  │                                                   │  │
+       │                          │  │  require_persistence = True?                     │  │
+       │                          │  │    YES → raise RuntimeError(                     │  │
+       │                          │  │              "MongoDB connection required…")     │  │
+       │                          │  │            → caller catches → sys.exit(1)        │  │
+       │                          │  │            (intentional Railway crash loop)      │  │
+       │                          │  │                                                   │  │
+       │                          │  │  require_persistence = False?                    │  │
+       │                          │  │    YES → returns False                           │  │
+       │                          │  └──────────────────────────────────────────────────┘  │
+       │                          │                             │                          │
+       │  8b. returns False       │                             │                          │
+       │◄─────────────────────────│                             │                          │
+       │                          │                             │                          │
+       │  [main() continues with  │                             │                          │
+       │   InMemoryBackend —      │                             │                          │
+       │   state lost on restart] │                             │                          │
+       │                          │                             │                          │
+```
+
+---
+
+## Notes
+
+- **Retry backoff formula**: `wait_time = 2 ** attempt` — attempt 1 waits 2 s, attempt 2 waits 4 s; after the third (final) attempt the sleep is skipped and the exhaustion branch is entered immediately.
+
+- **`require_persistence` behaviour**:
+  - `False` (default): after all retries are exhausted, `connect_with_retry()` returns `False` and `main()` silently falls back to `InMemoryBackend`. Server state is **not persisted** across restarts and a warning is logged.
+  - `True` (`--require-persistence` CLI flag): after exhaustion a `RuntimeError` is raised, which propagates up and causes the container to exit with code 1. On Railway this triggers an intentional crash-loop until MongoDB becomes reachable.
+
+- **`init_db()` is the single public entry point** from `connect_with_retry()`. Internally it calls `connect()` first; only if that succeeds does it proceed to `_migrate_collection_names()` and then create all indexes / collections.
+
+- **Change-stream detection** happens inside `connect()` (after the ping succeeds): `server_info()` checks the MongoDB major version, then `replSetGetStatus` checks for a replica set. The result is stored in `self._change_streams_supported` and exposed via `supports_change_streams()`.
+
+- **Collections created on success**:
+
+  | Collection | Index / Special property |
+  |---|---|
+  | `fluidmcp_servers` | Unique index on `id` |
+  | `fluidmcp_server_instances` | Index on `server_id` |
+  | `fluidmcp_server_logs` | Capped (100 MB); compound index on `(server_name, timestamp)` |
+  | `fluidmcp_llm_models` | Unique index on `model_id` |
+  | `fluidmcp_llm_model_versions` | Compound index on `(model_id, archived_at DESC)` |
+  | `fluidmcp_crash_events` | Compound index on `(server_id, timestamp)`; TTL index on `timestamp` (default 30 days) |
+
+- **Connection pool defaults**: `maxPoolSize=50`, `minPoolSize=10`. Both are overridable via `FMCP_MONGODB_MAX_POOL_SIZE` / `FMCP_MONGODB_MIN_POOL_SIZE`. Write concern is `w="majority"` with `retryWrites=True`.
+
+- **TLS**: certificate validation is enabled by default. Set `FMCP_MONGODB_ALLOW_INVALID_CERTS=true` only for development (logs a security warning).
+
+---
+
+## Interaction Summary
+
+| Step | From | To | Call | Returns |
+|---|---|---|---|---|
+| 1 | `main()` | `connect_with_retry()` | `connect_with_retry(db_manager, max_retries=3, require_persistence)` | `True` / `False` / raises `RuntimeError` |
+| 2 | `connect_with_retry()` | `DatabaseManager` | `await db_manager.init_db()` (per attempt) | `True` on success, `False` on failure |
+| 3 | `DatabaseManager.connect()` | MongoDB | `AsyncIOMotorClient(uri, **options)` | Motor client handle |
+| 4 | `DatabaseManager.connect()` | MongoDB | `await client.admin.command('ping')` | `{'ok': 1}` or raises `ConnectionFailure` |
+| 5a | `DatabaseManager.connect()` | — | `self.db = client[database_name]` | database handle (local) |
+| 5b | `DatabaseManager.connect()` | MongoDB | `await client.server_info()` then `replSetGetStatus` | version string / replica-set status |
+| 5c | `DatabaseManager.init_db()` | MongoDB | `_migrate_collection_names()` — renames `servers`→`fluidmcp_servers` etc. if needed | — |
+| 5d | `DatabaseManager.init_db()` | MongoDB | `create_index()` × 7 + `create_collection()` (capped) | — |
+| 6 | `DatabaseManager` | `connect_with_retry()` | `return True` | — |
+| 7 | `connect_with_retry()` | `main()` | `return True` | — |
+| 8a | `DatabaseManager` | `connect_with_retry()` | `return False` (on exception) | — |
+| 8b | `connect_with_retry()` | `main()` | `return False` (fallback) or `raise RuntimeError` (hard-exit) | — |

--- a/onboarding-tutorials/code-flow/fmcp-serve/server-lifecycle-feature-flow-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/server-lifecycle-feature-flow-diagram.md
@@ -1,0 +1,396 @@
+# MCP Server Lifecycle — Feature Flow Diagram
+
+> End-to-end flow for registering an MCP server configuration (POST /api/servers) and then starting it as a live subprocess (POST /api/servers/{id}/start), including auth, persistence, process spawning, and background health monitoring.
+
+## Overview
+
+The lifecycle splits into two sequential API calls. Registration persists a server configuration into MongoDB (flat-to-nested schema conversion included). Start loads that config, acquires a per-server lock, spawns an OS subprocess, performs the MCP stdio/SSE handshake, saves running state, and hands off to the background MCPHealthMonitor which polls every 30 seconds and auto-restarts on failure.
+
+---
+
+## Part 1: Server Registration (POST /api/servers)
+
+```
+HTTP Client
+    │
+    │  POST /api/servers
+    │  { id, name, command, args, env, ... }
+    ▼
+┌─────────────────────────────────────────────┐
+│  1. Route handler                            │
+│  fluidmcp/cli/api/management.py             │
+│  add_server()  @router.post("/servers")     │
+└─────────────────────────────────────────────┘
+    │
+    │  FastAPI Depends(get_token)
+    ▼
+┌─────────────────────────────────────────────┐
+│  2. Auth check                               │
+│  fluidmcp/cli/auth.py                       │
+│  verify_token() / get_token()               │
+└─────────────────────────────────────────────┘
+    │
+    < FMCP_SECURE_MODE == "true"? >
+    │                          │
+   [yes]                      [no]
+    │                          │
+    < token matches            │ (pass-through,
+      FMCP_BEARER_TOKEN? >     │  user_id = "anonymous")
+    │            │             │
+   [yes]        [no] ─────────────────────────► 401 HTTPException
+    │                                           {"WWW-Authenticate": "Bearer"}
+    │◄─────────── (public mode joins here) ─────┘
+    ▼
+┌─────────────────────────────────────────────┐
+│  3. Input sanitization                       │
+│  fluidmcp/cli/api/management.py             │
+│  sanitize_input(config)                     │
+│  ↳ strips MongoDB $-operators and dots       │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  4. Field validation                         │
+│  fluidmcp/cli/api/management.py             │
+│  validate_server_config(config)             │
+│  ↳ checks "id" and "name" required fields   │
+│  ↳ validates command allowlist              │
+│  ↳ validates env vars (format, length)      │
+└─────────────────────────────────────────────┘
+    │
+    < "id" and "name" present? >
+    │                    │
+   [yes]                [no] ────────────────► 400 HTTPException
+    ▼                                          "Server id/name is required"
+┌─────────────────────────────────────────────┐
+│  5. Duplicate check                          │
+│  fluidmcp/cli/api/management.py             │
+│  manager.configs.get(id)                    │
+│  + await manager.db.get_server_config(id)   │
+└─────────────────────────────────────────────┘
+    │
+    < server id already exists? >
+    │                    │
+   [no]                 [yes] ───────────────► 400/409 HTTPException
+    ▼                                          "Server already exists"
+┌─────────────────────────────────────────────┐
+│  6. Persist to MongoDB                       │
+│  fluidmcp/cli/repositories/database.py      │
+│  DatabaseManager.save_server_config(config) │
+│  ↳ calls _nest_config_for_storage()         │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  7. Schema migration (inside save)           │
+│  fluidmcp/cli/repositories/database.py      │
+│  DatabaseManager._nest_config_for_storage() │
+│  ↳ lifts command/args/env into              │
+│    nested mcp_config: { command, args, env }│
+│  ↳ sets defaults: description, enabled,     │
+│    restart_window_sec, tools, created_by    │
+│  ↳ MongoDB upsert with $setOnInsert for     │
+│    created_at timestamp                     │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  8. Store in-memory                          │
+│  fluidmcp/cli/api/management.py             │
+│  manager.configs[id] = config               │
+│  ↳ immediate access without DB round-trip   │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+  201 { message, id, name }
+  ──────────────────────────► HTTP Client
+```
+
+---
+
+## Part 2: Server Start (POST /api/servers/{id}/start)
+
+```
+HTTP Client
+    │
+    │  POST /api/servers/{id}/start
+    ▼
+┌─────────────────────────────────────────────┐
+│  1. Route handler                            │
+│  fluidmcp/cli/api/management.py             │
+│  start_server()                             │
+│    @router.post("/servers/{id}/start")      │
+└─────────────────────────────────────────────┘
+    │
+    │  FastAPI Depends(get_token)
+    ▼
+┌─────────────────────────────────────────────┐
+│  2. Auth check                               │
+│  fluidmcp/cli/auth.py                       │
+│  verify_token() / get_token()               │
+│  + get_current_user() → user_id             │
+└─────────────────────────────────────────────┘
+    │
+    < token valid / secure mode? >
+    │                   │
+   [yes]               [no] ─────────────────► 401 HTTPException
+    ▼
+┌─────────────────────────────────────────────┐
+│  3. Config lookup                            │
+│  fluidmcp/cli/api/management.py             │
+│  manager.configs.get(id)                    │
+│  + await manager.db.get_server_config(id)   │
+└─────────────────────────────────────────────┘
+    │
+    < config found? >
+    │           │
+   [yes]       [no] ──────────────────────────► 404 HTTPException
+    ▼                                           "Server not found"
+┌─────────────────────────────────────────────┐
+│  4. Enabled check                            │
+│  fluidmcp/cli/api/management.py             │
+│  config.get("enabled", True)                │
+└─────────────────────────────────────────────┘
+    │
+    < enabled? >
+    │          │
+   [yes]      [no] ──────────────────────────► 403 HTTPException
+    ▼                                          "Server is disabled"
+┌─────────────────────────────────────────────┐
+│  5. Already-running guard                    │
+│  fluidmcp/cli/api/management.py             │
+│  manager.processes[id].poll() is None       │
+└─────────────────────────────────────────────┘
+    │
+    < process already running? >
+    │                    │
+   [no]                 [yes] ───────────────► 400 HTTPException
+    ▼                                          "Server already running"
+┌─────────────────────────────────────────────┐
+│  6. Acquire operation lock                   │
+│  fluidmcp/cli/services/server_manager.py    │
+│  ServerManager._get_operation_lock(id)      │
+│  ↳ per-server asyncio.Lock                  │
+│  ↳ fail-fast if lock already held           │
+└─────────────────────────────────────────────┘
+    │
+    < lock already held? >
+    │               │
+   [no]            [yes] ──────────────────── returns False → 500
+    ▼                                          "Failed to start server"
+┌─────────────────────────────────────────────┐
+│  7. Dispatch to start_server()               │
+│  fluidmcp/cli/services/server_manager.py    │
+│  ServerManager.start_server(id, config,     │
+│                              user_id)        │
+│  → delegates to _start_server_unlocked()    │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  8. Spawn MCP process (30 s timeout)         │
+│  fluidmcp/cli/services/server_manager.py    │
+│  ServerManager._spawn_mcp_process(id,       │
+│                                   config)   │
+│  ↳ resolves working_dir / install_path      │
+│  ↳ auto-reclones GitHub repo if dir missing │
+│  ↳ merges instance env vars from DB         │
+│  ↳ opens stderr log file (0o600 perms)      │
+│  ↳ subprocess.Popen(cmd_list, ...)          │
+│  ↳ waits 0.5 s, checks process still alive │
+└─────────────────────────────────────────────┘
+    │
+    < process still alive after 0.5 s? >
+    │                           │
+   [yes]                       [no] ─────────► returns None → 500
+    ▼
+┌─────────────────────────────────────────────┐
+│  9. Transport-specific handshake             │
+│  fluidmcp/cli/services/server_manager.py    │
+│  _spawn_mcp_process() (continued)           │
+└─────────────────────────────────────────────┘
+    │
+    < transport == "sse"? >
+    │                  │
+   [yes]              [no]  (stdio — default)
+    │                  │
+    ▼                  ▼
+┌──────────────┐  ┌────────────────────────────┐
+│  SSE branch  │  │  stdio branch               │
+│  Poll HTTP   │  │  initialize_mcp_server()    │
+│  /sse until  │  │  (MCP initialize handshake) │
+│  200 (30 s)  │  │  → tools/list discovery     │
+│  → tool disc │  │  → cache in MongoDB         │
+│  via HTTP    │  └────────────────────────────┘
+│  POST /msg/  │
+└──────────────┘
+    │                  │
+    └──────┬───────────┘
+           ▼
+┌─────────────────────────────────────────────┐
+│  10. Save instance state to MongoDB          │
+│  fluidmcp/cli/repositories/database.py      │
+│  DatabaseManager.save_instance_state({      │
+│    server_id, state:"running", pid,         │
+│    start_time, restart_count:0,             │
+│    started_by: user_id,                     │
+│    last_used_at: now })                     │
+│  ↳ optimistic locking via expected_pid      │
+│  ↳ upsert into fluidmcp_server_instances    │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  11. Record metrics + uptime                 │
+│  fluidmcp/cli/services/metrics.py           │
+│  MetricsCollector.set_server_status(2)      │
+│  ↳ 2 = running                              │
+│  ↳ start_times[id] = time.monotonic()       │
+└─────────────────────────────────────────────┘
+    │
+    ▼
+  200 { message: "started", pid: <pid> }
+  ──────────────────────────► HTTP Client
+    │
+    │  (background — already running)
+    ▼
+┌─────────────────────────────────────────────┐
+│  12. MCPHealthMonitor polls every 30 s       │
+│  fluidmcp/cli/services/server_manager.py    │
+│  MCPHealthMonitor._monitor_loop()           │
+│  → _check_server(server_id, process)        │
+│  ↳ process.poll() != None → process dead    │
+└─────────────────────────────────────────────┘
+    │
+    < process still alive? >
+    │                   │
+   [yes]               [no]
+    │                   │
+    │ (reset restart    ▼
+    │  count after    ┌─────────────────────────────────────────┐
+    │  5 min uptime)  │  13. Evaluate restart policy             │
+    │                 │  fluidmcp/cli/services/server_manager.py │
+    │                 │  MCPHealthMonitor._check_server()        │
+    │                 │  ↳ load config from DB                   │
+    │                 │  ↳ check restart_policy and max_restarts │
+    │                 └─────────────────────────────────────────┘
+    │                   │
+    │         < should_restart? >
+    │         │                  │
+    │        [yes]              [no]
+    │         │                  │
+    │         │                  ▼
+    │         │       ┌──────────────────────────────┐
+    │         │       │  Cleanup DB state only        │
+    │         │       │  _cleanup_server(id, rc)      │
+    │         │       │  ↳ state: "stopped"/"failed"  │
+    │         │       │  ↳ save crash event if failed │
+    │         │       └──────────────────────────────┘
+    │         │
+    │         ▼
+    │  ┌─────────────────────────────────────────────┐
+    │  │  14. Exponential backoff + restart           │
+    │  │  fluidmcp/cli/services/server_manager.py    │
+    │  │  MCPHealthMonitor._calculate_restart_delay  │
+    │  │  ↳ delay = 5s * 2^min(count, 5)             │
+    │  │  ↳ max delay = 5 * 32 = 160 s               │
+    │  │  → acquire op lock                           │
+    │  │  → _cleanup_server(id, exit_code)            │
+    │  │  → _start_server_unlocked(id, config)        │
+    │  │    (60 s timeout, same path as step 8-11)    │
+    │  └─────────────────────────────────────────────┘
+    │         │
+    │         ▼
+    │  restart_counts[id] += 1
+    │  (loop continues every 30 s)
+    │
+    └──────────────────────────────────────────────── (monitor runs indefinitely)
+```
+
+---
+
+## Key Decision Points
+
+| Decision | Location | Yes path | No path |
+|---|---|---|---|
+| Secure mode enabled? | `auth.py · verify_token()` | Validate bearer token | Pass through (public) |
+| Bearer token valid? | `auth.py · _validate_bearer_token()` | Continue | 401 HTTPException |
+| `id` and `name` present? | `management.py · add_server()` | Continue | 400 HTTPException |
+| Server id already exists? | `management.py · add_server()` | 400/409 HTTPException | Continue |
+| Config found in DB/memory? | `management.py · start_server()` | Continue | 404 HTTPException |
+| Server enabled? | `management.py · start_server()` | Continue | 403 HTTPException |
+| Server already running? | `management.py · start_server()` | 400 HTTPException | Continue |
+| Operation lock already held? | `server_manager.py · _get_operation_lock()` | Fail-fast (500) | Acquire lock |
+| Process alive after 0.5 s? | `server_manager.py · _spawn_mcp_process()` | Proceed to handshake | Return None → 500 |
+| Transport is SSE? | `server_manager.py · _spawn_mcp_process()` | SSE HTTP poll handshake | stdio MCP handshake |
+| Process alive (monitor check)? | `server_manager.py · MCPHealthMonitor._check_server()` | No action (healthy) | Evaluate restart policy |
+| Restart policy allows restart? | `server_manager.py · MCPHealthMonitor._check_server()` | Backoff + restart | Cleanup DB state only |
+| Max restarts reached? | `server_manager.py · MCPHealthMonitor._check_server()` | No restart (log warning) | Proceed with restart |
+
+---
+
+## Side Effects
+
+| Step | Side Effect | Where |
+|---|---|---|
+| Registration — save config | MongoDB upsert into `fluidmcp_servers` collection; flat `command/args/env` promoted to nested `mcp_config` | `database.py · save_server_config()` |
+| Registration — in-memory | `manager.configs[id] = config` for zero-latency access | `management.py · add_server()` |
+| Spawn — stderr log | Opens `~/.fluidmcp/logs/mcp_{id}_stderr.log` with `0o600` permissions; rotates at 10 MB | `server_manager.py · _open_stderr_log()` |
+| Spawn — auto-reclone | If `source == "github"` and working_dir missing, re-clones repo and re-saves config to DB | `server_manager.py · _spawn_mcp_process()` |
+| Spawn — instance env merge | Loads per-instance env overrides from `db.get_instance_env(id)` and merges over config env | `server_manager.py · _spawn_mcp_process()` |
+| Start — instance state | MongoDB upsert into `fluidmcp_server_instances` with `state:"running"`, PID, `started_by`, `last_used_at` | `database.py · save_instance_state()` |
+| Start — tool discovery | Sends `tools/list` JSON-RPC; caches result back to `fluidmcp_servers.tools[]` | `server_manager.py · _discover_and_cache_tools()` |
+| Start — metrics | `MetricsCollector.set_server_status(2)` (running); `start_times[id]` written | `server_manager.py + metrics.py` |
+| Health monitor — restart | `restart_counts[id]` incremented; DB state set `"failed"` then `"running"` after restart | `server_manager.py · MCPHealthMonitor` |
+| Health monitor — crash event | On non-intentional stop, `db.save_crash_event({exit_code, stderr_tail, uptime_seconds})` | `server_manager.py · _cleanup_server()` |
+
+---
+
+## Error Paths
+
+| Trigger | Response | Code |
+|---|---|---|
+| Missing or invalid bearer token | `{"detail": "Invalid or missing authorization token"}` + `WWW-Authenticate: Bearer` | 401 |
+| `FMCP_BEARER_TOKEN` not set in secure mode | `{"detail": "Server misconfiguration: FMCP_BEARER_TOKEN not set in secure mode"}` | 500 |
+| Missing `id` field in registration payload | `{"detail": "Server id is required"}` | 400 |
+| Missing `name` field in registration payload | `{"detail": "Server name is required"}` | 400 |
+| Server id already exists (in-memory or DB) | `{"detail": "Server with id '...' already exists"}` | 400 |
+| MongoDB raises DuplicateKeyError on save | `{"detail": "Server with id '...' already exists"}` | 409 |
+| Server id not found at start time | `{"detail": "Server '...' not found"}` | 404 |
+| Server is disabled at start time | `{"detail": "Cannot start server '...': Server is disabled"}` | 403 |
+| Server process already running | `{"detail": "Server '...' is already running (PID: ...)"}` | 400 |
+| Operation lock already held | `start_server()` returns False → `{"detail": "Failed to start server '...'"}` | 500 |
+| `_spawn_mcp_process()` returns None | `start_server()` returns False → `{"detail": "Failed to start server '...'"}` | 500 |
+| Spawn startup 30 s timeout | `save_instance_state({state:"failed", last_error:"..."})`, returns False → 500 | 500 |
+| MCP stdio handshake fails | Process killed, stderr captured, returns None → 500 | 500 |
+| SSE server not ready within 30 s | Process killed, returns None → 500 | 500 |
+| Max auto-restarts reached (monitor) | Log warning, no restart; DB state remains `"failed"` | — |
+
+---
+
+## Step Reference
+
+| Step | Name | File | Function | Notes |
+|---|---|---|---|---|
+| P1-1 | Route handler | `fluidmcp/cli/api/management.py` | `add_server()` | Decorated `@router.post("/servers")` |
+| P1-2 | Auth check | `fluidmcp/cli/auth.py` | `verify_token()` / `get_token()` | FastAPI `Depends`; constant-time compare via `secrets.compare_digest` |
+| P1-3 | Input sanitization | `fluidmcp/cli/api/management.py` | `sanitize_input()` | Strips MongoDB `$`-prefixed keys and dots |
+| P1-4 | Config validation | `fluidmcp/cli/api/validators.py` | `validate_server_config()` | Command allowlist + env format checks |
+| P1-5 | Duplicate check | `fluidmcp/cli/api/management.py` | `add_server()` | Checks in-memory `manager.configs` then DB |
+| P1-6 | Persist config | `fluidmcp/cli/repositories/database.py` | `DatabaseManager.save_server_config()` | MongoDB upsert on `fluidmcp_servers` |
+| P1-7 | Schema migration | `fluidmcp/cli/repositories/database.py` | `DatabaseManager._nest_config_for_storage()` | Flat → nested `mcp_config`; PDF spec defaults |
+| P1-8 | In-memory store | `fluidmcp/cli/api/management.py` | `add_server()` | `manager.configs[id] = config` |
+| P2-1 | Route handler | `fluidmcp/cli/api/management.py` | `start_server()` | Decorated `@router.post("/servers/{id}/start")` |
+| P2-2 | Auth + user ID | `fluidmcp/cli/auth.py` | `get_token()` + `get_current_user()` | `user_id` is SHA-256 of token in secure mode |
+| P2-3 | Config lookup | `fluidmcp/cli/api/management.py` | `start_server()` | In-memory first, DB fallback |
+| P2-4 | Enabled check | `fluidmcp/cli/api/management.py` | `start_server()` | `config.get("enabled", True)` |
+| P2-5 | Already-running guard | `fluidmcp/cli/api/management.py` | `start_server()` | `manager.processes[id].poll() is None` |
+| P2-6 | Acquire lock | `fluidmcp/cli/services/server_manager.py` | `ServerManager._get_operation_lock()` | Per-server `asyncio.Lock`; fail-fast |
+| P2-7 | Delegate start | `fluidmcp/cli/services/server_manager.py` | `ServerManager.start_server()` | Wrapper that holds lock and calls `_start_server_unlocked()` |
+| P2-8 | Spawn process | `fluidmcp/cli/services/server_manager.py` | `ServerManager._spawn_mcp_process()` | `subprocess.Popen`; 30 s startup timeout |
+| P2-9 | Transport handshake | `fluidmcp/cli/services/server_manager.py` | `_spawn_mcp_process()` / `_handshake_sse_subprocess()` | stdio: MCP init + tools/list; SSE: HTTP poll + POST /messages/ |
+| P2-10 | Save instance state | `fluidmcp/cli/repositories/database.py` | `DatabaseManager.save_instance_state()` | Optimistic locking; upsert into `fluidmcp_server_instances` |
+| P2-11 | Record metrics | `fluidmcp/cli/services/metrics.py` | `MetricsCollector.set_server_status(2)` | Status 2 = running; `start_times[id]` set |
+| P2-12 | Health monitor loop | `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor._monitor_loop()` | Runs every 30 s; checks `process.poll()` |
+| P2-13 | Restart policy eval | `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor._check_server()` | Reads `restart_policy` + `max_restarts` from DB config |
+| P2-14 | Backoff restart | `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor._check_server()` | `5s * 2^count`; max 160 s; timeout 60 s per restart attempt |

--- a/onboarding-tutorials/code-flow/fmcp-serve/startup-key-flow-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/startup-key-flow-diagram.md
@@ -1,0 +1,59 @@
+# fmcp serve — Startup Key Flow
+
+> `fmcp serve` parses CLI flags, selects a persistence backend (MongoDB or in-memory), connects to the database with retry logic, creates the server manager and background tasks, builds the FastAPI app, restores saved LLM models, then hands control to Uvicorn.
+
+**Key steps:** CLI Parse → Choose Backend → MongoDB Connect → Create ServerManager → Start Background Tasks → Build FastAPI App → Restore LLM Models → Start Uvicorn
+
+## Flow Diagram
+
+```
+ START
+   │
+   ▼
+┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐
+│  1. CLI Parse        │     │  2. Choose Backend   │     │  3. MongoDB Connect  │     │  4. Create           │
+│  cli.py              │────►│  server.py           │────►│  server.py           │────►│     ServerManager    │
+│  main()              │     │  main()              │     │  connect_with_retry()│     │  server_manager.py   │
+└──────────────────────┘     └──────────────────────┘     └──────────────────────┘     │  ServerManager.      │
+                                                                                        │    __init__()        │
+                                                                                        └──────────────────────┘
+                                                                                                  │
+          ┌───────────────────────────────────────────────────────────────────────────────────────┘
+          │                                                                              (wrap down)
+          ▼
+┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐
+│  8. Start Uvicorn    │     │  7. Restore LLM      │     │  6. Build FastAPI    │     │  5. Start Background │
+│  server.py           │◄────│     Models           │◄────│     App              │◄────│     Tasks            │
+│  main()              │     │  server.py           │     │  server.py           │     │  server_manager.py   │
+│  uvicorn.run()       │     │  load_models_from_   │     │  create_app()        │     │  start_idle_         │
+└──────────────────────┘     │    persistence()     │     └──────────────────────┘     │    cleanup_task()    │
+                             └──────────────────────┘                                  │  MCPHealthMonitor.   │
+                                                                                        │    start()           │
+                                                                                        └──────────────────────┘
+   │
+   ▼
+ SERVING  (blocks on shutdown_event; SIGINT / SIGTERM triggers graceful teardown)
+```
+
+## Notes
+
+- **`--require-persistence` flag**: If set, `connect_with_retry()` raises `RuntimeError` after 3 failed attempts and the server never starts. Without the flag, it logs a warning and continues in ephemeral (no-persistence) mode.
+- **`--in-memory` / `--persistence-mode memory`**: Steps 3 (MongoDB Connect) is replaced by a trivial `InMemoryBackend.connect()` call; no network I/O or retry logic occurs.
+- **Exponential backoff** in `connect_with_retry()`: waits 2 s after attempt 1, 4 s after attempt 2, then gives up after attempt 3.
+- **Token handling**: If `--secure` is passed without `--token`, the CLI generates a `secrets.token_urlsafe(32)` token, prints it once to stdout, saves it to `~/.fmcp/tokens/current_token.txt` (mode 0o600), and exports it as `FMCP_BEARER_TOKEN`.
+- **`--allow-insecure`** must be supplied explicitly if `--secure` is omitted; omitting both causes an immediate `sys.exit(1)` before any server code runs.
+- **Background tasks** (Step 5) run as daemon threads and are stopped during graceful shutdown before the process exits.
+- **Model restoration** (Step 7) is skipped entirely when `db_connected` is `False`; models are restored per-type: `replicate` clients are health-checked before registration; `vllm`/`ollama`/`lmstudio` processes are launched via `launch_single_llm_model()`.
+
+## Step Summary
+
+| Step | Name | File | Function | Role |
+|------|------|------|----------|------|
+| 1 | CLI Parse | `fluidmcp/cli/cli.py` | `main()` | `serve_parser` validates auth flags, generates token if needed, then calls `asyncio.run(server_main(args))` |
+| 2 | Choose Backend | `fluidmcp/cli/server.py` | `main()` | Reads `--in-memory` / `--persistence-mode` flags; instantiates either `InMemoryBackend` or `DatabaseManager` |
+| 3 | MongoDB Connect | `fluidmcp/cli/server.py` | `connect_with_retry()` | Attempts `db_manager.init_db()` up to 3 times with 2 s / 4 s / 8 s backoff; raises on failure if `--require-persistence` |
+| 4 | Create ServerManager | `fluidmcp/cli/services/server_manager.py` | `ServerManager.__init__()` | Wires persistence backend; registers `atexit` cleanup hook for all child MCP processes |
+| 5 | Start Background Tasks | `fluidmcp/cli/services/server_manager.py` | `start_idle_cleanup_task()` · `MCPHealthMonitor.start()` | Launches idle-server GC loop and crash-detection health monitor as daemon threads |
+| 6 | Build FastAPI App | `fluidmcp/cli/server.py` | `create_app()` | Adds CORS, request-size middleware, mounts management/inspector/MCP routers, serves frontend static files |
+| 7 | Restore LLM Models | `fluidmcp/cli/server.py` | `load_models_from_persistence()` | Reads saved model docs from MongoDB; re-initialises Replicate clients or relaunches vLLM/Ollama processes |
+| 8 | Start Uvicorn | `fluidmcp/cli/server.py` | `main()` | Creates `uvicorn.Config` + `Server`, spawns `server.serve()` as an asyncio task, registers SIGINT/SIGTERM handlers, awaits shutdown event |

--- a/onboarding-tutorials/code-flow/fmcp-serve/startup-key-flow-diagram.md
+++ b/onboarding-tutorials/code-flow/fmcp-serve/startup-key-flow-diagram.md
@@ -18,9 +18,7 @@
                                                                                         │    __init__()        │
                                                                                         └──────────────────────┘
                                                                                                   │
-          ┌───────────────────────────────────────────────────────────────────────────────────────┘
-          │                                                                              (wrap down)
-          ▼
+                                                                                                  ▼
 ┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐     ┌──────────────────────┐
 │  8. Start Uvicorn    │     │  7. Restore LLM      │     │  6. Build FastAPI    │     │  5. Start Background │
 │  server.py           │◄────│     Models           │◄────│     App              │◄────│     Tasks            │
@@ -42,7 +40,7 @@
 - **Exponential backoff** in `connect_with_retry()`: waits 2 s after attempt 1, 4 s after attempt 2, then gives up after attempt 3.
 - **Token handling**: If `--secure` is passed without `--token`, the CLI generates a `secrets.token_urlsafe(32)` token, prints it once to stdout, saves it to `~/.fmcp/tokens/current_token.txt` (mode 0o600), and exports it as `FMCP_BEARER_TOKEN`.
 - **`--allow-insecure`** must be supplied explicitly if `--secure` is omitted; omitting both causes an immediate `sys.exit(1)` before any server code runs.
-- **Background tasks** (Step 5) run as daemon threads and are stopped during graceful shutdown before the process exits.
+- **Background tasks** (Step 5) run as asyncio tasks (coroutines sharing the event loop) and are cancelled during graceful shutdown before the process exits.
 - **Model restoration** (Step 7) is skipped entirely when `db_connected` is `False`; models are restored per-type: `replicate` clients are health-checked before registration; `vllm`/`ollama`/`lmstudio` processes are launched via `launch_single_llm_model()`.
 
 ## Step Summary
@@ -53,7 +51,7 @@
 | 2 | Choose Backend | `fluidmcp/cli/server.py` | `main()` | Reads `--in-memory` / `--persistence-mode` flags; instantiates either `InMemoryBackend` or `DatabaseManager` |
 | 3 | MongoDB Connect | `fluidmcp/cli/server.py` | `connect_with_retry()` | Attempts `db_manager.init_db()` up to 3 times with 2 s / 4 s / 8 s backoff; raises on failure if `--require-persistence` |
 | 4 | Create ServerManager | `fluidmcp/cli/services/server_manager.py` | `ServerManager.__init__()` | Wires persistence backend; registers `atexit` cleanup hook for all child MCP processes |
-| 5 | Start Background Tasks | `fluidmcp/cli/services/server_manager.py` | `start_idle_cleanup_task()` · `MCPHealthMonitor.start()` | Launches idle-server GC loop and crash-detection health monitor as daemon threads |
+| 5 | Start Background Tasks | `fluidmcp/cli/services/server_manager.py` | `start_idle_cleanup_task()` · `MCPHealthMonitor.start()` | Launches idle-server GC loop and crash-detection health monitor as asyncio tasks |
 | 6 | Build FastAPI App | `fluidmcp/cli/server.py` | `create_app()` | Adds CORS, request-size middleware, mounts management/inspector/MCP routers, serves frontend static files |
 | 7 | Restore LLM Models | `fluidmcp/cli/server.py` | `load_models_from_persistence()` | Reads saved model docs from MongoDB; re-initialises Replicate clients or relaunches vLLM/Ollama processes |
 | 8 | Start Uvicorn | `fluidmcp/cli/server.py` | `main()` | Creates `uvicorn.Config` + `Server`, spawns `server.serve()` as an asyncio task, registers SIGINT/SIGTERM handlers, awaits shutdown event |

--- a/onboarding-tutorials/fmcp-serve/tutorials/fmcp-serve-feature-tutorial.html
+++ b/onboarding-tutorials/fmcp-serve/tutorials/fmcp-serve-feature-tutorial.html
@@ -1,0 +1,1851 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>fmcp serve - Feature Tutorial | FluidMCP</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg:#0d1117;
+    --bg2:#161b22;
+    --bg3:#1c2128;
+    --bg4:#21262d;
+    --border:rgba(210,168,255,0.15);
+    --border2:rgba(88,166,255,0.15);
+    --accent:#d2a8ff;
+    --accent2:#58a6ff;
+    --accent3:#3fb950;
+    --accent4:#f78166;
+    --accent5:#e3b341;
+    --text:#e6edf3;
+    --text2:#8b949e;
+    --text3:#6e7681;
+    --shadow:0 8px 32px rgba(0,0,0,0.5);
+    --radius:12px;
+    --radius-sm:8px;
+  }
+
+  * { box-sizing:border-box; margin:0; padding:0; }
+
+  body {
+    font-family:'Inter',sans-serif;
+    background:var(--bg);
+    color:var(--text);
+    display:flex;
+    height:100vh;
+    overflow:hidden;
+  }
+
+  /* ─── SIDEBAR ─────────────────────────────────────────────── */
+  .sidebar {
+    width:280px;
+    min-width:280px;
+    background:var(--bg2);
+    border-right:1px solid var(--border);
+    display:flex;
+    flex-direction:column;
+    overflow:hidden;
+  }
+
+  .sidebar-header {
+    padding:24px 20px 16px;
+    border-bottom:1px solid var(--border);
+    flex-shrink:0;
+  }
+
+  .sidebar-logo {
+    display:flex;
+    align-items:center;
+    gap:10px;
+    margin-bottom:14px;
+  }
+
+  .logo-icon {
+    width:32px;
+    height:32px;
+    background:linear-gradient(135deg,#d2a8ff,#58a6ff);
+    border-radius:8px;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:16px;
+    font-weight:700;
+    color:#0d1117;
+    flex-shrink:0;
+  }
+
+  .sidebar-title {
+    font-size:13px;
+    font-weight:600;
+    color:var(--accent);
+    letter-spacing:0.5px;
+    text-transform:uppercase;
+  }
+
+  .sidebar-subtitle {
+    font-size:11px;
+    color:var(--text3);
+    margin-top:2px;
+  }
+
+  .sidebar-progress {
+    margin-top:12px;
+  }
+
+  .progress-label {
+    display:flex;
+    justify-content:space-between;
+    font-size:11px;
+    color:var(--text3);
+    margin-bottom:6px;
+  }
+
+  .progress-bar {
+    height:4px;
+    background:var(--bg3);
+    border-radius:2px;
+    overflow:hidden;
+  }
+
+  .progress-fill {
+    height:100%;
+    background:linear-gradient(90deg,var(--accent),var(--accent2));
+    border-radius:2px;
+    transition:width 0.4s ease;
+  }
+
+  .nav-list {
+    list-style:none;
+    overflow-y:auto;
+    flex:1;
+    padding:10px 0;
+  }
+
+  .nav-list::-webkit-scrollbar { width:4px; }
+  .nav-list::-webkit-scrollbar-track { background:transparent; }
+  .nav-list::-webkit-scrollbar-thumb { background:var(--border); border-radius:2px; }
+
+  .nav-item {
+    display:flex;
+    align-items:center;
+    gap:10px;
+    padding:9px 20px;
+    cursor:pointer;
+    transition:background 0.15s;
+    border-left:3px solid transparent;
+    position:relative;
+  }
+
+  .nav-item:hover { background:var(--bg3); }
+  .nav-item.active {
+    background:rgba(210,168,255,0.08);
+    border-left-color:var(--accent);
+  }
+
+  .nav-badge {
+    width:22px;
+    height:22px;
+    border-radius:6px;
+    background:var(--bg4);
+    border:1px solid var(--border);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:10px;
+    font-weight:600;
+    color:var(--text2);
+    flex-shrink:0;
+    transition:all 0.2s;
+  }
+
+  .nav-item.active .nav-badge {
+    background:var(--accent);
+    color:#0d1117;
+    border-color:var(--accent);
+  }
+
+  .nav-item.done .nav-badge {
+    background:var(--accent3);
+    color:#0d1117;
+    border-color:var(--accent3);
+  }
+
+  .nav-label {
+    font-size:12px;
+    font-weight:500;
+    color:var(--text2);
+    line-height:1.3;
+  }
+
+  .nav-item.active .nav-label { color:var(--text); }
+  .nav-item.done .nav-label { color:var(--accent3); }
+
+  /* ─── MAIN CONTENT ────────────────────────────────────────── */
+  .main {
+    flex:1;
+    overflow-y:auto;
+    padding:0;
+    scroll-behavior:smooth;
+  }
+
+  .main::-webkit-scrollbar { width:6px; }
+  .main::-webkit-scrollbar-track { background:transparent; }
+  .main::-webkit-scrollbar-thumb { background:var(--border); border-radius:3px; }
+
+  .lesson {
+    display:none;
+    padding:40px 48px 60px;
+    max-width:900px;
+    animation:slideInUp 0.3s ease;
+  }
+
+  .lesson.active { display:block; }
+
+  @keyframes slideInUp {
+    from { opacity:0; transform:translateY(16px); }
+    to   { opacity:1; transform:translateY(0); }
+  }
+
+  /* ─── LESSON HEADER ──────────────────────────────────────── */
+  .lesson-badge {
+    display:inline-flex;
+    align-items:center;
+    gap:6px;
+    padding:4px 12px;
+    background:rgba(210,168,255,0.1);
+    border:1px solid rgba(210,168,255,0.25);
+    border-radius:20px;
+    font-size:11px;
+    font-weight:600;
+    color:var(--accent);
+    letter-spacing:0.5px;
+    text-transform:uppercase;
+    margin-bottom:16px;
+  }
+
+  .lesson-title {
+    font-size:28px;
+    font-weight:700;
+    color:var(--text);
+    line-height:1.2;
+    margin-bottom:8px;
+  }
+
+  .lesson-subtitle {
+    font-size:15px;
+    color:var(--text2);
+    line-height:1.6;
+    margin-bottom:32px;
+    max-width:680px;
+  }
+
+  /* ─── CARDS ──────────────────────────────────────────────── */
+  .cards {
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+    gap:14px;
+    margin:20px 0;
+  }
+
+  .cards.cols-2 { grid-template-columns:repeat(2,1fr); }
+  .cards.cols-3 { grid-template-columns:repeat(3,1fr); }
+  .cards.cols-4 { grid-template-columns:repeat(4,1fr); }
+
+  .card {
+    background:var(--bg2);
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    padding:18px;
+    transition:border-color 0.2s, transform 0.2s;
+  }
+
+  .card:hover {
+    border-color:rgba(210,168,255,0.35);
+    transform:translateY(-2px);
+  }
+
+  .card-icon {
+    font-size:22px;
+    margin-bottom:10px;
+  }
+
+  .card-title {
+    font-size:13px;
+    font-weight:600;
+    color:var(--text);
+    margin-bottom:5px;
+  }
+
+  .card-text {
+    font-size:12px;
+    color:var(--text2);
+    line-height:1.5;
+  }
+
+  /* ─── CODE BLOCKS ─────────────────────────────────────────── */
+  .code-block {
+    background:var(--bg2);
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    overflow:hidden;
+    margin:16px 0;
+  }
+
+  .code-header {
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    padding:10px 16px;
+    background:var(--bg3);
+    border-bottom:1px solid var(--border);
+  }
+
+  .code-lang {
+    font-size:11px;
+    font-weight:600;
+    color:var(--text3);
+    text-transform:uppercase;
+    letter-spacing:0.5px;
+  }
+
+  .code-dots {
+    display:flex;
+    gap:5px;
+  }
+
+  .code-dots span {
+    width:10px;
+    height:10px;
+    border-radius:50%;
+  }
+
+  .code-dots .dot-r { background:#f78166; }
+  .code-dots .dot-y { background:#e3b341; }
+  .code-dots .dot-g { background:#3fb950; }
+
+  .code-body {
+    padding:18px;
+    font-family:'JetBrains Mono',monospace;
+    font-size:13px;
+    line-height:1.7;
+    color:#e6edf3;
+    overflow-x:auto;
+    white-space:pre;
+  }
+
+  .code-body::-webkit-scrollbar { height:4px; }
+  .code-body::-webkit-scrollbar-thumb { background:var(--border); border-radius:2px; }
+
+  /* Syntax highlight classes */
+  .kw  { color:#ff7b72; }
+  .str { color:#a5d6ff; }
+  .cm  { color:var(--text3); font-style:italic; }
+  .fn  { color:#d2a8ff; }
+  .num { color:#f2cc60; }
+  .var { color:#ffa657; }
+  .op  { color:#79c0ff; }
+  .key { color:#58a6ff; }
+
+  /* ─── INFO / WARN / OK BOXES ─────────────────────────────── */
+  .info-box, .warn-box, .ok-box, .err-box {
+    display:flex;
+    gap:12px;
+    padding:14px 16px;
+    border-radius:var(--radius-sm);
+    margin:14px 0;
+    font-size:13px;
+    line-height:1.6;
+  }
+
+  .info-box {
+    background:rgba(88,166,255,0.07);
+    border:1px solid rgba(88,166,255,0.2);
+  }
+
+  .warn-box {
+    background:rgba(227,179,65,0.07);
+    border:1px solid rgba(227,179,65,0.25);
+  }
+
+  .ok-box {
+    background:rgba(63,185,80,0.07);
+    border:1px solid rgba(63,185,80,0.2);
+  }
+
+  .err-box {
+    background:rgba(247,129,102,0.07);
+    border:1px solid rgba(247,129,102,0.2);
+  }
+
+  .box-icon { font-size:16px; flex-shrink:0; margin-top:1px; }
+  .box-text { color:var(--text2); }
+  .box-text strong { color:var(--text); }
+
+  /* ─── SECTION HEADINGS ───────────────────────────────────── */
+  .section-title {
+    font-size:16px;
+    font-weight:600;
+    color:var(--text);
+    margin:28px 0 12px;
+    display:flex;
+    align-items:center;
+    gap:8px;
+  }
+
+  .section-title::after {
+    content:'';
+    flex:1;
+    height:1px;
+    background:var(--border);
+  }
+
+  /* ─── DIRECTORY TREE ─────────────────────────────────────── */
+  .directory-tree {
+    background:var(--bg2);
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    padding:18px 20px;
+    font-family:'JetBrains Mono',monospace;
+    font-size:12.5px;
+    line-height:1.8;
+    margin:16px 0;
+    overflow-x:auto;
+  }
+
+  .dir-line { display:flex; align-items:baseline; gap:6px; white-space:nowrap; }
+  .dir-indent-1 { padding-left:20px; }
+  .dir-indent-2 { padding-left:40px; }
+  .dir-indent-3 { padding-left:60px; }
+  .dir-icon { font-size:13px; flex-shrink:0; }
+  .dir-name { color:var(--accent2); }
+  .dir-name.dir { color:var(--accent); }
+  .dir-highlight { color:var(--accent3); font-weight:600; }
+  .dir-comment { color:var(--text3); font-style:italic; font-size:11.5px; }
+  .dir-tree-char { color:var(--text3); }
+
+  /* ─── TABLES ──────────────────────────────────────────────── */
+  .event-table {
+    width:100%;
+    border-collapse:collapse;
+    margin:16px 0;
+    font-size:13px;
+  }
+
+  .event-table th {
+    background:var(--bg3);
+    color:var(--text2);
+    font-weight:600;
+    font-size:11px;
+    text-transform:uppercase;
+    letter-spacing:0.5px;
+    padding:10px 14px;
+    text-align:left;
+    border-bottom:1px solid var(--border);
+  }
+
+  .event-table td {
+    padding:10px 14px;
+    border-bottom:1px solid rgba(210,168,255,0.06);
+    color:var(--text2);
+    vertical-align:top;
+    line-height:1.5;
+  }
+
+  .event-table tr:last-child td { border-bottom:none; }
+  .event-table tr:hover td { background:rgba(255,255,255,0.02); }
+  .event-table td:first-child { color:var(--accent2); font-family:'JetBrains Mono',monospace; font-size:12px; }
+
+  .tag {
+    display:inline-block;
+    padding:2px 8px;
+    border-radius:4px;
+    font-size:11px;
+    font-weight:600;
+    font-family:'JetBrains Mono',monospace;
+  }
+
+  .tag-green { background:rgba(63,185,80,0.15); color:var(--accent3); }
+  .tag-blue  { background:rgba(88,166,255,0.15); color:var(--accent2); }
+  .tag-purple{ background:rgba(210,168,255,0.15); color:var(--accent); }
+  .tag-red   { background:rgba(247,129,102,0.15); color:var(--accent4); }
+  .tag-yellow{ background:rgba(227,179,65,0.15); color:var(--accent5); }
+
+  /* ─── ARCHITECTURE DIAGRAM ───────────────────────────────── */
+  .arch-diagram {
+    background:var(--bg2);
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    padding:24px;
+    margin:16px 0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    gap:0;
+    flex-wrap:wrap;
+    row-gap:16px;
+  }
+
+  .arch-box {
+    background:var(--bg3);
+    border:1px solid var(--border);
+    border-radius:var(--radius-sm);
+    padding:12px 18px;
+    text-align:center;
+    min-width:120px;
+  }
+
+  .arch-box-title {
+    font-size:12px;
+    font-weight:600;
+    color:var(--text);
+    margin-bottom:3px;
+  }
+
+  .arch-box-sub {
+    font-size:10px;
+    color:var(--text3);
+    font-family:'JetBrains Mono',monospace;
+  }
+
+  .arch-box.primary { border-color:rgba(210,168,255,0.4); }
+  .arch-box.secondary { border-color:rgba(88,166,255,0.4); }
+  .arch-box.tertiary { border-color:rgba(63,185,80,0.4); }
+
+  .arch-arrow {
+    font-size:18px;
+    color:var(--text3);
+    padding:0 8px;
+    flex-shrink:0;
+  }
+
+  /* ─── STEP LIST ───────────────────────────────────────────── */
+  .step-list {
+    list-style:none;
+    margin:16px 0;
+  }
+
+  .step-item {
+    display:flex;
+    gap:14px;
+    padding:14px 0;
+    border-bottom:1px solid rgba(210,168,255,0.06);
+  }
+
+  .step-item:last-child { border-bottom:none; }
+
+  .step-num {
+    width:26px;
+    height:26px;
+    border-radius:50%;
+    background:linear-gradient(135deg,rgba(210,168,255,0.2),rgba(88,166,255,0.2));
+    border:1px solid var(--border);
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    font-size:11px;
+    font-weight:700;
+    color:var(--accent);
+    flex-shrink:0;
+    margin-top:1px;
+  }
+
+  .step-content { flex:1; }
+  .step-title { font-size:13px; font-weight:600; color:var(--text); margin-bottom:4px; }
+  .step-desc { font-size:12px; color:var(--text2); line-height:1.6; }
+
+  /* ─── DO / DON'T TABLE ───────────────────────────────────── */
+  .dos-donts {
+    display:grid;
+    grid-template-columns:1fr 1fr;
+    gap:16px;
+    margin:16px 0;
+  }
+
+  .dos-col, .donts-col {
+    background:var(--bg2);
+    border:1px solid var(--border);
+    border-radius:var(--radius);
+    overflow:hidden;
+  }
+
+  .dos-col { border-top:2px solid var(--accent3); }
+  .donts-col { border-top:2px solid var(--accent4); }
+
+  .col-header {
+    padding:12px 16px;
+    font-size:12px;
+    font-weight:700;
+    letter-spacing:0.5px;
+    text-transform:uppercase;
+    background:var(--bg3);
+    border-bottom:1px solid var(--border);
+  }
+
+  .dos-col .col-header { color:var(--accent3); }
+  .donts-col .col-header { color:var(--accent4); }
+
+  .col-list { list-style:none; padding:12px 16px; }
+
+  .col-list li {
+    font-size:12.5px;
+    color:var(--text2);
+    padding:6px 0;
+    border-bottom:1px solid rgba(255,255,255,0.03);
+    display:flex;
+    gap:8px;
+    align-items:flex-start;
+    line-height:1.5;
+  }
+
+  .col-list li:last-child { border-bottom:none; }
+  .col-list li .li-icon { flex-shrink:0; margin-top:1px; }
+
+  /* ─── INLINE CODE ─────────────────────────────────────────── */
+  code {
+    font-family:'JetBrains Mono',monospace;
+    font-size:12px;
+    background:rgba(210,168,255,0.1);
+    color:var(--accent);
+    padding:2px 6px;
+    border-radius:4px;
+  }
+
+  /* ─── NAVIGATION BUTTONS ─────────────────────────────────── */
+  .lesson-nav {
+    display:flex;
+    align-items:center;
+    gap:10px;
+    margin-top:40px;
+    padding-top:24px;
+    border-top:1px solid var(--border);
+  }
+
+  .complete-btn {
+    padding:9px 20px;
+    border-radius:var(--radius-sm);
+    font-size:13px;
+    font-weight:600;
+    cursor:pointer;
+    border:none;
+    transition:all 0.2s;
+    display:flex;
+    align-items:center;
+    gap:6px;
+  }
+
+  .complete-btn.primary {
+    background:linear-gradient(135deg,var(--accent),var(--accent2));
+    color:#0d1117;
+  }
+
+  .complete-btn.primary:hover { opacity:0.88; transform:translateY(-1px); }
+
+  .complete-btn.secondary {
+    background:var(--bg3);
+    color:var(--text2);
+    border:1px solid var(--border);
+  }
+
+  .complete-btn.secondary:hover { border-color:var(--accent); color:var(--accent); }
+
+  .complete-btn.done {
+    background:rgba(63,185,80,0.15);
+    color:var(--accent3);
+    border:1px solid rgba(63,185,80,0.3);
+  }
+
+  .spacer { flex:1; }
+
+  /* ─── RESPONSIVE ──────────────────────────────────────────── */
+  @media(max-width:768px) {
+    .sidebar { width:220px; min-width:220px; }
+    .lesson { padding:24px 20px 40px; }
+    .cards.cols-3, .cards.cols-4 { grid-template-columns:1fr 1fr; }
+    .dos-donts { grid-template-columns:1fr; }
+  }
+</style>
+</head>
+<body>
+
+<!-- ─── SIDEBAR ─────────────────────────────────────────────── -->
+<aside class="sidebar">
+  <div class="sidebar-header">
+    <div class="sidebar-logo">
+      <div class="logo-icon">F</div>
+      <div>
+        <div class="sidebar-title">FluidMCP</div>
+        <div class="sidebar-subtitle">Feature Tutorial</div>
+      </div>
+    </div>
+    <div class="sidebar-progress">
+      <div class="progress-label">
+        <span>Progress</span>
+        <span id="prog-label">0 / 8</span>
+      </div>
+      <div class="progress-bar">
+        <div class="progress-fill" id="prog-fill" style="width:0%"></div>
+      </div>
+    </div>
+  </div>
+  <ul class="nav-list" id="nav-list"></ul>
+</aside>
+
+<!-- ─── MAIN ─────────────────────────────────────────────────── -->
+<main class="main" id="main"></main>
+
+<script>
+/* ─────────────────────────────────────────────────────────────
+   LESSONS DATA
+   ───────────────────────────────────────────────────────────── */
+const lessons = [
+
+/* ═══════════════════════════════════════════════════════ L1 */
+{
+  id:1,
+  title:`What is <code>fmcp serve</code>?`,
+  sub:`A persistent FastAPI gateway for dynamic MCP server management with MongoDB state persistence.`,
+  content:`
+<div class="section-title">&#x1F4A1; Command Overview</div>
+<p style="color:var(--text2);font-size:14px;line-height:1.7;margin-bottom:16px;">
+  <code>fmcp serve</code> starts a long-running <strong>FastAPI gateway</strong> on port <strong>8099</strong> that manages MCP servers
+  dynamically through a REST API. Unlike <code>fmcp run</code>, which blocks the terminal and bundles servers from a static config file,
+  <code>fmcp serve</code> stays alive and lets you add, start, stop, and inspect servers at runtime via HTTP calls.
+</p>
+
+<div class="cards cols-2">
+  <div class="card">
+    <div class="card-icon">&#x1F6AB;</div>
+    <div class="card-title">fmcp run &mdash; Old approach</div>
+    <div class="card-text">Reads a config file once, starts all servers, then <strong>blocks the process</strong>. Cannot add servers at runtime. No REST API. No state persistence.</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x2705;</div>
+    <div class="card-title">fmcp serve &mdash; New approach</div>
+    <div class="card-text">Starts a <strong>persistent gateway</strong>. Servers are added via REST API. State stored in MongoDB. Survives restarts. Deployable to Railway / Docker.</div>
+  </div>
+</div>
+
+<div class="section-title">&#x1F3D7;&#xFE0F; Architecture Overview</div>
+
+<div class="arch-diagram">
+  <div class="arch-box">
+    <div class="arch-box-title">CLI / REST Client</div>
+    <div class="arch-box-sub">curl / your app</div>
+  </div>
+  <div class="arch-arrow">&#x2192;</div>
+  <div class="arch-box primary">
+    <div class="arch-box-title">FastAPI Gateway</div>
+    <div class="arch-box-sub">port 8099</div>
+  </div>
+  <div class="arch-arrow">&#x21C4;</div>
+  <div class="arch-box secondary">
+    <div class="arch-box-title">ServerManager</div>
+    <div class="arch-box-sub">process lifecycle</div>
+  </div>
+  <div class="arch-arrow">&#x2192;</div>
+  <div class="arch-box tertiary">
+    <div class="arch-box-title">MongoDB</div>
+    <div class="arch-box-sub">state persistence</div>
+  </div>
+</div>
+
+<div class="info-box">
+  <span class="box-icon">&#x2139;&#xFE0F;</span>
+  <div class="box-text">
+    <strong>How the flow works:</strong> A REST client sends a <code>POST /api/servers</code> request.
+    The FastAPI gateway saves the config to MongoDB via <code>DatabaseManager</code>, then the
+    <code>ServerManager</code> spawns the actual MCP server subprocess. On restart, all server
+    configs are reloaded from MongoDB automatically.
+  </div>
+</div>
+
+<div class="section-title">&#x2728; Key Benefits</div>
+<div class="cards cols-4">
+  <div class="card">
+    <div class="card-icon">&#x1F504;</div>
+    <div class="card-title">Persistent State</div>
+    <div class="card-text">Server configs survive container restarts via MongoDB</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F512;</div>
+    <div class="card-title">Bearer Token Auth</div>
+    <div class="card-text">Secure every endpoint with timing-safe token validation</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F680;</div>
+    <div class="card-title">Railway Ready</div>
+    <div class="card-text">Production Dockerfile included, auto-detects PORT env var</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F527;</div>
+    <div class="card-title">Dynamic Mgmt</div>
+    <div class="card-text">Add / remove / restart servers with a single HTTP call</div>
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L2 */
+{
+  id:2,
+  title:`Directory Structure`,
+  sub:`Every file involved in the serve command — what it is, what it does, and what to look at first.`,
+  content:`
+<div class="section-title">&#x1F4C1; Relevant File Tree</div>
+
+<div class="directory-tree">
+<div class="dir-line"><span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">fluidmcp/</span></div>
+<div class="dir-line dir-indent-1"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">cli/</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">cli.py</span>           <span class="dir-comment"># CLI argument parser &mdash; serve command entry point</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">server.py</span>        <span class="dir-comment"># FastAPI app creation, startup, connect_with_retry()</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">auth.py</span>          <span class="dir-comment"># Bearer token auth: verify_token(), secrets.compare_digest()</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">api/</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">management.py</span>    <span class="dir-comment"># All REST API route handlers (40+ endpoints)</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">inspector.py</span>     <span class="dir-comment"># MCP inspector WebSocket sessions</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">models/</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">api.py</span>           <span class="dir-comment"># Pydantic request/response models</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">repositories/</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">database.py</span>      <span class="dir-comment"># MongoDB async driver, DatabaseManager, collections setup</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">memory.py</span>        <span class="dir-comment"># In-memory fallback backend (dev/testing)</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">base.py</span>          <span class="dir-comment"># PersistenceBackend abstract interface</span></div>
+<div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">services/</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">server_manager.py</span> <span class="dir-comment"># MCP server process lifecycle, MCPHealthMonitor</span></div>
+<div class="dir-line dir-indent-1"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">Dockerfile</span>       <span class="dir-comment"># Production container (Railway deployment)</span></div>
+</div>
+
+<div class="section-title">&#x1F4CB; Component Relationship</div>
+<table class="event-table">
+  <thead>
+    <tr>
+      <th>File</th>
+      <th>Purpose</th>
+      <th>Key Functions / Classes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>cli.py</td>
+      <td>Parses <code>fmcp serve</code> sub-command and dispatches to <code>server.run()</code></td>
+      <td><code>serve_command()</code></td>
+    </tr>
+    <tr>
+      <td>server.py</td>
+      <td>FastAPI app factory, MongoDB retry logic, graceful shutdown</td>
+      <td><code>create_app()</code>, <code>connect_with_retry()</code>, <code>main()</code>, <code>run()</code></td>
+    </tr>
+    <tr>
+      <td>auth.py</td>
+      <td>Bearer token validation; used as FastAPI dependency on every protected route</td>
+      <td><code>verify_token()</code>, <code>get_token()</code>, <code>_validate_bearer_token()</code></td>
+    </tr>
+    <tr>
+      <td>api/management.py</td>
+      <td>All REST route handlers — servers, LLM models, chat completions, image gen</td>
+      <td><code>router</code>, 40+ endpoint functions</td>
+    </tr>
+    <tr>
+      <td>repositories/database.py</td>
+      <td>Async MongoDB driver wrapper; creates collections &amp; indexes on first connect</td>
+      <td><code>DatabaseManager</code>, <code>init_db()</code>, <code>connect()</code></td>
+    </tr>
+    <tr>
+      <td>repositories/memory.py</td>
+      <td>Dict-backed in-memory store; implements same <code>PersistenceBackend</code> interface</td>
+      <td><code>InMemoryBackend</code></td>
+    </tr>
+    <tr>
+      <td>services/server_manager.py</td>
+      <td>Spawns and tracks MCP server subprocesses; auto-restarts on crash</td>
+      <td><code>ServerManager</code>, <code>MCPHealthMonitor</code></td>
+    </tr>
+    <tr>
+      <td>Dockerfile</td>
+      <td>Production image — builds frontend, installs dependencies, runs <code>fmcp serve</code></td>
+      <td>CMD, HEALTHCHECK, ENV defaults</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="ok-box">
+  <span class="box-icon">&#x1F50D;</span>
+  <div class="box-text">
+    <strong>Where to start reading:</strong> Open <code>server.py</code> first — it wires everything together.
+    Trace <code>main()</code> &#x2192; <code>connect_with_retry()</code> &#x2192; <code>create_app()</code> to understand the full startup sequence.
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L3 */
+{
+  id:3,
+  title:`CLI Arguments & Configuration`,
+  sub:`Every flag accepted by fmcp serve, with dev vs production comparison.`,
+  content:`
+<div class="section-title">&#x1F6A9; Basic Usage</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Minimal development start</span>
+fmcp serve --in-memory --allow-insecure
+
+<span class="cm"># Production start with MongoDB and auth</span>
+fmcp serve \
+  --host 0.0.0.0 \
+  --port 8099 \
+  --secure \
+  --mongodb-uri mongodb+srv://user:pass@cluster.net/fluidmcp \
+  --database fluidmcp \
+  --require-persistence</div>
+</div>
+
+<div class="section-title">&#x1F4CB; All Flags Reference</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Flag</th><th>Default</th><th>Env Override</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--host</td>
+      <td><code>0.0.0.0</code></td>
+      <td>&mdash;</td>
+      <td>Bind address for the Uvicorn server</td>
+    </tr>
+    <tr>
+      <td>--port</td>
+      <td><code>8099</code></td>
+      <td><code>PORT</code></td>
+      <td>TCP port to listen on</td>
+    </tr>
+    <tr>
+      <td>--mongodb-uri</td>
+      <td><code>mongodb://localhost:27017</code></td>
+      <td><code>MONGODB_URI</code></td>
+      <td>Full MongoDB connection string</td>
+    </tr>
+    <tr>
+      <td>--database</td>
+      <td><code>fluidmcp</code></td>
+      <td><code>FMCP_DATABASE</code></td>
+      <td>MongoDB database name</td>
+    </tr>
+    <tr>
+      <td>--secure</td>
+      <td>off</td>
+      <td><code>FMCP_SECURE_MODE=true</code></td>
+      <td>Enable bearer token authentication on all endpoints</td>
+    </tr>
+    <tr>
+      <td>--token</td>
+      <td>auto-generated</td>
+      <td><code>FMCP_BEARER_TOKEN</code></td>
+      <td>Supply a specific bearer token instead of generating one</td>
+    </tr>
+    <tr>
+      <td>--allow-insecure</td>
+      <td>off</td>
+      <td>&mdash;</td>
+      <td>Allow HTTP without auth (development only)</td>
+    </tr>
+    <tr>
+      <td>--require-persistence</td>
+      <td>off</td>
+      <td>&mdash;</td>
+      <td>Exit immediately if MongoDB is unreachable (fail-fast)</td>
+    </tr>
+    <tr>
+      <td>--persistence-mode</td>
+      <td><code>mongodb</code></td>
+      <td>&mdash;</td>
+      <td>Choose <code>mongodb</code> or <code>memory</code> backend</td>
+    </tr>
+    <tr>
+      <td>--in-memory</td>
+      <td>off</td>
+      <td>&mdash;</td>
+      <td>Shorthand for <code>--persistence-mode memory</code></td>
+    </tr>
+    <tr>
+      <td>--allowed-origins</td>
+      <td>localhost only</td>
+      <td><code>FMCP_ALLOWED_ORIGINS</code></td>
+      <td>Comma-separated CORS origins (e.g. <code>https://app.example.com</code>)</td>
+    </tr>
+    <tr>
+      <td>--allow-all-origins</td>
+      <td>off</td>
+      <td>&mdash;</td>
+      <td>Allow all CORS origins with <code>*</code> — DEV ONLY, security risk</td>
+    </tr>
+    <tr>
+      <td>--verbose</td>
+      <td>off</td>
+      <td>&mdash;</td>
+      <td>Enable debug-level logging output</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F504; Dev vs Production Comparison</div>
+<div class="cards cols-2">
+  <div class="card">
+    <div class="card-icon">&#x1F6E0;&#xFE0F;</div>
+    <div class="card-title">Development Mode</div>
+    <div style="margin-top:10px;">
+      <div class="code-block" style="margin:0">
+        <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+        <div class="code-body">fmcp serve \
+  --in-memory \
+  --allow-insecure \
+  --allow-all-origins \
+  --port 8099</div>
+      </div>
+    </div>
+    <div class="card-text" style="margin-top:8px;">No MongoDB required. No auth. Data lost on restart. Perfect for local testing.</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F3ED;</div>
+    <div class="card-title">Production Mode</div>
+    <div style="margin-top:10px;">
+      <div class="code-block" style="margin:0">
+        <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+        <div class="code-body">fmcp serve \
+  --secure \
+  --mongodb-uri \${MONGODB_URI} \
+  --require-persistence \
+  --allowed-origins \
+  "https://app.example.com"</div>
+      </div>
+    </div>
+    <div class="card-text" style="margin-top:8px;">Auth enforced. Fails fast if MongoDB down. CORS locked down. Always use this in Railway/Docker.</div>
+  </div>
+</div>
+
+<div class="warn-box">
+  <span class="box-icon">&#x26A0;&#xFE0F;</span>
+  <div class="box-text">
+    <strong>Never use <code>--allow-insecure</code> or <code>--allow-all-origins</code> in production.</strong>
+    These flags disable authentication and open CORS to every origin respectively — they exist solely for local developer convenience.
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L4 */
+{
+  id:4,
+  title:`MongoDB Connection Setup`,
+  sub:`Connection pooling, timeouts, collections, indexes, and the retry logic inside server.py.`,
+  content:`
+<div class="section-title">&#x1F50C; Environment Variables</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Variable</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MONGODB_URI</td>
+      <td><code>mongodb://localhost:27017</code></td>
+      <td>Full MongoDB connection string, including credentials</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_SERVER_TIMEOUT</td>
+      <td><code>30000</code> ms</td>
+      <td>Max time to find a reachable MongoDB server</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_CONNECT_TIMEOUT</td>
+      <td><code>10000</code> ms</td>
+      <td>Timeout for the initial TCP connection</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_SOCKET_TIMEOUT</td>
+      <td><code>45000</code> ms</td>
+      <td>Timeout for individual socket reads/writes</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_MAX_POOL_SIZE</td>
+      <td><code>50</code></td>
+      <td>Maximum connections kept in the connection pool</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_MIN_POOL_SIZE</td>
+      <td><code>10</code></td>
+      <td>Minimum connections maintained in the pool</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_ALLOW_INVALID_CERTS</td>
+      <td><code>false</code></td>
+      <td>Disable TLS cert validation — DEV ONLY, MitM risk</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F501; Retry Logic &mdash; <code>connect_with_retry()</code> in server.py</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">python</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># server.py — simplified view of the retry loop</span>
+<span class="kw">async def</span> <span class="fn">connect_with_retry</span>(db_manager, max_retries=<span class="num">3</span>, require_persistence=<span class="kw">False</span>):
+    <span class="kw">for</span> attempt <span class="kw">in</span> <span class="fn">range</span>(<span class="num">1</span>, max_retries + <span class="num">1</span>):
+        db_connected = <span class="kw">await</span> db_manager.<span class="fn">init_db</span>()
+        <span class="kw">if</span> db_connected:
+            <span class="kw">return True</span>
+
+        wait_time = <span class="num">2</span> ** attempt   <span class="cm"># Exponential backoff: 2s &#x2192; 4s &#x2192; 8s</span>
+        <span class="kw">await</span> asyncio.<span class="fn">sleep</span>(wait_time)
+
+    <span class="kw">if</span> require_persistence:
+        <span class="kw">raise</span> <span class="fn">RuntimeError</span>(<span class="str">"MongoDB required but unavailable"</span>)
+    <span class="kw">return False</span>   <span class="cm"># Degrade gracefully (warn, continue in-memory)</span></div>
+</div>
+
+<div class="info-box">
+  <span class="box-icon">&#x23F1;&#xFE0F;</span>
+  <div class="box-text">
+    The Dockerfile <code>HEALTHCHECK</code> uses a 40-second start period specifically to allow the full
+    retry sequence (2 + 4 + 8 = 14 s of waits) plus MongoDB DNS/startup time before Railway marks the container unhealthy.
+  </div>
+</div>
+
+<div class="section-title">&#x1F4BE; MongoDB Collections</div>
+<p style="color:var(--text2);font-size:13px;margin-bottom:12px;">All collections are created automatically by <code>DatabaseManager.init_db()</code> on first connect:</p>
+<table class="event-table">
+  <thead>
+    <tr><th>Collection</th><th>Index</th><th>Purpose</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>fluidmcp_servers</td>
+      <td>Unique on <code>id</code></td>
+      <td>Server configs — command, args, env, metadata</td>
+    </tr>
+    <tr>
+      <td>fluidmcp_server_instances</td>
+      <td>Index on <code>server_id</code></td>
+      <td>Runtime instance state — PID, start time, status</td>
+    </tr>
+    <tr>
+      <td>fluidmcp_server_logs</td>
+      <td>Capped collection 100 MB</td>
+      <td>Stdout / stderr output from running MCP servers</td>
+    </tr>
+    <tr>
+      <td>fluidmcp_llm_models</td>
+      <td>Unique on <code>model_id</code></td>
+      <td>Registered LLM model configurations (Replicate, vLLM, etc.)</td>
+    </tr>
+    <tr>
+      <td>fluidmcp_crash_events</td>
+      <td>TTL 30 days</td>
+      <td>Crash reports from server subprocess exits</td>
+    </tr>
+    <tr>
+      <td>fluidmcp_audit_log</td>
+      <td>&mdash;</td>
+      <td>API call audit trail (who did what, when)</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F9EA; In-Memory Fallback</div>
+<div class="cards cols-2">
+  <div class="card">
+    <div class="card-icon">&#x1F4BE;</div>
+    <div class="card-title">Use MongoDB when&hellip;</div>
+    <div class="card-text">Running in production, Railway/Docker, or any environment where server configs must survive restarts.</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x26A1;</div>
+    <div class="card-title">Use --in-memory when&hellip;</div>
+    <div class="card-text">Local development, CI tests, or quick demos where data loss on restart is acceptable.</div>
+  </div>
+</div>
+
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Start with in-memory backend (no MongoDB needed)</span>
+fmcp serve --in-memory --port 8099
+
+<span class="cm"># Equivalent long form</span>
+fmcp serve --persistence-mode memory --port 8099</div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L5 */
+{
+  id:5,
+  title:`Bearer Token Authentication`,
+  sub:`How tokens are generated, stored, validated, and why Railway deployments require a fixed token.`,
+  content:`
+<div class="section-title">&#x1F511; How Authentication Works</div>
+<div class="cards cols-3">
+  <div class="card">
+    <div class="card-icon">&#x1F3AF;</div>
+    <div class="card-title">1. Token Source</div>
+    <div class="card-text">Token comes from: <code>--token</code> flag &#x2192; <code>FMCP_BEARER_TOKEN</code> env &#x2192; auto-generated via <code>secrets.token_urlsafe(32)</code></div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F4C2;</div>
+    <div class="card-title">2. Token Storage</div>
+    <div class="card-text">Auto-generated tokens are saved to <code>~/.fmcp/tokens/current_token.txt</code> with <code>chmod 600</code> (owner read/write only)</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F510;</div>
+    <div class="card-title">3. Validation</div>
+    <div class="card-text"><code>auth.py</code> checks <code>Authorization: Bearer &lt;token&gt;</code> header using <code>secrets.compare_digest()</code> for timing-safe comparison</div>
+  </div>
+</div>
+
+<div class="section-title">&#x1F4CE; The auth.py Flow</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">python</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># auth.py — simplified</span>
+<span class="kw">def</span> <span class="fn">verify_token</span>(credentials = <span class="fn">Depends</span>(security)) -> <span class="kw">None</span>:
+    bearer_token = os.environ.<span class="fn">get</span>(<span class="str">"FMCP_BEARER_TOKEN"</span>)
+    secure_mode  = os.environ.<span class="fn">get</span>(<span class="str">"FMCP_SECURE_MODE"</span>) == <span class="str">"true"</span>
+
+    <span class="kw">if not</span> secure_mode:
+        <span class="kw">return None</span>               <span class="cm"># Public access when auth is off</span>
+
+    <span class="kw">if not</span> credentials <span class="kw">or</span> credentials.scheme.lower() != <span class="str">"bearer"</span>:
+        <span class="kw">raise</span> <span class="fn">HTTPException</span>(<span class="num">401</span>, <span class="str">"Invalid or missing authorization token"</span>)
+
+    <span class="cm"># Timing-safe comparison prevents timing oracle attacks</span>
+    <span class="kw">if not</span> secrets.<span class="fn">compare_digest</span>(credentials.credentials, bearer_token):
+        <span class="kw">raise</span> <span class="fn">HTTPException</span>(<span class="num">401</span>, <span class="str">"Invalid or missing authorization token"</span>)</div>
+</div>
+
+<div class="warn-box">
+  <span class="box-icon">&#x26A0;&#xFE0F;</span>
+  <div class="box-text">
+    <strong>Critical for Railway:</strong> Railway containers are <em>ephemeral</em>. Every restart destroys the filesystem.
+    If you rely on an auto-generated token, <strong>it regenerates on every deploy/restart</strong>, breaking all API clients.
+    <br><br>
+    <strong>Fix:</strong> Generate once with <code>openssl rand -hex 32</code> and set it as <code>FMCP_BEARER_TOKEN</code>
+    in the Railway environment variables dashboard.
+  </div>
+</div>
+
+<div class="section-title">&#x1F527; Token Management Commands</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Show current token (reads ~/.fmcp/tokens/current_token.txt)</span>
+fmcp token show
+
+<span class="cm"># Generate a new token and save it</span>
+fmcp token regenerate
+
+<span class="cm"># Remove saved token</span>
+fmcp token clear
+
+<span class="cm"># Generate a production token manually (recommended for Railway)</span>
+openssl rand -hex 32</div>
+</div>
+
+<div class="section-title">&#x1F4E1; Using the Token in API Calls</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Every protected endpoint requires Authorization header</span>
+curl -X GET http://localhost:8099/api/servers \
+  -H <span class="str">"Authorization: Bearer YOUR_TOKEN_HERE"</span>
+
+<span class="cm"># /health is intentionally public (no auth required)</span>
+curl http://localhost:8099/health</div>
+</div>
+
+<div class="section-title">&#x1F512; Security Properties</div>
+<div class="cards cols-2">
+  <div class="card">
+    <div class="card-icon">&#x23F1;&#xFE0F;</div>
+    <div class="card-title">Timing-Safe Comparison</div>
+    <div class="card-text"><code>secrets.compare_digest()</code> takes the same time whether the token matches or not, preventing timing oracle attacks that can reconstruct tokens bit-by-bit.</div>
+  </div>
+  <div class="card">
+    <div class="card-icon">&#x1F4C1;</div>
+    <div class="card-title">Restrictive File Permissions</div>
+    <div class="card-text">Saved token files use <code>chmod 600</code> (read/write for owner only). The parent <code>~/.fmcp</code> directory uses <code>chmod 700</code>.</div>
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L6 */
+{
+  id:6,
+  title:`REST API Endpoints`,
+  sub:`Every endpoint group with curl examples — from adding a server to executing a tool.`,
+  content:`
+<div class="section-title">&#x1F5C2;&#xFE0F; Server Management Endpoints</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Method + Path</th><th>Auth</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>POST /api/servers</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Register a new MCP server configuration</td>
+    </tr>
+    <tr>
+      <td>GET /api/servers</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>List all registered servers and their status</td>
+    </tr>
+    <tr>
+      <td>GET /api/servers/{id}</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Get a single server&apos;s full configuration</td>
+    </tr>
+    <tr>
+      <td>POST /api/servers/{id}/start</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Spawn the MCP server subprocess</td>
+    </tr>
+    <tr>
+      <td>POST /api/servers/{id}/stop</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Gracefully terminate the server process</td>
+    </tr>
+    <tr>
+      <td>POST /api/servers/{id}/restart</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Stop then start the server</td>
+    </tr>
+    <tr>
+      <td>GET /api/servers/{id}/status</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Runtime state — PID, uptime, last exit code</td>
+    </tr>
+    <tr>
+      <td>GET /api/servers/{id}/logs</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Tail stdout/stderr from the server process</td>
+    </tr>
+    <tr>
+      <td>GET /api/servers/{id}/tools</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>List MCP tools exposed by this server</td>
+    </tr>
+    <tr>
+      <td>POST /api/servers/{id}/tools/{tool}/run</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Execute an MCP tool with provided arguments</td>
+    </tr>
+    <tr>
+      <td>DELETE /api/servers/{id}</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Remove server config from MongoDB</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F916; LLM Model Endpoints</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Method + Path</th><th>Auth</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>POST /api/llm/models</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Register a new LLM model (Replicate, vLLM, Ollama)</td>
+    </tr>
+    <tr>
+      <td>GET /api/llm/models</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>List all registered LLM models</td>
+    </tr>
+    <tr>
+      <td>POST /api/llm/v1/chat/completions</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>OpenAI-compatible chat completion endpoint</td>
+    </tr>
+    <tr>
+      <td>POST /api/llm/v1/generate/image</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Text-to-image generation (Replicate FLUX, etc.)</td>
+    </tr>
+    <tr>
+      <td>POST /api/llm/v1/generate/video</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Text-to-video generation</td>
+    </tr>
+    <tr>
+      <td>GET /api/llm/predictions/{id}</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Poll generation status for async predictions</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F4CA; System Endpoints</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Path</th><th>Auth</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>GET /health</td>
+      <td><span class="tag tag-green">Public</span></td>
+      <td>Health check — DB status, model counts, version. Used by Railway&apos;s HEALTHCHECK</td>
+    </tr>
+    <tr>
+      <td>GET /metrics</td>
+      <td><span class="tag tag-purple">Bearer</span></td>
+      <td>Prometheus metrics — request counts, latencies, uptime, GPU mem</td>
+    </tr>
+    <tr>
+      <td>GET /docs</td>
+      <td><span class="tag tag-green">Public</span></td>
+      <td>Swagger UI — interactive API documentation</td>
+    </tr>
+    <tr>
+      <td>GET /</td>
+      <td><span class="tag tag-green">Public</span></td>
+      <td>Root JSON with links to docs, health, API</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F4BB; Working Example: Add and Start a Filesystem Server</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Step 1: Start fmcp serve (dev mode, no auth)</span>
+fmcp serve --in-memory --allow-insecure &
+
+<span class="cm"># Step 2: Register a server config (no auth header needed in dev mode)</span>
+curl -X POST http://localhost:8099/api/servers \
+  -H <span class="str">"Content-Type: application/json"</span> \
+  -d <span class="str">'{
+    "id": "filesystem",
+    "name": "Filesystem Server",
+    "mcp_config": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": {}
+    }
+  }'</span>
+
+<span class="cm"># Step 3: Start the server subprocess</span>
+curl -X POST http://localhost:8099/api/servers/filesystem/start
+
+<span class="cm"># Step 4: List available MCP tools</span>
+curl http://localhost:8099/api/servers/filesystem/tools
+
+<span class="cm"># Step 5: Execute a tool</span>
+curl -X POST \
+  http://localhost:8099/api/servers/filesystem/tools/list_directory/run \
+  -H <span class="str">"Content-Type: application/json"</span> \
+  -d <span class="str">'{"path": "/tmp"}'</span></div>
+</div>
+
+<div class="ok-box">
+  <span class="box-icon">&#x1F4A1;</span>
+  <div class="box-text">
+    <strong>In production</strong> (with <code>--secure</code>), add <code>-H "Authorization: Bearer YOUR_TOKEN"</code>
+    to every curl call except <code>/health</code>.
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L7 */
+{
+  id:7,
+  title:`Railway Deployment`,
+  sub:`Step-by-step guide to deploying fmcp serve on Railway with MongoDB persistence.`,
+  content:`
+<div class="section-title">&#x1F680; Deployment Steps</div>
+<ul class="step-list">
+  <li class="step-item">
+    <div class="step-num">1</div>
+    <div class="step-content">
+      <div class="step-title">Add MongoDB Service</div>
+      <div class="step-desc">In Railway dashboard: <strong>New &#x2192; Database &#x2192; MongoDB</strong>. Railway auto-provisions a MongoDB instance and injects <code>MONGODB_URI</code> into your service environment.</div>
+    </div>
+  </li>
+  <li class="step-item">
+    <div class="step-num">2</div>
+    <div class="step-content">
+      <div class="step-title">Connect Repository</div>
+      <div class="step-desc">Railway: <strong>New &#x2192; GitHub Repo</strong> &#x2192; select your FluidMCP fork. Railway detects the <code>Dockerfile</code> automatically &mdash; no <code>railway.toml</code> needed.</div>
+    </div>
+  </li>
+  <li class="step-item">
+    <div class="step-num">3</div>
+    <div class="step-content">
+      <div class="step-title">Generate Bearer Token</div>
+      <div class="step-desc">Run this locally once and copy the output:
+        <div class="code-block" style="margin:8px 0 0">
+          <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+          <div class="code-body">openssl rand -hex 32
+<span class="cm"># Example output: a3f9e2c8b1d4...</span></div>
+        </div>
+      </div>
+    </div>
+  </li>
+  <li class="step-item">
+    <div class="step-num">4</div>
+    <div class="step-content">
+      <div class="step-title">Set Environment Variables in Railway</div>
+      <div class="step-desc">In your Railway service settings &#x2192; Variables, add these:</div>
+    </div>
+  </li>
+  <li class="step-item">
+    <div class="step-num">5</div>
+    <div class="step-content">
+      <div class="step-title">Deploy</div>
+      <div class="step-desc">Railway auto-deploys on push to your configured branch. Watch the build logs for the MongoDB connection attempt and health check.</div>
+    </div>
+  </li>
+  <li class="step-item">
+    <div class="step-num">6</div>
+    <div class="step-content">
+      <div class="step-title">Verify</div>
+      <div class="step-desc">Call the public health endpoint (no auth required) to confirm everything is running correctly.</div>
+    </div>
+  </li>
+</ul>
+
+<div class="section-title">&#x1F4CB; Required Environment Variables</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Variable</th><th>Source</th><th>Required?</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MONGODB_URI</td>
+      <td><span class="tag tag-blue">Railway auto</span></td>
+      <td><span class="tag tag-red">Yes</span></td>
+      <td>Auto-injected from the MongoDB service you connected</td>
+    </tr>
+    <tr>
+      <td>FMCP_BEARER_TOKEN</td>
+      <td><span class="tag tag-yellow">Manual</span></td>
+      <td><span class="tag tag-red">Critical</span></td>
+      <td>Must be set manually. Auto-generated token regenerates every restart!</td>
+    </tr>
+    <tr>
+      <td>PORT</td>
+      <td><span class="tag tag-blue">Railway auto</span></td>
+      <td><span class="tag tag-green">Auto</span></td>
+      <td>Railway assigns this; Dockerfile CMD uses <code>\${PORT}</code></td>
+    </tr>
+    <tr>
+      <td>FMCP_ALLOWED_ORIGINS</td>
+      <td><span class="tag tag-yellow">Manual</span></td>
+      <td><span class="tag tag-green">Optional</span></td>
+      <td>Comma-separated CORS origins, e.g. <code>https://app.example.com</code></td>
+    </tr>
+    <tr>
+      <td>FMCP_DATABASE</td>
+      <td><span class="tag tag-yellow">Manual</span></td>
+      <td><span class="tag tag-green">Optional</span></td>
+      <td>MongoDB database name (default: <code>fluidmcp</code>)</td>
+    </tr>
+    <tr>
+      <td>FMCP_MONGODB_SERVER_TIMEOUT</td>
+      <td><span class="tag tag-yellow">Manual</span></td>
+      <td><span class="tag tag-green">Optional</span></td>
+      <td>Server selection timeout in ms (default: 30000)</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F40B; Dockerfile CMD</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">dockerfile</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Dockerfile — final CMD (Railway auto-provides PORT and MONGODB_URI)</span>
+<span class="key">CMD</span> fmcp serve \
+    --host 0.0.0.0 \
+    --port <span class="var">\${PORT}</span> \
+    --secure \
+    --mongodb-uri <span class="var">\${MONGODB_URI}</span> \
+    --database <span class="var">\${FMCP_DATABASE:-fluidmcp}</span> \
+    --require-persistence</div>
+</div>
+
+<div class="section-title">&#x2705; Expected Health Check Response</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm"># Verify after deploy (replace with your Railway public URL)</span>
+curl https://your-app.railway.app/health</div>
+</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">json</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body">{
+  <span class="key">"status"</span>: <span class="str">"healthy"</span>,
+  <span class="key">"timestamp"</span>: <span class="str">"2026-04-08T10:00:00Z"</span>,
+  <span class="key">"database"</span>: {
+    <span class="key">"status"</span>: <span class="str">"connected"</span>,
+    <span class="key">"type"</span>: <span class="str">"DatabaseManager"</span>,
+    <span class="key">"persistence_enabled"</span>: <span class="kw">true</span>
+  },
+  <span class="key">"models"</span>: { <span class="key">"total"</span>: <span class="num">0</span>, <span class="key">"by_type"</span>: { <span class="key">"replicate"</span>: <span class="num">0</span> } },
+  <span class="key">"version"</span>: <span class="str">"2.0.0"</span>
+}</div>
+</div>
+
+<div class="warn-box">
+  <span class="box-icon">&#x26A0;&#xFE0F;</span>
+  <div class="box-text">
+    If <code>database.status</code> is <code>"disconnected"</code> or <code>"error"</code>, check that the MongoDB service
+    is linked in Railway and <code>MONGODB_URI</code> is populated. The overall <code>status</code> will show <code>"degraded"</code>
+    rather than <code>"healthy"</code> when the DB is unreachable.
+  </div>
+</div>
+`
+},
+
+/* ═══════════════════════════════════════════════════════ L8 */
+{
+  id:8,
+  title:`Best Practices & Troubleshooting`,
+  sub:`What to do, what to avoid, and how to diagnose the most common issues.`,
+  content:`
+<div class="section-title">&#x2696;&#xFE0F; Do&apos;s and Don&apos;ts</div>
+<div class="dos-donts">
+  <div class="dos-col">
+    <div class="col-header">&#x2705; Do&apos;s</div>
+    <ul class="col-list">
+      <li><span class="li-icon">&#x1F511;</span> Always set <code>FMCP_BEARER_TOKEN</code> manually in Railway — never rely on auto-generation</li>
+      <li><span class="li-icon">&#x1F4BE;</span> Use <code>--require-persistence</code> in production so crashes are loud and obvious</li>
+      <li><span class="li-icon">&#x2601;&#xFE0F;</span> Use MongoDB Atlas for production (not localhost or Railway-managed for critical data)</li>
+      <li><span class="li-icon">&#x1F512;</span> Generate tokens with <code>openssl rand -hex 32</code> (256-bit entropy)</li>
+      <li><span class="li-icon">&#x1F310;</span> Lock down CORS origins with <code>--allowed-origins</code> to your frontend domain</li>
+      <li><span class="li-icon">&#x1F9EA;</span> Use <code>--in-memory</code> for local dev and CI to avoid needing a real MongoDB</li>
+      <li><span class="li-icon">&#x1F4CA;</span> Monitor <code>/health</code> in your uptime checker — it is public and needs no auth</li>
+    </ul>
+  </div>
+  <div class="donts-col">
+    <div class="col-header">&#x274C; Don&apos;ts</div>
+    <ul class="col-list">
+      <li><span class="li-icon">&#x1F6AB;</span> Never use <code>--allow-insecure</code> in production — it disables all auth</li>
+      <li><span class="li-icon">&#x1F6AB;</span> Don&apos;t expose port 8099 publicly without <code>--secure</code> enabled</li>
+      <li><span class="li-icon">&#x1F6AB;</span> Don&apos;t use <code>--in-memory</code> in production — data is lost on every restart</li>
+      <li><span class="li-icon">&#x1F6AB;</span> Don&apos;t pass tokens on the CLI in production (<code>--token abc</code> appears in process list)</li>
+      <li><span class="li-icon">&#x1F6AB;</span> Don&apos;t set <code>FMCP_MONGODB_ALLOW_INVALID_CERTS=true</code> in production — enables MitM attacks</li>
+      <li><span class="li-icon">&#x1F6AB;</span> Don&apos;t use <code>--allow-all-origins</code> — any website can call your API</li>
+    </ul>
+  </div>
+</div>
+
+<div class="section-title">&#x1F527; Common Issues and Fixes</div>
+<table class="event-table">
+  <thead>
+    <tr><th>Symptom</th><th>Likely Cause</th><th>Fix</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>MongoDB connection failed</td>
+      <td>Wrong URI format or IP not whitelisted</td>
+      <td>Check <code>MONGODB_URI</code> includes credentials. In Atlas, whitelist <code>0.0.0.0/0</code> for Railway (its IPs change)</td>
+    </tr>
+    <tr>
+      <td>HTTP 401 Unauthorized</td>
+      <td>Token mismatch after container restart</td>
+      <td>Set <code>FMCP_BEARER_TOKEN</code> in Railway env vars. Verify with <code>fmcp token show</code> on local</td>
+    </tr>
+    <tr>
+      <td>MCP server not starting</td>
+      <td>Wrong command or missing dependency</td>
+      <td>Check <code>GET /api/servers/{id}/logs</code> for stderr output. Ensure <code>npx</code> / <code>python</code> is in PATH</td>
+    </tr>
+    <tr>
+      <td>Container crash loop on Railway</td>
+      <td>MongoDB unreachable + <code>--require-persistence</code></td>
+      <td>Fix the MongoDB service link in Railway. The crash loop is intentional (fail-fast mode)</td>
+    </tr>
+    <tr>
+      <td>HTTP 500 on protected endpoints</td>
+      <td><code>FMCP_BEARER_TOKEN</code> not set while <code>--secure</code> is on</td>
+      <td>Set <code>FMCP_BEARER_TOKEN</code> env var, or pass <code>--token</code> flag at startup</td>
+    </tr>
+    <tr>
+      <td>CORS error in browser</td>
+      <td>Frontend origin not in allowed list</td>
+      <td>Add your frontend URL to <code>FMCP_ALLOWED_ORIGINS</code> env or <code>--allowed-origins</code> flag</td>
+    </tr>
+    <tr>
+      <td>Tools list is empty</td>
+      <td>Server not started yet</td>
+      <td>Call <code>POST /api/servers/{id}/start</code> first, then wait ~2s for the process to initialize</td>
+    </tr>
+  </tbody>
+</table>
+
+<div class="section-title">&#x1F4CB; Quick Reference Cheatsheet</div>
+<div class="code-block">
+  <div class="code-header"><span class="code-lang">bash</span><div class="code-dots"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div></div>
+  <div class="code-body"><span class="cm">## ─── LOCAL DEV ───────────────────────────────────────</span>
+fmcp serve --in-memory --allow-insecure
+
+<span class="cm">## ─── LOCAL WITH MONGODB ──────────────────────────────</span>
+<span class="kw">export</span> <span class="var">MONGODB_URI</span>=mongodb://localhost:27017
+fmcp serve --secure
+
+<span class="cm">## ─── PRODUCTION LOCALLY ──────────────────────────────</span>
+<span class="kw">export</span> <span class="var">FMCP_BEARER_TOKEN</span>=$(openssl rand -hex 32)
+<span class="kw">export</span> <span class="var">MONGODB_URI</span>=mongodb+srv://user:pass@cluster.net
+fmcp serve --secure --require-persistence
+
+<span class="cm">## ─── TEST AUTH ───────────────────────────────────────</span>
+curl http://localhost:8099/health
+curl -H <span class="str">"Authorization: Bearer \${FMCP_BEARER_TOKEN}"</span> \
+     http://localhost:8099/api/servers
+
+<span class="cm">## ─── ADD + START FIRST SERVER ────────────────────────</span>
+TOKEN=\${FMCP_BEARER_TOKEN}
+curl -X POST http://localhost:8099/api/servers \
+  -H <span class="str">"Authorization: Bearer \${TOKEN}"</span> \
+  -H <span class="str">"Content-Type: application/json"</span> \
+  -d <span class="str">'{"id":"fs","mcp_config":{"command":"npx",
+      "args":["-y","@modelcontextprotocol/server-filesystem","/tmp"],
+      "env":{}}}'</span>
+curl -X POST http://localhost:8099/api/servers/fs/start \
+  -H <span class="str">"Authorization: Bearer \${TOKEN}"</span></div>
+</div>
+
+<div class="ok-box">
+  <span class="box-icon">&#x1F3AF;</span>
+  <div class="box-text">
+    <strong>You have completed the fmcp serve tutorial!</strong>
+    You now understand the full lifecycle: CLI flags &#x2192; MongoDB connection &#x2192; Bearer token auth &#x2192;
+    REST API usage &#x2192; Railway deployment. Open <code>server.py</code> and trace <code>main()</code> for the authoritative implementation.
+  </div>
+</div>
+`
+}
+
+]; /* end lessons array */
+
+/* ─────────────────────────────────────────────────────────────
+   BUILD UI
+   ───────────────────────────────────────────────────────────── */
+const navList = document.getElementById('nav-list');
+const mainEl  = document.getElementById('main');
+let currentIdx = 0;
+
+const NAV_LABELS = [
+  "What is fmcp serve?",
+  "Directory Structure",
+  "CLI Arguments",
+  "MongoDB Setup",
+  "Bearer Token Auth",
+  "REST API Endpoints",
+  "Railway Deployment",
+  "Best Practices"
+];
+
+lessons.forEach((l, i) => {
+  /* --- nav item --- */
+  const li = document.createElement('li');
+  li.className = 'nav-item' + (i === 0 ? ' active' : '');
+  li.dataset.idx = i;
+  li.innerHTML = `
+    <div class="nav-badge">${l.id}</div>
+    <div class="nav-label">${NAV_LABELS[i]}</div>
+  `;
+  li.addEventListener('click', () => showLesson(i));
+  navList.appendChild(li);
+
+  /* --- lesson section --- */
+  const sec = document.createElement('section');
+  sec.className = 'lesson' + (i === 0 ? ' active' : '');
+  sec.id = 'lesson-' + l.id;
+
+  const doneClass = isDone(l.id) ? ' done' : '';
+  const doneText  = isDone(l.id) ? '&#x2713; Completed' : 'Mark Complete';
+
+  sec.innerHTML = `
+    <div class="lesson-badge">Lesson ${l.id} of ${lessons.length}</div>
+    <h1 class="lesson-title">${l.title}</h1>
+    <p class="lesson-subtitle">${l.sub}</p>
+    ${l.content}
+    <div class="lesson-nav">
+      ${i > 0 ? `<button class="complete-btn secondary" onclick="showLesson(${i-1})">&#x2190; Previous</button>` : ''}
+      <div class="spacer"></div>
+      <button class="complete-btn${doneClass}" id="done-btn-${l.id}" onclick="markDone(${l.id}, this)">
+        ${doneText}
+      </button>
+      ${i < lessons.length - 1
+        ? `<button class="complete-btn primary" onclick="showLesson(${i+1})">Next &#x2192;</button>`
+        : `<button class="complete-btn primary" onclick="showLesson(0)">&#x1F3E0; Start Over</button>`
+      }
+    </div>
+  `;
+  mainEl.appendChild(sec);
+});
+
+/* ─────────────────────────────────────────────────────────────
+   NAVIGATION
+   ───────────────────────────────────────────────────────────── */
+function showLesson(idx) {
+  if (idx < 0 || idx >= lessons.length) return;
+
+  /* hide current */
+  document.querySelectorAll('.lesson').forEach(s => s.classList.remove('active'));
+  document.querySelectorAll('.nav-item').forEach(n => n.classList.remove('active'));
+
+  /* show new */
+  document.getElementById('lesson-' + lessons[idx].id).classList.add('active');
+  const navItems = document.querySelectorAll('.nav-item');
+  navItems[idx].classList.add('active');
+
+  currentIdx = idx;
+  mainEl.scrollTop = 0;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   PROGRESS
+   ───────────────────────────────────────────────────────────── */
+function isDone(id) {
+  return localStorage.getItem('fmcp-serve-done-' + id) === '1';
+}
+
+function markDone(id, btn) {
+  const already = isDone(id);
+  if (already) {
+    localStorage.removeItem('fmcp-serve-done-' + id);
+    btn.classList.remove('done');
+    btn.innerHTML = 'Mark Complete';
+  } else {
+    localStorage.setItem('fmcp-serve-done-' + id, '1');
+    btn.classList.add('done');
+    btn.innerHTML = '&#x2713; Completed';
+  }
+  updateProgress();
+  updateNavDone();
+}
+
+function updateProgress() {
+  const done = lessons.filter(l => isDone(l.id)).length;
+  const pct  = Math.round(done / lessons.length * 100);
+  document.getElementById('prog-fill').style.width = pct + '%';
+  document.getElementById('prog-label').textContent = done + ' / ' + lessons.length;
+}
+
+function updateNavDone() {
+  const navItems = document.querySelectorAll('.nav-item');
+  lessons.forEach((l, i) => {
+    if (isDone(l.id)) {
+      navItems[i].classList.add('done');
+      navItems[i].querySelector('.nav-badge').textContent = '✓';
+    } else {
+      navItems[i].classList.remove('done');
+      navItems[i].querySelector('.nav-badge').textContent = l.id;
+    }
+  });
+}
+
+/* ─────────────────────────────────────────────────────────────
+   INIT
+   ───────────────────────────────────────────────────────────── */
+updateProgress();
+updateNavDone();
+</script>
+</body>
+</html>

--- a/onboarding-tutorials/fmcp-serve/tutorials/fmcp-serve-feature-tutorial.html
+++ b/onboarding-tutorials/fmcp-serve/tutorials/fmcp-serve-feature-tutorial.html
@@ -804,7 +804,7 @@ const lessons = [
 <div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">auth.py</span>          <span class="dir-comment"># Bearer token auth: verify_token(), secrets.compare_digest()</span></div>
 <div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">api/</span></div>
 <div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name dir-highlight">management.py</span>    <span class="dir-comment"># All REST API route handlers (40+ endpoints)</span></div>
-<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">inspector.py</span>     <span class="dir-comment"># MCP inspector WebSocket sessions</span></div>
+<div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">inspector.py</span>     <span class="dir-comment"># MCP inspector HTTP / SSE sessions</span></div>
 <div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">models/</span></div>
 <div class="dir-line dir-indent-3"><span class="dir-tree-char">&#x2514;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C4;</span><span class="dir-name">api.py</span>           <span class="dir-comment"># Pydantic request/response models</span></div>
 <div class="dir-line dir-indent-2"><span class="dir-tree-char">&#x251C;&#x2500;&#x2500;</span> <span class="dir-icon">&#x1F4C2;</span><span class="dir-name dir">repositories/</span></div>
@@ -1141,11 +1141,7 @@ fmcp serve \
       <td>TTL 30 days</td>
       <td>Crash reports from server subprocess exits</td>
     </tr>
-    <tr>
-      <td>fluidmcp_audit_log</td>
-      <td>&mdash;</td>
-      <td>API call audit trail (who did what, when)</td>
-    </tr>
+
   </tbody>
 </table>
 
@@ -1422,11 +1418,9 @@ curl -X POST http://localhost:8099/api/servers \
   -d <span class="str">'{
     "id": "filesystem",
     "name": "Filesystem Server",
-    "mcp_config": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
-      "env": {}
-    }
+    "command": "npx",
+    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+    "env": {}
   }'</span>
 
 <span class="cm"># Step 3: Start the server subprocess</span>
@@ -1702,9 +1696,9 @@ TOKEN=\${FMCP_BEARER_TOKEN}
 curl -X POST http://localhost:8099/api/servers \
   -H <span class="str">"Authorization: Bearer \${TOKEN}"</span> \
   -H <span class="str">"Content-Type: application/json"</span> \
-  -d <span class="str">'{"id":"fs","mcp_config":{"command":"npx",
+  -d <span class="str">'{"id":"fs","command":"npx",
       "args":["-y","@modelcontextprotocol/server-filesystem","/tmp"],
-      "env":{}}}'</span>
+      "env":{}}'</span>
 curl -X POST http://localhost:8099/api/servers/fs/start \
   -H <span class="str">"Authorization: Bearer \${TOKEN}"</span></div>
 </div>


### PR DESCRIPTION
## Summary

- Added architecture and flow diagrams for the `fmcp serve` feature under `onboarding-tutorials/code-flow/fmcp-serve/`
- Added interactive HTML tutorial for the `fmcp serve` feature at `onboarding-tutorials/fmcp-serve/tutorials/fmcp-serve-feature-tutorial.html`

## Changes

- `architecture-diagram.md` - High-level architecture diagram for the serve mode
- `health-check-data-flow-diagram.md` - Data flow diagram for health check subsystem
- `mongodb-connection-sequence-diagram.md` - Sequence diagram for MongoDB connection lifecycle
- `server-lifecycle-feature-flow-diagram.md` - Flow diagram for server lifecycle management
- `startup-key-flow-diagram.md` - Key flow diagram for server startup sequence
- `fmcp-serve-feature-tutorial.html` - Interactive onboarding tutorial for the `fmcp serve` feature

## Test plan

- [x] Review HTML tutorial renders correctly in a browser
- [x] Verify all Mermaid diagrams in markdown files render correctly on GitHub