### PR TITLE
MCP-450: MCP-JAM Phase 3B: MCP Apps UI widget sandbox (SEP-1865)

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -11,7 +11,6 @@ from loguru import logger
 
 from ..services.inspector_session import InspectorSession
 from ..auth import verify_token
-from ..services.inspector_agent import choose_tool_with_llm
 
 router = APIRouter(dependencies=[Depends(verify_token)])
 
@@ -258,6 +257,15 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
         agent_result = await choose_tool_with_llm(
             body.message, tools, chat_history=body.chat_history or []
         )
+
+        # Validate the response has the expected fields
+        tool_name = agent_result.get("tool_name")
+        available_names = {t["name"] for t in tools}
+        if not tool_name or not isinstance(tool_name, str) or tool_name not in available_names:
+            return {
+                "clarification_needed": True,
+                "message": "Could not determine which tool to run."
+            }
 
         # Validate the response has the expected fields
         tool_name = agent_result.get("tool_name")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -40,6 +40,9 @@ class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
 
+class ReadResourceRequest(BaseModel):
+    uri: str
+
 # ─── URL Validation ────────────────────────────────────────────────────────────
 
 def _validate_mcp_url(url: str) -> None:
@@ -227,6 +230,42 @@ async def get_logs(session_id: str):
 
     session.last_used = time.time()
     return {"logs": session.logs}
+
+@router.get("/inspector/{session_id}/resources")
+async def list_resources(session_id: str):
+    """
+    List all resources available on the connected MCP server.
+    Also used to discover widget resources (ui:// URIs).
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        resources = await session.list_resources()
+        return {"resources": resources, "count": len(resources)}
+    except Exception as e:
+        logger.error(f"Inspector: list_resources failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to fetch resources: {str(e)}")
+
+
+@router.post("/inspector/{session_id}/resources/read")
+async def read_resource(session_id: str, body: ReadResourceRequest):
+    """
+    Read a resource by URI from the connected MCP server.
+    Used to fetch widget HTML for ui:// resource URIs.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        content = await session.read_resource(body.uri)
+        return content
+    except Exception as e:
+        logger.error(f"Inspector: read_resource failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to read resource: {str(e)}")
+
 
 @router.post("/inspector/{session_id}/chat")
 async def chat_with_tools(session_id: str, body: ChatRequest):

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 from ..services.inspector_session import InspectorSession
 from ..auth import verify_token
+from ..services.inspector_agent import choose_tool_with_llm
 
 router = APIRouter(dependencies=[Depends(verify_token)])
 

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -267,15 +267,6 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "Could not determine which tool to run."
             }
 
-        # Validate the response has the expected fields
-        tool_name = agent_result.get("tool_name")
-        available_names = {t["name"] for t in tools}
-        if not tool_name or not isinstance(tool_name, str) or tool_name not in available_names:
-            return {
-                "clarification_needed": True,
-                "message": "Could not determine which tool to run."
-            }
-
         session.add_log(
             "chat",
             f"User: {body.message} → tool selected: {tool_name}"

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -261,7 +261,11 @@ async def read_resource(session_id: str, body: ReadResourceRequest):
 
     try:
         content = await session.read_resource(body.uri)
-        return content
+        if isinstance(content, dict) and "contents" in content:
+            return content
+        if isinstance(content, list):
+            return {"contents": content}
+        return {"contents": [content]}
     except Exception as e:
         logger.error(f"Inspector: read_resource failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to read resource: {str(e)}")

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -74,8 +74,12 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-    User request:
-    {message}
+Instructions:
+1. Choose the BEST tool to fulfill the request.
+2. Extract parameters from the request.
+3. If parameters are missing:
+   - Infer reasonable defaults OR leave them empty
+   - DO NOT explain anything
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -74,8 +74,8 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-User request:
-{message}
+    User request:
+    {message}
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -38,7 +38,7 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list = []):
+async def choose_tool_with_llm(message: str, tools: list, chat_history: list | None = None):
     """
     Universal MCP agent powered by Groq.
 
@@ -46,6 +46,9 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
     even when GROQ_API_KEY is absent — the error surfaces only when the chat
     endpoint is actually called.
     """
+
+    if chat_history is None:
+        chat_history = []
 
     if not tools:
         raise RuntimeError("No tools available")
@@ -74,19 +77,12 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [
 Available tools:
 {tool_description}
 
-Instructions:
-1. Choose the BEST tool to fulfill the request.
-2. Extract parameters from the request.
-3. If parameters are missing:
-   - Infer reasonable defaults OR leave them empty
-   - DO NOT explain anything
+User request: {message}
 
 Instructions:
 1. Choose the BEST tool to fulfill the request.
 2. Extract parameters from the request.
-3. If parameters are missing:
-   - Infer reasonable defaults OR leave them empty
-   - DO NOT explain anything
+3. If parameters are missing, infer reasonable defaults or leave them empty.
 
 Return ONLY JSON.
 """

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -129,8 +129,7 @@ Rules:
                     }
                 ],
                 temperature=0,
-                max_tokens=200,
-                stop=["\n\n"]
+                max_tokens=200
             )
 
         response = await asyncio.to_thread(_call_llm)

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -36,12 +36,10 @@ class InspectorSession:
     """
     Manages a temporary connection to an external MCP server for the inspector.
 
-    Uses raw JSON-RPC over HTTP (for http transport) or SSE + HTTP POST
-    (for sse transport). No MCP SDK required — matches FluidMCP's existing
-    httpx-based pattern.
-
-    For stdio transport, the server is assumed to be already running and
-    accessible via a URL endpoint.
+    HTTP transport: raw JSON-RPC POST, response comes back in the same HTTP response.
+    SSE transport:  persistent GET /sse connection (background task) receives all
+                    responses; requests are sent via POST to the messages endpoint.
+                    This matches the MCP SSE spec — the stream must stay open.
     """
 
     def __init__(
@@ -58,281 +56,275 @@ class InspectorSession:
         self.auth = auth or {}
         self.extra_headers = headers or {}
         self.env_vars = env_vars or {}
-        self.timeout = timeout / 1000  # Convert ms to seconds
+        self.timeout = timeout / 1000  # ms → seconds
         self.created_at = time.time()
         self.last_used = time.time()
 
-        # Execution logs for this session
         self.logs: List[Dict[str, Any]] = []
 
+        # Auto-incrementing request ID (avoids hardcoded 1/2/3 collisions)
+        self._req_id = 0
 
-        # For SSE: the endpoint to POST messages to (received during SSE handshake)
+        # SSE state
         self._sse_post_url: Optional[str] = None
-        self._sse_session_id: Optional[str] = None
+        self._sse_ready = asyncio.Event()      # set once endpoint URL is known
+        self._sse_pending: Dict[int, "asyncio.Future[dict]"] = {}  # id → Future
+        self._sse_task: Optional[asyncio.Task] = None
 
-        # Shared httpx client for this session
+        # Shared httpx client for HTTP/POST requests
         self._client: Optional[httpx.AsyncClient] = None
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = httpx.AsyncClient(
                 timeout=httpx.Timeout(connect=10.0, read=self.timeout, write=10.0, pool=10.0),
-                follow_redirects=False,  # prevent redirect-based SSRF bypass
+                follow_redirects=False,
             )
         return self._client
 
     def _build_headers(self) -> Dict[str, str]:
-        """Build request headers including auth and any custom headers."""
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-
-        # Add bearer token auth if configured
-        auth_type = self.auth.get("type", "none")
-        if auth_type == "bearer":
-            token = self.auth.get("token", "")
-            if token:
-                headers["Authorization"] = f"Bearer {token}"
-
-        # Merge any custom headers (these can override defaults)
+        if self.auth.get("type") == "bearer" and self.auth.get("token"):
+            headers["Authorization"] = f"Bearer {self.auth['token']}"
         headers.update(self.extra_headers)
         return headers
 
     MAX_LOGS = 250
 
     def add_log(self, log_type: str, message: str) -> None:
-        log_entry = {
+        entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "type": log_type,
-            "message": message
+            "message": message,
         }
-        self.logs.append(log_entry)
+        self.logs.append(entry)
         if len(self.logs) > self.MAX_LOGS:
             self.logs.pop(0)
         logger.debug(f"Inspector log [{log_type}]: {message}")
 
+    # ── SSE persistent listener ───────────────────────────────────────────────
+
+    async def _sse_listener(self) -> None:
+        """
+        Background task: holds the GET /sse connection open for the entire session.
+
+        - First data event   → the POST messages endpoint URL (signals _sse_ready)
+        - Subsequent events  → JSON-RPC responses, routed to waiting callers via Futures
+        """
+        sse_url = self.url if self.url.endswith("/sse") else f"{self.url}/sse"
+        sse_headers = {**self._build_headers(), "Accept": "text/event-stream"}
+
+        # Dedicated client with no read timeout — this stream stays open indefinitely
+        sse_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0),
+            follow_redirects=False,
+        )
+        try:
+            async with sse_client.stream("GET", sse_url, headers=sse_headers) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:"):].strip()
+                    if not data_str:
+                        continue
+
+                    # ── First event: endpoint URL ──────────────────────────
+                    if self._sse_post_url is None:
+                        endpoint_url: Optional[str] = None
+                        if data_str.startswith("/") or data_str.startswith("http"):
+                            if data_str.startswith("/"):
+                                p = urlparse(self.url)
+                                endpoint_url = f"{p.scheme}://{p.netloc}{data_str}"
+                            else:
+                                endpoint_url = data_str
+                        else:
+                            try:
+                                ev = json.loads(data_str)
+                                if "endpoint" in ev:
+                                    endpoint_url = ev["endpoint"]
+                            except json.JSONDecodeError:
+                                pass
+
+                        if endpoint_url:
+                            try:
+                                _validate_url(endpoint_url)
+                            except ValueError as e:
+                                raise Exception(f"SSE endpoint rejected: {e}")
+
+                            base_host = urlparse(self.url).netloc
+                            ep_host = urlparse(endpoint_url).netloc
+                            if ep_host and ep_host != base_host:
+                                raise Exception(
+                                    f"SSE endpoint host mismatch — "
+                                    f"expected {base_host}, got {ep_host}"
+                                )
+
+                            self._sse_post_url = endpoint_url
+                            self._sse_ready.set()
+                            logger.debug(f"SSE messages endpoint: {endpoint_url}")
+                        continue
+
+                    # ── Subsequent events: JSON-RPC responses ──────────────
+                    try:
+                        msg = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    req_id = msg.get("id")
+                    if req_id is not None:
+                        future = self._sse_pending.pop(req_id, None)
+                        if future and not future.done():
+                            future.set_result(msg)
+
+        except asyncio.CancelledError:
+            pass  # normal shutdown
+        except Exception as e:
+            logger.warning(f"SSE listener terminated: {e}")
+            # Unblock any callers waiting on futures
+            for fut in self._sse_pending.values():
+                if not fut.done():
+                    fut.set_exception(e)
+            self._sse_pending.clear()
+            if not self._sse_ready.is_set():
+                self._sse_ready.set()
+        finally:
+            await sse_client.aclose()
+
+    async def _sse_request(self, request: dict) -> dict:
+        """POST a request and await the response that comes back on the SSE stream."""
+        await asyncio.wait_for(self._sse_ready.wait(), timeout=10.0)
+
+        if not self._sse_post_url:
+            raise Exception("SSE session not ready — no endpoint URL")
+
+        req_id = request["id"]
+        loop = asyncio.get_event_loop()
+        future: "asyncio.Future[dict]" = loop.create_future()
+        self._sse_pending[req_id] = future
+
+        try:
+            client = self._get_client()
+            resp = await client.post(
+                self._sse_post_url, json=request, headers=self._build_headers()
+            )
+            resp.raise_for_status()
+            # Server responds 202 Accepted; actual result arrives via SSE stream
+            return await asyncio.wait_for(future, timeout=self.timeout)
+        except Exception:
+            self._sse_pending.pop(req_id, None)
+            if not future.done():
+                future.cancel()
+            raise
+
+    # ── Transport dispatcher ──────────────────────────────────────────────────
+
+    def _make_request(self, method: str, params: dict) -> dict:
+        return {"jsonrpc": "2.0", "id": self._next_id(), "method": method, "params": params}
+
+    async def _send(self, request: dict) -> dict:
+        """Route request through SSE or plain HTTP depending on transport."""
+        if self.transport == "sse":
+            return await self._sse_request(request)
+
+        client = self._get_client()
+        response = await client.post(self.url, json=request, headers=self._build_headers())
+        response.raise_for_status()
+        return response.json()
+
+    # ── Public API ────────────────────────────────────────────────────────────
 
     async def initialize(self) -> Dict[str, Any]:
-        """
-        Perform the MCP initialize handshake to verify the server is reachable
-        and retrieve server info.
-
-        Returns server info dict with name and version.
-        Raises httpx.HTTPError or Exception on failure.
-        """
         self.last_used = time.time()
 
         if self.transport == "sse":
-            server_info = await self._initialize_sse()
-        else:
-            # HTTP and stdio both use JSON-RPC POST
-            server_info = await self._initialize_http()
+            # Kick off the background SSE listener before sending any requests
+            loop = asyncio.get_event_loop()
+            self._sse_task = loop.create_task(self._sse_listener())
 
-        # Log successful connection
-        self.add_log("connect", f"Connected to {server_info.get('name', 'Unknown Server')} ({self.transport.upper()})")
-        return server_info
-
-    async def _initialize_http(self) -> Dict[str, Any]:
-        """Send MCP initialize JSON-RPC request over HTTP POST."""
-        client = self._get_client()
-        headers = self._build_headers()
-
-        init_request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "FluidMCP Inspector",
-                    "version": "1.0.0"
+        init_request = self._make_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "extensions": {
+                    "io.modelcontextprotocol/ui": {
+                        "mimeTypes": ["text/html+mcp", "text/html;profile=mcp-app"]
+                    }
                 }
-            }
-        }
+            },
+            "clientInfo": {"name": "FluidMCP Inspector", "version": "1.0.0"},
+        })
 
-        response = await client.post(self.url, json=init_request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
+        data = await self._send(init_request)
 
         if "error" in data:
             raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
 
         result = data.get("result", {})
         server_info = result.get("serverInfo", {})
-
-        return {
+        info = {
             "name": server_info.get("name", "Unknown MCP Server"),
             "version": server_info.get("version", "unknown"),
-            "protocol_version": result.get("protocolVersion", "unknown")
+            "protocol_version": result.get("protocolVersion", "unknown"),
         }
 
-    async def _initialize_sse(self) -> Dict[str, Any]:
-        """
-        Connect to SSE endpoint to get the POST messages URL,
-        then send the initialize request via POST.
-
-        MCP SSE pattern:
-          1. GET /sse  → streams events, first event contains the endpoint URL
-          2. POST {endpoint_url}  → send JSON-RPC messages
-        """
-        client = self._get_client()
-        headers = self._build_headers()
-        sse_headers = {**headers, "Accept": "text/event-stream"}
-
-        # Determine SSE endpoint URL
-        sse_url = self.url if self.url.endswith("/sse") else f"{self.url}/sse"
-
-        # Connect to SSE and read the first event to get the messages endpoint
-        endpoint_url = None
-        try:
-            async with client.stream("GET", sse_url, headers=sse_headers, timeout=10.0) as response:
-                response.raise_for_status()
-                async for line in response.aiter_lines():
-                    if line.startswith("data:"):
-                        data_str = line[len("data:"):].strip()
-                        # MCP SSE servers send the messages endpoint URL as first data event
-                        if data_str.startswith("/") or data_str.startswith("http"):
-                            # Relative path — make it absolute
-                            if data_str.startswith("/"):
-                                parsed = urlparse(self.url)
-                                endpoint_url = f"{parsed.scheme}://{parsed.netloc}{data_str}"
-                            else:
-                                endpoint_url = data_str
-                            break
-                        # Some servers send JSON with endpoint info
-                        try:
-                            event_data = json.loads(data_str)
-                            if "endpoint" in event_data:
-                                endpoint_url = event_data["endpoint"]
-                                break
-                        except json.JSONDecodeError:
-                            pass
-        except asyncio.TimeoutError:
-            raise Exception("SSE connection timed out waiting for endpoint URL")
-
-        if not endpoint_url:
-            raise Exception("SSE server did not provide a messages endpoint URL")
-
-        # Validate SSE-derived endpoint against SSRF blocklist
-        try:
-            _validate_url(endpoint_url)
-        except ValueError as e:
-            raise Exception(f"SSE endpoint rejected: {e}")
-
-        # Enforce same host as the original URL to prevent open-redirect abuse
-        base_host = urlparse(self.url).netloc
-        ep_host = urlparse(endpoint_url).netloc
-        if ep_host and ep_host != base_host:
-            raise Exception(f"SSE endpoint host mismatch — expected {base_host}, got {ep_host}")
-
-        self._sse_post_url = endpoint_url
-        logger.debug(f"SSE messages endpoint: {endpoint_url}")
-
-        # Now send initialize via POST to the messages endpoint
-        init_request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "FluidMCP Inspector",
-                    "version": "1.0.0"
-                }
-            }
-        }
-
-        response = await client.post(endpoint_url, json=init_request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-
-        if "error" in data:
-            raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
-
-        result = data.get("result", {})
-        server_info = result.get("serverInfo", {})
-
-        return {
-            "name": server_info.get("name", "Unknown MCP Server"),
-            "version": server_info.get("version", "unknown"),
-            "protocol_version": result.get("protocolVersion", "unknown")
-        }
-
-    def _get_post_url(self) -> str:
-        """Get the URL to POST JSON-RPC messages to."""
-        if self.transport == "sse" and self._sse_post_url:
-            return self._sse_post_url
-        return self.url
+        self.add_log("connect", f"Connected to {info['name']} ({self.transport.upper()})")
+        return info
 
     async def list_tools(self) -> list:
-        """Fetch the list of tools available on the MCP server."""
         self.last_used = time.time()
-        client = self._get_client()
-        headers = self._build_headers()
-        post_url = self._get_post_url()
-
-        request = {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list",
-            "params": {}
-        }
-
-        response = await client.post(post_url, json=request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-
+        data = await self._send(self._make_request("tools/list", {}))
         if "error" in data:
             raise Exception(f"tools/list error: {data['error'].get('message', 'Unknown error')}")
-
         return data.get("result", {}).get("tools", [])
 
     async def call_tool(self, name: str, params: Dict[str, Any]) -> Any:
-        """Execute a tool on the MCP server."""
         self.last_used = time.time()
-        client = self._get_client()
-        headers = self._build_headers()
-        post_url = self._get_post_url()
-
-        # Log tool call
         self.add_log("tool_call", f"Running tool: {name}")
-
-
-        request = {
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": name,
-                "arguments": params
-            }
-        }
-
         try:
-            response = await client.post(post_url, json=request, headers=headers)
-            response.raise_for_status()
-            data = response.json()
-
+            data = await self._send(
+                self._make_request("tools/call", {"name": name, "arguments": params})
+            )
             if "error" in data:
-                error_msg = data['error'].get('message', 'Unknown error')
-                self.add_log("tool_error", f"Tool '{name}' failed: {error_msg}")
-                raise Exception(f"tools/call error: {error_msg}")
-
-            # NOTE: MCP servers sometimes return isError: true inside a successful result.
-            # We log tool_result here because the JSON-RPC call succeeded at transport level.
-            # The frontend ToolResult component handles isError display separately.
-            # Future improvement: check result body for isError and log tool_error instead.
+                msg = data["error"].get("message", "Unknown error")
+                self.add_log("tool_error", f"Tool '{name}' failed: {msg}")
+                raise Exception(f"tools/call error: {msg}")
             self.add_log("tool_result", f"Tool '{name}' executed successfully")
             return data.get("result", {})
         except Exception as e:
-            # Log unexpected errors
-            if not self.logs or self.logs[-1]["type"] != "tool_error":  # Only log if not already logged above
+            if not self.logs or self.logs[-1]["type"] != "tool_error":
                 self.add_log("tool_error", f"Tool '{name}' error: {str(e)}")
             raise
 
-    async def close(self):
-        """Close the httpx client."""
+    async def list_resources(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/list", {}))
+        if "error" in data:
+            raise Exception(f"resources/list error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {}).get("resources", [])
+
+    async def read_resource(self, uri: str) -> dict:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/read", {"uri": uri}))
+        if "error" in data:
+            raise Exception(f"resources/read error: {data['error'].get('message', 'Unknown error')}")
+        contents = data.get("result", {}).get("contents", [])
+        return contents[0] if contents else {}
+
+    async def close(self) -> None:
         self.add_log("disconnect", "Session closed")
+        if self._sse_task:
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sse_task = None
         if self._client is not None:
             try:
                 await self._client.aclose()

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -147,8 +147,11 @@ class InspectorSession:
                         else:
                             try:
                                 ev = json.loads(data_str)
-                                if "endpoint" in ev:
+                                if "endpoint" in ev and isinstance(ev["endpoint"], str):
                                     endpoint_url = ev["endpoint"]
+                                    if endpoint_url.startswith("/"):
+                                        p = urlparse(self.url)
+                                        endpoint_url = f"{p.scheme}://{p.netloc}{endpoint_url}"
                             except json.JSONDecodeError:
                                 pass
 
@@ -313,8 +316,7 @@ class InspectorSession:
         data = await self._send(self._make_request("resources/read", {"uri": uri}))
         if "error" in data:
             raise Exception(f"resources/read error: {data['error'].get('message', 'Unknown error')}")
-        contents = data.get("result", {}).get("contents", [])
-        return contents[0] if contents else {}
+        return data.get("result", {"contents": []})
 
     async def close(self) -> None:
         self.add_log("disconnect", "Session closed")

--- a/fluidmcp/frontend/public/sandbox-proxy.html
+++ b/fluidmcp/frontend/public/sandbox-proxy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><style>*{margin:0;padding:0}body{overflow:hidden}</style></head>
+<body>
+<script>
+  var inner = document.createElement('iframe');
+  inner.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms');
+  inner.style.cssText = 'border:none;width:100%;height:100vh;display:block';
+  document.body.appendChild(inner);
+
+  window.addEventListener('message', function(event) {
+    if (event.source === window.parent) {
+      if (event.data && event.data.method === 'ui/notifications/sandbox-resource-ready') {
+        inner.srcdoc = event.data.params.html;
+      } else {
+        inner.contentWindow && inner.contentWindow.postMessage(event.data, '*');
+      }
+    } else if (event.source === inner.contentWindow) {
+      window.parent.postMessage(event.data, '*');
+    }
+  });
+
+  window.parent.postMessage({
+    jsonrpc: '2.0',
+    method: 'ui/notifications/sandbox-proxy-ready',
+    params: {}
+  }, '*');
+</script>
+</body>
+</html>

--- a/fluidmcp/frontend/public/sandbox-proxy.html
+++ b/fluidmcp/frontend/public/sandbox-proxy.html
@@ -4,7 +4,7 @@
 <body>
 <script>
   var inner = document.createElement('iframe');
-  inner.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms');
+  inner.setAttribute('sandbox', 'allow-scripts allow-forms');
   inner.style.cssText = 'border:none;width:100%;height:100vh;display:block';
   document.body.appendChild(inner);
 

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react';
+import apiClient from '@/services/api';
+
+interface WidgetSandboxProps {
+  sessionId: string;
+  resourceUri: string;
+  toolInput: Record<string, any>;
+  toolResult: any;
+}
+
+export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }: WidgetSandboxProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(300);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [errorMsg, setErrorMsg] = useState('');
+  // Tracks pending requests WE sent to the widget (id → resolve/reject)
+  const pendingRef = useRef<Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>>(new Map());
+  // Fallback timeout: if widget doesn't complete MCP handshake, auto-clear loading state
+  const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    // Send a message to the proxy iframe (which forwards to the inner widget iframe)
+    const sendToProxy = (data: any) => {
+      iframe.contentWindow?.postMessage(data, '*');
+    };
+
+    const handleMessage = async (event: MessageEvent) => {
+      // Only handle messages from our proxy iframe
+      if (event.source !== iframe.contentWindow) return;
+      const msg = event.data;
+      if (!msg || typeof msg !== 'object') return;
+
+      // If this is a response to a request WE sent (has id + result/error, no method)
+      if (msg.id !== undefined && !msg.method && (msg.result !== undefined || msg.error !== undefined)) {
+        const pending = pendingRef.current.get(msg.id);
+        if (pending) {
+          pendingRef.current.delete(msg.id);
+          if (msg.error) pending.reject(new Error(msg.error.message || 'Widget error'));
+          else pending.resolve(msg.result);
+        }
+        return;
+      }
+
+      // Requests / notifications FROM the widget
+      const method: string = msg.method;
+      if (!method) return;
+
+      // ── Proxy is ready: fetch widget HTML and load it ──────────────────────
+      if (method === 'ui/notifications/sandbox-proxy-ready') {
+        try {
+          const res = await apiClient.readInspectorResource(sessionId, resourceUri);
+          const html: string = res?.text || res?.content || '';
+          if (!html) {
+            setStatus('error');
+            setErrorMsg('Widget resource returned empty HTML');
+            return;
+          }
+          sendToProxy({
+            jsonrpc: '2.0',
+            method: 'ui/notifications/sandbox-resource-ready',
+            params: { html },
+          });
+          // Fallback: if the widget doesn't implement the MCP UI handshake,
+          // auto-clear the loading overlay after 2 s so the widget is visible.
+          readyTimeoutRef.current = setTimeout(() => {
+            setStatus(prev => prev === 'loading' ? 'ready' : prev);
+          }, 2000);
+        } catch (e: any) {
+          setStatus('error');
+          setErrorMsg(`Failed to load widget: ${e.message}`);
+        }
+        return;
+      }
+
+      // ── Widget handshake ───────────────────────────────────────────────────
+      if (method === 'ui/initialize') {
+        sendToProxy({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            hostInfo: { name: 'FluidMCP Inspector', version: '1.0.0' },
+            hostCapabilities: {},
+          },
+        });
+        return;
+      }
+
+      if (method === 'ui/notifications/initialized') {
+        if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current);
+        setStatus('ready');
+        // Send tool arguments to widget
+        sendToProxy({
+          jsonrpc: '2.0',
+          method: 'ui/notifications/tool-input',
+          params: { arguments: toolInput },
+        });
+        // Send structured result data (structuredContent for widget, not LLM)
+        const raw = toolResult?.result ?? toolResult ?? {};
+        const structuredContent = raw.structuredContent ?? null;
+        const content = raw.content ?? [];
+        if (structuredContent !== null || content.length > 0) {
+          sendToProxy({
+            jsonrpc: '2.0',
+            method: 'ui/notifications/tool-result',
+            params: { content, structuredContent },
+          });
+        }
+        return;
+      }
+
+      // ── Widget requests a tool call ────────────────────────────────────────
+      if (method === 'tools/call') {
+        const { name, arguments: args } = msg.params || {};
+        try {
+          const result = await apiClient.runInspectorTool(sessionId, name, args || {});
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, result });
+        } catch (e: any) {
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: e.message } });
+        }
+        return;
+      }
+
+      // ── Widget reads a resource ────────────────────────────────────────────
+      if (method === 'resources/read') {
+        const { uri } = msg.params || {};
+        try {
+          const result = await apiClient.readInspectorResource(sessionId, uri);
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, result });
+        } catch (e: any) {
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: e.message } });
+        }
+        return;
+      }
+
+      // ── Widget resizes itself ──────────────────────────────────────────────
+      if (method === 'ui/notifications/size-change') {
+        const { height: h } = msg.params || {};
+        if (typeof h === 'number' && h > 0) {
+          setHeight(Math.min(h + 20, 800));
+        }
+        return;
+      }
+
+      // ── Widget wants to open a link ────────────────────────────────────────
+      if (method === 'ui/open-link') {
+        const { url } = msg.params || {};
+        if (url) window.open(url, '_blank', 'noopener,noreferrer');
+        if (msg.id !== undefined) sendToProxy({ jsonrpc: '2.0', id: msg.id, result: {} });
+        return;
+      }
+
+      // ── Widget injects a message into chat ─────────────────────────────────
+      if (method === 'ui/message') {
+        // Future: bubble up to chat. For now, just ack.
+        if (msg.id !== undefined) sendToProxy({ jsonrpc: '2.0', id: msg.id, result: {} });
+        return;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      pendingRef.current.clear();
+      if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current);
+    };
+  }, [sessionId, resourceUri, toolInput, toolResult]);
+
+  if (status === 'error') {
+    return (
+      <div style={{
+        marginTop: '0.5rem', padding: '0.5rem 0.75rem',
+        fontSize: '0.75rem', color: '#fca5a5',
+        background: 'rgba(239,68,68,0.1)',
+        border: '1px solid rgba(239,68,68,0.3)',
+        borderRadius: '6px',
+      }}>
+        Widget error: {errorMsg}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      marginTop: '0.6rem',
+      borderRadius: '8px',
+      overflow: 'hidden',
+      border: '1px solid rgba(99,102,241,0.35)',
+      background: '#fff',
+      position: 'relative',
+    }}>
+      {status === 'loading' && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(9,9,11,0.7)', fontSize: '0.75rem',
+          color: 'rgba(255,255,255,0.5)', zIndex: 1,
+        }}>
+          Loading widget...
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        title="MCP Widget"
+        style={{
+          width: '100%',
+          height: `${height}px`,
+          border: 'none',
+          display: 'block',
+          transition: 'height 0.15s ease',
+        }}
+      />
+    </div>
+  );
+}

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -205,7 +205,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
       <iframe
         ref={iframeRef}
         src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
-        sandbox="allow-scripts allow-same-origin allow-forms"
+        sandbox="allow-scripts allow-forms"
         title="MCP Widget"
         style={{
           width: '100%',

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,10 +1,72 @@
 // import React from "react";
 import { useState, useEffect, useRef } from "react";
+
+// Compact collapsible result bubble for chat mode
+function ChatResultBubble({ result }: { result: unknown }) {
+  const [expanded, setExpanded] = useState(true);
+  const [viewMode, setViewMode] = useState<"formatted" | "raw">("formatted");
+  const isMcp = typeof result === "object" && result !== null &&
+    "content" in result && Array.isArray((result as any).content);
+  const isMcpArray = Array.isArray(result) && result.length > 0 &&
+    (result as any[]).every((i: any) => typeof i === "object" && i !== null && "type" in i);
+  const preview = typeof result === "object" && result !== null
+    ? `{${Object.keys(result as object).length} keys}`
+    : String(result).slice(0, 60);
+
+  const tabStyle = (active: boolean) => ({
+    padding: "0.2rem 0.5rem", borderRadius: "0.25rem", border: "none",
+    fontSize: "0.75rem", fontWeight: 500 as const, cursor: "pointer",
+    background: active ? "#fff" : "transparent",
+    color: active ? "#000" : "rgba(255,255,255,0.6)"
+  });
+
+  return (
+    <div style={{ fontSize: "0.8rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <button
+          onClick={() => setExpanded(v => !v)}
+          style={{
+            background: "none", border: "none", cursor: "pointer",
+            color: "#22c55e", fontWeight: 600, padding: "0.25rem 0",
+            fontSize: "0.8rem", display: "flex", alignItems: "center", gap: "0.3rem"
+          }}
+        >
+          {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
+        </button>
+        {expanded && (
+          <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
+            <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
+            <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+          </div>
+        )}
+      </div>
+      {expanded && (
+        <div style={{
+          maxHeight: "260px", overflowY: "auto",
+          background: "rgba(0,0,0,0.3)",
+          border: "1px solid rgba(63,63,70,0.5)",
+          borderRadius: "0.5rem",
+          padding: "0.75rem",
+          marginTop: "0.25rem"
+        }}>
+          {viewMode === "raw"
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace" }}>{JSON.stringify(result, null, 2)}</pre>
+            : (isMcp || isMcpArray)
+              ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
+              : <JsonResultView data={result} />
+          }
+        </div>
+      )}
+    </div>
+  );
+}
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
 import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
 import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
 
 // Type for server object
@@ -72,16 +134,33 @@ export default function MCPInspector() {
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
   const [chatInput, setChatInput] = useState("")
-  // const [chatHistory, setChatHistory] = useState<any[]>([])
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
+  // 3A-2: Per-server logs
+  const [logsByServer, setLogsByServer] = useState<Record<string, LogEntry[]>>({})
+  const logs = logsByServer[selectedServerId ?? ""] ?? []
+
+  // 3A-3: Per-server chat memory
+  const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
+  const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
+
+  // Helper to update chat for the currently selected server
+  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
+    if (!selectedServerId) return;
+    setChatHistoryByServer(prev => ({
+      ...prev,
+      [selectedServerId]: typeof updater === "function"
+        ? updater(prev[selectedServerId] ?? [])
+        : updater
+    }));
+  };
+
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
     left: 25,     // percentage (right auto-calculated as 100-left)
     logs: 35      // percentage of left panel height
   })
-  const [logs, setLogs] = useState<LogEntry[]>([])
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
+  const chatBottomRef = useRef<HTMLDivElement>(null);
 
   const handleConnect = async () => {
 
@@ -164,13 +243,16 @@ export default function MCPInspector() {
       setToolResult(null);
       setToolError(null);
 
-      // Clear chat and show a welcome message for the new server
-      setChatHistory([{
-        id: crypto.randomUUID(),
-        type: "assistant",
-        content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
-        timestamp: Date.now(),
-      }]);
+      // Set welcome message for this server (preserve other servers' histories)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [{
+          id: crypto.randomUUID(),
+          type: "assistant",
+          content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+          timestamp: Date.now(),
+        }]
+      }));
 
       setAuthType("none")
       setToken("")
@@ -281,6 +363,19 @@ export default function MCPInspector() {
             : s
         )
       );
+      // Append reconnect notice to existing chat history (don't wipe it)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [
+          ...(prev[serverId] ?? []),
+          {
+            id: crypto.randomUUID(),
+            type: "assistant" as const,
+            content: `Reconnected to ${res.server_info?.name || "server"}.`,
+            timestamp: Date.now(),
+          }
+        ]
+      }));
     } catch (err: any) {
       console.error("Failed to reconnect", err);
 
@@ -301,10 +396,10 @@ export default function MCPInspector() {
 
   const handleRemove = (serverId: string) => {
     setServers((prev) => prev.filter((s) => s.id !== serverId));
-
-    if (selectedServerId === serverId) {
-      setSelectedServerId(null);
-    }
+    // Clean up per-server state
+    setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
   const runTool = async (params: any) => {
@@ -368,7 +463,7 @@ export default function MCPInspector() {
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
 
-  setChatHistory(prev => [...prev, userMsg])
+  updateChat(prev => [...prev, userMsg])
 
   try {
     setChatLoading(true)
@@ -381,14 +476,14 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, thinkingMsg])
+    updateChat(prev => [...prev, thinkingMsg])
 
     // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
         message,
-        chat_history: nextHistory.slice(-8).map(m => ({
+        chat_history: nextHistory.slice(-8).map((m: ChatMessage) => ({
           type: m.type,
           content: m.content
         }))
@@ -396,7 +491,7 @@ export default function MCPInspector() {
     )
 
     // Remove thinking message
-    setChatHistory(prev => prev.filter(m => m.id !== thinkingMsg.id))
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
@@ -406,7 +501,7 @@ export default function MCPInspector() {
         timestamp: Date.now()
       }
 
-      setChatHistory(prev => [...prev, assistantMsg])
+      updateChat(prev => [...prev, assistantMsg])
       return
     }
 
@@ -419,7 +514,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, toolCallMsg])
+    updateChat(prev => [...prev, toolCallMsg])
 
     // Execute tool
     const result = await apiClient.runInspectorTool(
@@ -435,7 +530,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, resultMsg])
+    updateChat(prev => [...prev, resultMsg])
 
   } catch (err: any) {
 
@@ -446,7 +541,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, errorMsg])
+    updateChat(prev => [...prev, errorMsg])
   } finally {
     setChatLoading(false)
   }
@@ -507,18 +602,19 @@ export default function MCPInspector() {
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
+  // Uses rAF so scroll runs after the DOM (including dynamic result content) has painted
   useEffect(() => {
-    if (chatRef.current) {
-      chatRef.current.scrollTop = chatRef.current.scrollHeight;
-    }
-  }, [chatHistory]);
+    requestAnimationFrame(() => {
+      chatBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  }, [chatHistoryByServer, selectedServerId]);
 
-  // Fetch logs from the server
+  // Fetch logs from the server (3A-2: stored per-server)
   const fetchLogs = async () => {
-    if (!selectedServer?.session_id) return;
+    if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogs(res.logs || []);
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -526,21 +622,9 @@ export default function MCPInspector() {
 
   // Poll for logs every 2 seconds when a session is active
   useEffect(() => {
-    if (!selectedServer?.session_id) {
-      return;
-    }
-    // NOTE FOR REVIEW: When a new server connects, its logs replace the previous server's logs.
-    // Decision needed: Should we accumulate logs across all servers (keyed by session_id)?
-    // Or is replacing on new connection acceptable?
-    // Options:
-    //   A) Current behaviour — replace logs on new connection (simple, clean)
-    //   B) Accumulate all logs — merge new logs into existing, tag each entry with server name
-    //   C) Per-server log history — store logs[serverId] map, show logs for selected server
-    // Leaning towards C if inspector gets heavy usage, but A is fine for now.
-    fetchLogs();     // Fetch immediately
-
-    const interval = setInterval(fetchLogs, 2000);     // Set up polling interval
-
+    if (!selectedServer?.session_id) return;
+    fetchLogs();
+    const interval = setInterval(fetchLogs, 2000);
     return () => clearInterval(interval);
   }, [selectedServer?.session_id]);
 
@@ -711,15 +795,7 @@ export default function MCPInspector() {
                                 setSelectedTool(null);
                                 setToolResult(null);
                                 setToolError(null);
-                                // Reset chat
-                                setChatHistory([
-                                  {
-                                    id: crypto.randomUUID(),
-                                    type: "assistant",
-                                    content: `Switched to ${server?.server_info?.name || "server"}. Chat cleared.`,
-                                    timestamp: Date.now()
-                                  }
-                                ]);
+                                // 3A-3: preserve chat history on switch (no reset)
                                 
                               }}
                               style={{
@@ -948,14 +1024,24 @@ export default function MCPInspector() {
                     }}
                   >
                     {/* Logs header */}
-                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
-                      <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
-                        LOGS
-                      </span>
-                      {logs.length > 0 && (
-                        <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
-                          {logs.length} entries
+                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                      <div>
+                        <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
+                          LOGS
                         </span>
+                        {logs.length > 0 && (
+                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
+                            {logs.length} entries
+                          </span>
+                        )}
+                      </div>
+                      {logs.length > 0 && selectedServerId && (
+                        <button
+                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                        >
+                          Clear
+                        </button>
                       )}
                     </div>
 
@@ -1087,7 +1173,7 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
+                <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
                     <div>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
@@ -1124,21 +1210,19 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "0", overflow: "hidden" }}>
+                    <div style={{ display: "grid", gridTemplateRows: "1fr auto", flex: 1, minHeight: 0, overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
-                          {/* Chat History */}
+                          {/* Chat History — grid row 1 (1fr = all remaining space) */}
                           <div
                             ref={chatRef}
                             style={{
-                              flex: 1,
-                              minHeight: 0,        
                               overflowY: "auto",
-                              marginBottom: "1rem",
+                              minHeight: 0,
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
-                              padding: "0.5rem 0.5rem 0.5rem 0.25rem"
+                              padding: "0.5rem 0.5rem 0.75rem 0.25rem"
                             }}
                           >
                             {chatHistory.map((msg) => {
@@ -1211,10 +1295,10 @@ export default function MCPInspector() {
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
                                     <div style={{
                                       borderLeft: "3px solid #22c55e",
-                                      paddingLeft: "0.5rem",
+                                      paddingLeft: "0.6rem",
                                       maxWidth: "85%"
                                     }}>
-                                      <ToolResult result={msg.result} />
+                                      <ChatResultBubble result={msg.result} />
                                     </div>
                                   </div>
                                 )
@@ -1256,10 +1340,22 @@ export default function MCPInspector() {
 
                               return null
                             })}
+                            <div ref={chatBottomRef} />
                           </div>
 
-                          {/* Chat Input */}
-                          <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
+                          {/* Chat Input — grid row 2 (auto height, always at bottom) */}
+                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem" }}>
+                          {chatHistory.length > 1 && selectedServerId && (
+                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                              <button
+                                onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                                style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                              >
+                                Clear Chat
+                              </button>
+                            </div>
+                          )}
+                          <div style={{ display: "flex", gap: "0.5rem" }}>
                             <input
                               value={chatInput}
                               disabled={chatLoading}
@@ -1291,6 +1387,7 @@ export default function MCPInspector() {
                             >
                               {chatLoading ? "Thinking..." : "Send"}
                             </button>
+                          </div>
                           </div>
                         </>
                       ) : (

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -645,9 +645,9 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
-  // Auto-scroll logs to bottom when new entries arrive
+  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
   useEffect(() => {
-    logsRef.current?.scrollTo({ top: logsRef.current.scrollHeight });
+    logsRef.current?.scrollTo({ top: 0 });
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
@@ -1123,11 +1123,12 @@ export default function MCPInspector() {
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log, i) => {
+                          {[...logs].reverse().map((log) => {
                             const color = logColors[log.type] || "#9ca3af";
+                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
                             return (
                               <div
-                                key={i}
+                                key={logKey}
                                 style={{
                                   display: "grid",
                                   // Fixed columns: time | type | message

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -96,12 +96,22 @@ interface LogEntry {
 
 type ChatMessage = {
   id: string
+  runId?: string       // groups thinking + tool_call + tool_result for one agent turn
   type: "user" | "thinking" | "tool_call" | "tool_result" | "assistant" | "error"
   content?: string
   toolName?: string
   params?: any
   result?: any
   timestamp: number
+  perfMark?: number    // high-res mark for duration math (performance.now())
+}
+
+type ExecutionRun = {
+  runId: string
+  serverId: string
+  startTime: number    // Date.now() — wall time
+  endTime?: number     // set on completion or error
+  steps: ChatMessage[] // thinking + tool_call + tool_result in order
 }
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
@@ -129,7 +139,9 @@ export default function MCPInspector() {
   const [toolError, setToolError] = useState<string | null>(null)
   const [executing, setExecuting] = useState(false)
   const [executionTime, setExecutionTime] = useState<number | null>(null)
-  const [executionHistory, setExecutionHistory] = useState<any[]>([])
+  // 3A-4: typed per-server execution history
+  const [executionHistoryByServer, setExecutionHistoryByServer] = useState<Record<string, ExecutionRun[]>>({})
+  const executionHistory = executionHistoryByServer[selectedServerId ?? ""] ?? []
 
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
@@ -399,6 +411,7 @@ export default function MCPInspector() {
     // Clean up per-server state
     setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setExecutionHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
@@ -421,16 +434,20 @@ export default function MCPInspector() {
 
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
-      setExecutionHistory((prev) => [
-        {
-          id: Date.now(),
-          tool: selectedTool,
-          params,
-          result: res,
-          time: new Date().toLocaleTimeString(),
-        },
-        ...prev,
-      ]);
+      if (selectedServerId) {
+        const runId = crypto.randomUUID();
+        const run: ExecutionRun = {
+          runId,
+          serverId: selectedServerId,
+          startTime: Date.now() - Math.round(end - start),
+          endTime: Date.now(),
+          steps: [
+            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+          ]
+        };
+        setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
+      }
     } catch (err: any) {
       console.error(err);
       setToolError(err?.message || "Tool execution failed");
@@ -447,7 +464,7 @@ export default function MCPInspector() {
 
  const runChatTool = async () => {
   // Guard against concurrent requests
-  if (!chatInput || !selectedServer?.session_id || chatLoading) return
+  if (!chatInput || !selectedServer?.session_id || chatLoading || !selectedServerId) return
 
   const message = chatInput
   setChatInput("")
@@ -456,7 +473,8 @@ export default function MCPInspector() {
     id: generateId(),
     type: "user",
     content: message,
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    perfMark: performance.now()
   }
 
   // Capture history with userMsg before any state updates — used below to
@@ -465,20 +483,27 @@ export default function MCPInspector() {
 
   updateChat(prev => [...prev, userMsg])
 
+  // 3A-4: start an ExecutionRun for this agent turn
+  const runId = crypto.randomUUID()
+  const runStartTime = Date.now()
+  const runSteps: ChatMessage[] = []
+  const capturedServerId = selectedServerId
+
   try {
     setChatLoading(true)
 
-    // Show thinking
     const thinkingMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "thinking",
       content: "Deciding which tool to use...",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, thinkingMsg])
+    runSteps.push(thinkingMsg)
 
-    // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
@@ -490,33 +515,39 @@ export default function MCPInspector() {
       }
     )
 
-    // Remove thinking message
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
-        id: generateId(),
+        id: crypto.randomUUID(),
+        runId,
         type: "assistant",
         content: res.message,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        perfMark: performance.now()
       }
-
       updateChat(prev => [...prev, assistantMsg])
+      // save run (no tool call — just clarification)
+      setExecutionHistoryByServer(prev => ({
+        ...prev,
+        [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+      }))
       return
     }
 
-    // Tool call message
     const toolCallMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "tool_call",
       toolName: res.tool_name,
       params: res.params,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, toolCallMsg])
+    runSteps.push(toolCallMsg)
 
-    // Execute tool
     const result = await apiClient.runInspectorTool(
       selectedServer.session_id,
       res.tool_name,
@@ -524,24 +555,42 @@ export default function MCPInspector() {
     )
 
     const resultMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "tool_result",
       result,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, resultMsg])
+    runSteps.push(resultMsg)
+
+    // save completed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
 
   } catch (err: any) {
 
     const errorMsg: ChatMessage = {
-      id: generateId(),
+      id: crypto.randomUUID(),
+      runId,
       type: "error",
       content: err?.message || "Chat error",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, errorMsg])
+    runSteps.push(errorMsg)
+
+    // save failed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
   } finally {
     setChatLoading(false)
   }
@@ -949,7 +998,7 @@ export default function MCPInspector() {
                       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
                         <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
                         <button
-                          onClick={() => setExecutionHistory([])}
+                          onClick={() => selectedServerId && setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
                           style={{
                             fontSize: "0.7rem", padding: "0.2rem 0.5rem",
                             borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
@@ -966,26 +1015,34 @@ export default function MCPInspector() {
                           maxHeight: "160px", overflowY: "auto",
                         }}
                       >
-                        {executionHistory.map((item) => (
-                          <div
-                            key={item.id}
-                            onClick={() => {
-                              setToolResult(item.result);
-                              setSelectedTool(item.tool);
-                              setToolError(null);
-                            }}
-                            style={{
-                              padding: "0.4rem 0.5rem",
-                              borderRadius: "0.35rem",
-                              border: "1px solid rgba(63,63,70,0.6)",
-                              cursor: "pointer",
-                              background: "rgba(255,255,255,0.04)",
-                            }}
-                          >
-                            <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{item.tool.name}</div>
-                            <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>{item.time}</div>
-                          </div>
-                        ))}
+                        {executionHistory.map((item: ExecutionRun) => {
+                          const toolCall = item.steps.find(s => s.type === "tool_call");
+                          const toolResult = item.steps.find(s => s.type === "tool_result");
+                          const duration = item.endTime ? item.endTime - item.startTime : null;
+                          return (
+                            <div
+                              key={item.runId}
+                              onClick={() => {
+                                if (toolResult) setToolResult(toolResult.result);
+                                if (toolCall?.toolName) setSelectedTool(selectedServer?.tools.find((t: any) => t.name === toolCall.toolName) || null);
+                                setToolError(null);
+                              }}
+                              style={{
+                                padding: "0.4rem 0.5rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                cursor: "pointer",
+                                background: "rgba(255,255,255,0.04)",
+                              }}
+                            >
+                              <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{toolCall?.toolName || "run"}</div>
+                              <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+                                {new Date(item.startTime).toLocaleTimeString()}
+                                {duration !== null && <span style={{ marginLeft: "0.4rem", color: "rgba(99,102,241,0.8)" }}>{duration}ms</span>}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -645,9 +645,9 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
-  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
+  // Auto-scroll logs to bottom when new entries arrive
   useEffect(() => {
-    logsRef.current?.scrollTo({ top: 0 });
+    logsRef.current?.scrollTo({ top: logsRef.current.scrollHeight });
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
@@ -1123,12 +1123,11 @@ export default function MCPInspector() {
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log) => {
+                          {[...logs].reverse().map((log, i) => {
                             const color = logColors[log.type] || "#9ca3af";
-                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
                             return (
                               <div
-                                key={logKey}
+                                key={i}
                                 style={{
                                   display: "grid",
                                   // Fixed columns: time | type | message

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -6,6 +6,7 @@ import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
 import { JsonResultView } from '../components/result/JsonResultView';
 import { McpContentView } from '../components/result/McpContentView';
+import { WidgetSandbox } from '../components/WidgetSandbox';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 
 // Compact collapsible result bubble for chat mode
@@ -131,7 +132,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
 }
 
 // ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
-function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
+function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; run?: ExecutionRun; sessionId?: string }) {
   const [collapsed, setCollapsed] = useState(false);
   const thinking  = steps.find(s => s.type === "thinking");
   const toolCall  = steps.find(s => s.type === "tool_call");
@@ -224,6 +225,14 @@ function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: Executi
                 <div style={{ marginTop: "0.2rem" }}>
                   <ChatResultBubble result={toolResult.result} />
                 </div>
+                {toolResult.resourceUri && sessionId && toolCall && (
+                  <WidgetSandbox
+                    sessionId={sessionId}
+                    resourceUri={toolResult.resourceUri}
+                    toolInput={toolCall.params || {}}
+                    toolResult={toolResult.result}
+                  />
+                )}
               </div>
             </div>
           )}
@@ -278,6 +287,7 @@ type ChatMessage = {
   toolName?: string
   params?: any
   result?: any
+  resourceUri?: string // set on tool_result when tool has _meta["ui/resourceUri"]
   timestamp: number
   perfMark?: number    // high-res mark for duration math (performance.now())
 }
@@ -733,11 +743,22 @@ export default function MCPInspector() {
       res.params
     )
 
+    // Check for UI widget resource — can be on the tool definition (tools/list)
+    // or on the result itself (FastMCP puts _meta on the result, not the tool def)
+    const toolDef = selectedServer.tools.find((t: any) => t.name === res.tool_name)
+    const resourceUri: string | undefined =
+      toolDef?._meta?.["ui/resourceUri"] ||
+      toolDef?._meta?.ui?.resourceUri ||
+      result?.result?._meta?.["ui/resourceUri"] ||
+      result?.result?._meta?.ui?.resourceUri ||
+      undefined
+
     const resultMsg: ChatMessage = {
       id: generateId(),
       runId,
       type: "tool_result",
       result,
+      resourceUri,
       timestamp: Date.now(),
       perfMark: performance.now()
     }
@@ -1424,7 +1445,7 @@ export default function MCPInspector() {
                               if (group.kind === "run") {
                                 return (
                                   <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} sessionId={selectedServer?.session_id ?? undefined} />
                                   </div>
                                 );
                               }

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -138,7 +138,7 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
   const toolCall  = steps.find(s => s.type === "tool_call");
   const toolResult = steps.find(s => s.type === "tool_result");
   const errorStep = steps.find(s => s.type === "error");
-  const isActive  = !toolResult && !errorStep; // run still in progress
+  const isActive  = run ? !run.endTime : !toolResult && !errorStep; // use run.endTime when available
 
   const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
   const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,5 +1,12 @@
-// import React from "react";
 import { useState, useEffect, useRef } from "react";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { apiClient } from "@/services/api";
+import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
+import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
+import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 
 // Compact collapsible result bubble for chat mode
 function ChatResultBubble({ result }: { result: unknown }) {
@@ -60,15 +67,160 @@ function ChatResultBubble({ result }: { result: unknown }) {
     </div>
   );
 }
-import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
-import { apiClient } from "@/services/api";
-import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
-import { ToolResult } from '../components/result/ToolResult';
-import { JsonResultView } from '../components/result/JsonResultView';
-import { McpContentView } from '../components/result/McpContentView';
-import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
+// ── Animated thinking indicator ──────────────────────────────────────────────
+function ThinkingDots() {
+  return (
+    <span style={{ display: "inline-flex", gap: "3px", alignItems: "center", marginLeft: "4px" }}>
+      {[0, 1, 2].map(i => (
+        <span key={i} style={{
+          width: "4px", height: "4px", borderRadius: "50%",
+          background: "rgba(255,255,255,0.55)", display: "inline-block",
+          animation: `thinking-blink 1.4s infinite ${i * 0.2}s`,
+        }} />
+      ))}
+    </span>
+  );
+}
 
+// ── Group flat chat messages into standalone + run blocks ─────────────────────
+type DisplayGroup =
+  | { kind: "standalone"; msg: ChatMessage }
+  | { kind: "run"; runId: string; steps: ChatMessage[]; run?: ExecutionRun }
+
+function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): DisplayGroup[] {
+  const runMap = new Map(execHistory.map(r => [r.runId, r]));
+  const seen = new Set<string>();
+  return messages.reduce<DisplayGroup[]>((acc, msg) => {
+    if (!msg.runId) {
+      acc.push({ kind: "standalone", msg });
+    } else if (!seen.has(msg.runId)) {
+      seen.add(msg.runId);
+      acc.push({
+        kind: "run",
+        runId: msg.runId,
+        steps: messages.filter(m => m.runId === msg.runId),
+        run: runMap.get(msg.runId),
+      });
+    }
+    return acc;
+  }, []);
+}
+
+// ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
+function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const thinking  = steps.find(s => s.type === "thinking");
+  const toolCall  = steps.find(s => s.type === "tool_call");
+  const toolResult = steps.find(s => s.type === "tool_result");
+  const errorStep = steps.find(s => s.type === "error");
+  const isActive  = !toolResult && !errorStep; // run still in progress
+
+  const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
+  const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
+    ? Math.round(toolCall.perfMark - thinking.perfMark) : null;
+  const toolMs     = (toolResult?.perfMark && toolCall?.perfMark)
+    ? Math.round(toolResult.perfMark - toolCall.perfMark) : null;
+
+  const dot = (color: string) => (
+    <div style={{ width: "7px", height: "7px", borderRadius: "50%", background: color, marginTop: "4px", flexShrink: 0 }} />
+  );
+
+  return (
+    <div style={{ maxWidth: "90%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px", overflow: "hidden" }}>
+      {/* Header */}
+      <div
+        onClick={() => setCollapsed(v => !v)}
+        style={{
+          display: "flex", alignItems: "center", gap: "0.5rem",
+          padding: "0.45rem 0.75rem",
+          background: "rgba(255,255,255,0.04)", cursor: "pointer",
+          borderBottom: collapsed ? "none" : "1px solid rgba(63,63,70,0.25)",
+        }}
+      >
+        <span style={{ fontSize: "0.7rem", opacity: 0.45 }}>{collapsed ? "▶" : "▼"}</span>
+        <span style={{ fontSize: "0.8rem", fontWeight: 600 }}>
+          {toolCall ? `🔧 ${toolCall.toolName}` : errorStep ? "❌ Error" : "🤖 Thinking"}
+        </span>
+        {isActive && <ThinkingDots />}
+        {totalMs !== null && (
+          <span style={{ marginLeft: "auto", fontSize: "0.7rem", color: "rgba(99,102,241,0.7)", fontFamily: "monospace" }}>
+            {totalMs}ms
+          </span>
+        )}
+      </div>
+
+      {!collapsed && (
+        <div style={{ padding: "0.6rem 0.75rem", display: "flex", flexDirection: "column", gap: "0.55rem" }}>
+          {/* Thinking step */}
+          {thinking && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#3b82f6")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#60a5fa", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Thinking
+                  {thinkingMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{thinkingMs}ms</span>}
+                  {isActive && <ThinkingDots />}
+                </div>
+                <div style={{ fontSize: "0.73rem", opacity: 0.6, fontStyle: "italic", marginTop: "0.15rem" }}>
+                  {thinking.content}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Tool call step */}
+          {toolCall && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#f59e0b")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fbbf24", fontWeight: 600 }}>
+                  Tool: {toolCall.toolName}
+                </div>
+                <pre style={{
+                  margin: "0.2rem 0 0", padding: "0.35rem 0.5rem",
+                  background: "rgba(0,0,0,0.3)", borderRadius: "6px",
+                  fontSize: "0.7rem", overflowX: "auto", whiteSpace: "pre-wrap",
+                  wordBreak: "break-all", color: "#e5e7eb", fontFamily: "ui-monospace,monospace",
+                }}>
+                  {JSON.stringify(toolCall.params, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          {/* Result step */}
+          {toolResult && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#22c55e")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#4ade80", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Result
+                  {toolMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{toolMs}ms</span>}
+                </div>
+                <div style={{ marginTop: "0.2rem" }}>
+                  <ChatResultBubble result={toolResult.result} />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Error step */}
+          {errorStep && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#ef4444")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fca5a5", fontWeight: 600 }}>Error</div>
+                <div style={{ fontSize: "0.73rem", color: "#fca5a5", marginTop: "0.15rem" }}>
+                  {errorStep.content}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
 // Type for server object
 interface MCPServer {
   id: string;
@@ -154,13 +306,17 @@ export default function MCPInspector() {
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
   const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
 
-  // Helper to update chat for the currently selected server
-  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
-    if (!selectedServerId) return;
+  // Helper to update chat — accepts explicit serverId so async flows
+  // (runChatTool) stay pinned to the originating server even if the user
+  // switches selection while the request is in-flight.
+  const updateChat = (
+    serverId: string,
+    updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])
+  ) => {
     setChatHistoryByServer(prev => ({
       ...prev,
-      [selectedServerId]: typeof updater === "function"
-        ? updater(prev[selectedServerId] ?? [])
+      [serverId]: typeof updater === "function"
+        ? updater(prev[serverId] ?? [])
         : updater
     }));
   };
@@ -173,6 +329,8 @@ export default function MCPInspector() {
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const chatBottomRef = useRef<HTMLDivElement>(null);
+  // Tracks how many backend log entries existed when the user last cleared, per server
+  const logsClearedOffsetRef = useRef<Record<string, number>>({});
 
   const handleConnect = async () => {
 
@@ -259,7 +417,7 @@ export default function MCPInspector() {
       setChatHistoryByServer(prev => ({
         ...prev,
         [serverId]: [{
-          id: crypto.randomUUID(),
+          id: generateId(),
           type: "assistant",
           content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
           timestamp: Date.now(),
@@ -381,7 +539,7 @@ export default function MCPInspector() {
         [serverId]: [
           ...(prev[serverId] ?? []),
           {
-            id: crypto.randomUUID(),
+            id: generateId(),
             type: "assistant" as const,
             content: `Reconnected to ${res.server_info?.name || "server"}.`,
             timestamp: Date.now(),
@@ -415,6 +573,12 @@ export default function MCPInspector() {
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
+  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
+  const generateId = () =>
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
+
   const runTool = async (params: any) => {
     if (!selectedServer?.session_id || !selectedTool || executing) return;
 
@@ -435,15 +599,15 @@ export default function MCPInspector() {
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
       if (selectedServerId) {
-        const runId = crypto.randomUUID();
+        const runId = generateId();
         const run: ExecutionRun = {
           runId,
           serverId: selectedServerId,
           startTime: Date.now() - Math.round(end - start),
           endTime: Date.now(),
           steps: [
-            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
-            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+            { id: generateId(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: generateId(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
           ]
         };
         setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
@@ -455,12 +619,6 @@ export default function MCPInspector() {
       setExecuting(false);
     }
   };
-
-  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
-  const generateId = () =>
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
  const runChatTool = async () => {
   // Guard against concurrent requests
@@ -480,20 +638,20 @@ export default function MCPInspector() {
   // Capture history with userMsg before any state updates — used below to
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
+  const capturedServerId = selectedServerId
 
-  updateChat(prev => [...prev, userMsg])
+  updateChat(capturedServerId, prev => [...prev, userMsg])
 
   // 3A-4: start an ExecutionRun for this agent turn
-  const runId = crypto.randomUUID()
+  const runId = generateId()
   const runStartTime = Date.now()
   const runSteps: ChatMessage[] = []
-  const capturedServerId = selectedServerId
 
   try {
     setChatLoading(true)
 
     const thinkingMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "thinking",
       content: "Deciding which tool to use...",
@@ -501,7 +659,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, thinkingMsg])
+    updateChat(capturedServerId, prev => [...prev, thinkingMsg])
     runSteps.push(thinkingMsg)
 
     const res = await apiClient.chatWithInspector(
@@ -515,18 +673,18 @@ export default function MCPInspector() {
       }
     )
 
-    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+    updateChat(capturedServerId, prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         runId,
         type: "assistant",
         content: res.message,
         timestamp: Date.now(),
         perfMark: performance.now()
       }
-      updateChat(prev => [...prev, assistantMsg])
+      updateChat(capturedServerId, prev => [...prev, assistantMsg])
       // save run (no tool call — just clarification)
       setExecutionHistoryByServer(prev => ({
         ...prev,
@@ -536,7 +694,7 @@ export default function MCPInspector() {
     }
 
     const toolCallMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "tool_call",
       toolName: res.tool_name,
@@ -545,7 +703,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, toolCallMsg])
+    updateChat(capturedServerId, prev => [...prev, toolCallMsg])
     runSteps.push(toolCallMsg)
 
     const result = await apiClient.runInspectorTool(
@@ -555,7 +713,7 @@ export default function MCPInspector() {
     )
 
     const resultMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "tool_result",
       result,
@@ -563,7 +721,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, resultMsg])
+    updateChat(capturedServerId, prev => [...prev, resultMsg])
     runSteps.push(resultMsg)
 
     // save completed run
@@ -575,7 +733,7 @@ export default function MCPInspector() {
   } catch (err: any) {
 
     const errorMsg: ChatMessage = {
-      id: crypto.randomUUID(),
+      id: generateId(),
       runId,
       type: "error",
       content: err?.message || "Chat error",
@@ -583,7 +741,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(prev => [...prev, errorMsg])
+    updateChat(capturedServerId, prev => [...prev, errorMsg])
     runSteps.push(errorMsg)
 
     // save failed run
@@ -626,9 +784,13 @@ export default function MCPInspector() {
     if (savedSelectedId) setSelectedServerId(savedSelectedId)
   }, [])
 
-  // Persist servers list whenever it changes
+  // Persist servers list — strip auth secrets (tokens/header values) before writing
   useEffect(() => {
-    sessionStorage.setItem('inspector-servers', JSON.stringify(servers))
+    const safeServers = servers.map(s => ({
+      ...s,
+      auth: s.auth ? { type: s.auth.type } : undefined,
+    }));
+    sessionStorage.setItem('inspector-servers', JSON.stringify(safeServers))
   }, [servers])
 
   // Persist selected server ID whenever it changes
@@ -663,7 +825,9 @@ export default function MCPInspector() {
     if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
+      const allLogs: LogEntry[] = res.logs || [];
+      const offset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: allLogs.slice(offset) }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -1094,7 +1258,11 @@ export default function MCPInspector() {
                       </div>
                       {logs.length > 0 && selectedServerId && (
                         <button
-                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          onClick={() => {
+                            const currentTotal = (logsClearedOffsetRef.current[selectedServerId] ?? 0) + logs.length;
+                            logsClearedOffsetRef.current[selectedServerId] = currentTotal;
+                            setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
+                          }}
                           style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
                         >
                           Clear

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -102,6 +102,17 @@ type DisplayGroup =
 
 function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): DisplayGroup[] {
   const runMap = new Map(execHistory.map(r => [r.runId, r]));
+
+  // Pre-build runId → steps map in a single pass to avoid O(n²) inner filter
+  const stepsByRunId = new Map<string, ChatMessage[]>();
+  for (const msg of messages) {
+    if (msg.runId) {
+      const arr = stepsByRunId.get(msg.runId);
+      if (arr) arr.push(msg);
+      else stepsByRunId.set(msg.runId, [msg]);
+    }
+  }
+
   const seen = new Set<string>();
   return messages.reduce<DisplayGroup[]>((acc, msg) => {
     if (!msg.runId) {
@@ -111,7 +122,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
       acc.push({
         kind: "run",
         runId: msg.runId,
-        steps: messages.filter(m => m.runId === msg.runId),
+        steps: stepsByRunId.get(msg.runId) ?? [],
         run: runMap.get(msg.runId),
       });
     }
@@ -686,12 +697,9 @@ export default function MCPInspector() {
       }
     )
 
-    updateChat(capturedServerId, prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
-
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
         id: generateId(),
-        runId,
         type: "assistant",
         content: res.message,
         timestamp: Date.now(),

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -41,26 +41,39 @@ function ChatResultBubble({ result }: { result: unknown }) {
           {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
         </button>
         {expanded && (
-          <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
-            <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
-            <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+            <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
+              <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
+              <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+            </div>
+            <button
+              onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
+              style={{ ...tabStyle(false), border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.25rem" }}
+              title="Copy to clipboard"
+            >
+              Copy
+            </button>
           </div>
         )}
       </div>
       {expanded && (
         <div style={{
-          maxHeight: "260px", overflowY: "auto",
+          maxHeight: "260px", overflowY: "auto", overflowX: "hidden",
           background: "rgba(0,0,0,0.3)",
           border: "1px solid rgba(63,63,70,0.5)",
           borderRadius: "0.5rem",
           padding: "0.75rem",
-          marginTop: "0.25rem"
+          marginTop: "0.25rem",
+          width: "100%", boxSizing: "border-box",
         }}>
           {viewMode === "raw"
-            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace" }}>{JSON.stringify(result, null, 2)}</pre>
-            : (isMcp || isMcpArray)
-              ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
-              : <JsonResultView data={result} />
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-all", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
+            : <div style={{ minWidth: 0, width: "100%", overflow: "hidden" }}>
+                {(isMcp || isMcpArray)
+                  ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
+                  : <JsonResultView data={result} />
+                }
+              </div>
           }
         </div>
       )}
@@ -862,6 +875,7 @@ export default function MCPInspector() {
       className="dashboard"
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
+      <style>{`@keyframes thinking-blink{0%,80%,100%{opacity:0}40%{opacity:1}}`}</style>
       <Navbar />
 
       <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
@@ -1157,58 +1171,6 @@ export default function MCPInspector() {
                       )}
                     </div>
 
-                    {/* Execution History */}
-                    <div style={{ marginTop: "1.25rem", flexShrink: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
-                        <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
-                        <button
-                          onClick={() => selectedServerId && setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
-                          style={{
-                            fontSize: "0.7rem", padding: "0.2rem 0.5rem",
-                            borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
-                            background: "transparent", color: "rgba(255,255,255,0.6)", cursor: "pointer",
-                          }}
-                        >
-                          Clear
-                        </button>
-                      </div>
-
-                      <div
-                        style={{
-                          display: "flex", flexDirection: "column", gap: "0.4rem",
-                          maxHeight: "160px", overflowY: "auto",
-                        }}
-                      >
-                        {executionHistory.map((item: ExecutionRun) => {
-                          const toolCall = item.steps.find(s => s.type === "tool_call");
-                          const toolResult = item.steps.find(s => s.type === "tool_result");
-                          const duration = item.endTime ? item.endTime - item.startTime : null;
-                          return (
-                            <div
-                              key={item.runId}
-                              onClick={() => {
-                                if (toolResult) setToolResult(toolResult.result);
-                                if (toolCall?.toolName) setSelectedTool(selectedServer?.tools.find((t: any) => t.name === toolCall.toolName) || null);
-                                setToolError(null);
-                              }}
-                              style={{
-                                padding: "0.4rem 0.5rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
-                                cursor: "pointer",
-                                background: "rgba(255,255,255,0.04)",
-                              }}
-                            >
-                              <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{toolCall?.toolName || "run"}</div>
-                              <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>
-                                {new Date(item.startTime).toLocaleTimeString()}
-                                {duration !== null && <span style={{ marginLeft: "0.4rem", color: "rgba(99,102,241,0.8)" }}>{duration}ms</span>}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
                   </div>
                 </Panel>
 
@@ -1450,83 +1412,30 @@ export default function MCPInspector() {
                               padding: "0.5rem 0.5rem 0.75rem 0.25rem"
                             }}
                           >
-                            {chatHistory.map((msg) => {
+                            {groupMessages(chatHistory, executionHistory).map((group) => {
+                              if (group.kind === "run") {
+                                return (
+                                  <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                  </div>
+                                );
+                              }
+
+                              const msg = group.msg;
 
                               if (msg.type === "user") {
                                 return (
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
                                     <div style={{
-                                      background: "#2563eb",
-                                      color: "#fff",
+                                      background: "#2563eb", color: "#fff",
                                       padding: "0.6rem 0.75rem",
                                       borderRadius: "12px 12px 4px 12px",
-                                      maxWidth: "70%",
-                                      fontSize: "0.9rem",
-                                      lineHeight: 1.4
+                                      maxWidth: "70%", fontSize: "0.9rem", lineHeight: 1.4
                                     }}>
                                       {msg.content}
                                     </div>
                                   </div>
-                                )
-                              }
-
-                              if (msg.type === "thinking") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      fontSize: "0.8rem",
-                                      opacity: 0.7,
-                                      fontStyle: "italic",
-                                      padding: "0.3rem 0.5rem"
-                                    }}>
-                                      🤖 {msg.content}...
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              if (msg.type === "tool_call") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      background: "rgba(59,130,246,0.12)",
-                                      border: "1px solid rgba(59,130,246,0.35)",
-                                      borderRadius: "8px",
-                                      padding: "0.6rem",
-                                      maxWidth: "80%",
-                                      fontSize: "0.8rem"
-                                    }}>
-                                      <div style={{ fontWeight: 600, marginBottom: "0.3rem" }}>
-                                        🔧 Tool: {msg.toolName}
-                                      </div>
-
-                                      <div style={{
-                                        fontFamily: "monospace",
-                                        fontSize: "0.75rem",
-                                        background: "rgba(0,0,0,0.3)",
-                                        padding: "0.4rem",
-                                        borderRadius: "6px",
-                                        overflowX: "auto"
-                                      }}>
-                                        {JSON.stringify(msg.params, null, 2)}
-                                      </div>
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              if (msg.type === "tool_result") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      borderLeft: "3px solid #22c55e",
-                                      paddingLeft: "0.6rem",
-                                      maxWidth: "85%"
-                                    }}>
-                                      <ChatResultBubble result={msg.result} />
-                                    </div>
-                                  </div>
-                                )
+                                );
                               }
 
                               if (msg.type === "assistant") {
@@ -1537,33 +1446,15 @@ export default function MCPInspector() {
                                       border: "1px solid rgba(99,102,241,0.3)",
                                       padding: "0.6rem 0.75rem",
                                       borderRadius: "12px 12px 12px 4px",
-                                      maxWidth: "70%",
-                                      fontSize: "0.9rem"
+                                      maxWidth: "70%", fontSize: "0.9rem"
                                     }}>
                                       {msg.content}
                                     </div>
                                   </div>
-                                )
+                                );
                               }
 
-                              if (msg.type === "error") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      background: "rgba(239,68,68,0.15)",
-                                      border: "1px solid rgba(239,68,68,0.4)",
-                                      padding: "0.6rem",
-                                      borderRadius: "8px",
-                                      color: "#fca5a5",
-                                      maxWidth: "70%"
-                                    }}>
-                                      ❌ {msg.content}
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              return null
+                              return null;
                             })}
                             <div ref={chatBottomRef} />
                           </div>

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -328,6 +328,16 @@ class ApiClient {
     });
   }
 
+  async listInspectorResources(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/resources`);
+  }
+
+  async readInspectorResource(sessionId: string, uri: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/resources/read`, {
+      method: "POST",
+      body: JSON.stringify({ uri }),
+    });
+  }
 
   /**
    * Clone a GitHub repository and register its MCP server(s).


### PR DESCRIPTION
## Summary
- Implements SEP-1865 (MCP Apps) — widget rendering inline in the Chat tab
- When a tool result contains `_meta["ui/resourceUri"]`, the inspector fetches the widget HTML via `resources/read` and renders it in a sandboxed double-iframe directly below the tool result bubble

## Changes
- `fluidmcp/cli/api/inspector.py` — new `GET /inspector/{session_id}/resources` and `POST /inspector/{session_id}/resources/read` endpoints
- `fluidmcp/cli/services/inspector_session.py` — `list_resources()` and `read_resource()` methods, auto-incrementing request IDs, full SSE persistent listener rewrite
- `fluidmcp/frontend/src/components/WidgetSandbox.tsx` — sandboxed iframe component with postMessage bridge
- `fluidmcp/frontend/public/sandbox-proxy.html` — double-iframe proxy for widget isolation
- `fluidmcp/frontend/src/services/api.ts` — `listInspectorResources()` and `readInspectorResource()` methods
- `fluidmcp/frontend/src/pages/MCPInspector.tsx` — widget rendering wired into ExecutionRunBlock

## Notes
- Based on mcp-jam-phase3b-timeline-widgets (#593) — once that merges into development, this PR will show only widget sandbox changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)