### PR TITLE
MCP-471: MCP-JAM phase 3 - Persist inspector servers across page navigation

### DIFF
--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -458,6 +458,44 @@ export default function MCPInspector() {
     setExecutionTime(null)
   }, [selectedTool])
 
+  // ── Session persistence ────────────────────────────────────────────────────
+  // Restore servers + selected server on mount (survives page navigation)
+  useEffect(() => {
+    const savedServers = sessionStorage.getItem('inspector-servers')
+    const savedSelectedId = sessionStorage.getItem('inspector-selected-server-id')
+
+    if (savedServers) {
+      try {
+        const parsed: MCPServer[] = JSON.parse(savedServers)
+        // Any mid-connect server was interrupted — treat as disconnected on restore
+        const restored = parsed.map(s =>
+          s.status === 'connecting'
+            ? { ...s, status: 'disconnected' as const, session_id: null }
+            : s
+        )
+        setServers(restored)
+      } catch {
+        // ignore malformed storage
+      }
+    }
+
+    if (savedSelectedId) setSelectedServerId(savedSelectedId)
+  }, [])
+
+  // Persist servers list whenever it changes
+  useEffect(() => {
+    sessionStorage.setItem('inspector-servers', JSON.stringify(servers))
+  }, [servers])
+
+  // Persist selected server ID whenever it changes
+  useEffect(() => {
+    if (selectedServerId) {
+      sessionStorage.setItem('inspector-selected-server-id', selectedServerId)
+    } else {
+      sessionStorage.removeItem('inspector-selected-server-id')
+    }
+  }, [selectedServerId])
+
   useEffect(() => {
     const saved = sessionStorage.getItem('inspector-panel-sizes')
     if (saved) setPanelSizes(JSON.parse(saved))


### PR DESCRIPTION
## Summary
- Connected servers, tools list, auth config, and session IDs now survive page navigation
- Restored from `sessionStorage` on mount — no reconnect needed within the 30-min backend session TTL
- If a session did expire, the existing **Reconnect** button handles it gracefully

## Changes
- `fluidmcp/frontend/src/pages/MCPInspector.tsx` only (~38 lines)
  - Restore servers + selected server on mount from `sessionStorage`
  - Persist servers list on every state change
  - Persist selected server ID on every change
  - Mid-connect servers restored as `disconnected` (safe fallback)

## Notes
- No tool results or chat history persisted (intentional — fresh context per visit)
- Consistent with existing `sessionStorage` usage for panel sizes
- Based on `mcp-jam-phase3-header-token` (#551)

🤖 Generated with [Claude Code](https://claude.com/claude-code)