### PR TITLE
MCP-477: fix: add Bearer token to cloneFromGithub and preserve HTTP status in errors

### DIFF
--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -94,7 +94,7 @@ class ApiClient {
         const error: ApiError = await response.json().catch(() => ({
           detail: `HTTP ${response.status}: ${response.statusText}`,
         }));
-        throw new Error(error.detail);
+        throw new ApiHttpError(error.detail, response.status);
       }
 
       return response.json();
@@ -349,6 +349,7 @@ class ApiClient {
         headers: {
           'Content-Type': 'application/json',
           'X-GitHub-Token': githubToken,
+          ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
         },
         body: JSON.stringify(payload),
         signal: timeoutController.signal,


### PR DESCRIPTION
## Summary

- **Bug 1 — Missing Bearer token on GitHub clone**: `cloneFromGithub` used a raw `fetch` instead of `this.request()`, so the `Authorization: Bearer` header was never sent to `/api/servers/from-github`. The backend requires `get_token` auth on this endpoint (same as all other POST/PUT/DELETE server endpoints), meaning the call would fail with 401 in secure mode.

- **Bug 2 — HTTP status code lost in `request()` errors**: `request()` threw a plain `Error`, discarding the HTTP status code. Changed to `ApiHttpError` (already used by `cloneFromGithub`) so all callers can now distinguish 401 / 403 / 404 / 409 etc. — confirmed safe since all backend errors return `{"detail": "..."}` (FastAPI default).

## Backend verification

- `/api/servers/from-github` uses `Depends(get_token)` — Bearer token required ✓
- All error responses use `{"detail": "..."}` — `ApiHttpError(error.detail, status)` reads the right field ✓
- GET endpoints (`/servers`, `/servers/{id}`) are intentionally unauthenticated — no impact ✓

## Test plan

- [ ] In secure mode (`FMCP_SECURE_MODE=true`), open Manage → Clone from GitHub → confirm clone succeeds (previously would 401)
- [ ] Trigger a 409 conflict (clone same repo twice without upsert) → confirm the "server ID already taken" UI hint still appears
- [ ] Trigger any other API error (e.g. stop a server that isn't running) → confirm error message is shown correctly

Generated with Claude Code