### PR TITLE
MCP Inspector 4A: Widget sandbox scroll & layout fixes

### DIFF
--- a/fluidmcp/cli/.env.example
+++ b/fluidmcp/cli/.env.example
@@ -15,7 +15,8 @@
 # FMCP_GITHUB_TOKEN=ghp_yourTokenHere
 # GITHUB_TOKEN=ghp_yourTokenHere
 
-# Inspector is using Groq's model, so GROQ_API_KEY is required for InspectorAgent to function
+# Inspector chat uses Groq's model; GROQ_API_KEY is required only for InspectorAgent chat features,
+# not for basic inspector connectivity
 #GROQ_API_KEY=gsk_yourTokenHere 
 
 # S3 Credentials - REQUIRED only when using --master mode

--- a/fluidmcp/cli/.env.example
+++ b/fluidmcp/cli/.env.example
@@ -15,6 +15,9 @@
 # FMCP_GITHUB_TOKEN=ghp_yourTokenHere
 # GITHUB_TOKEN=ghp_yourTokenHere
 
+# Inspector is using Groq's model, so GROQ_API_KEY is required for InspectorAgent to function
+#GROQ_API_KEY=gsk_yourTokenHere 
+
 # S3 Credentials - REQUIRED only when using --master mode
 # Uncomment all 4 to enable S3 sync features
 # S3_BUCKET_NAME=your-bucket-name

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -6,7 +6,7 @@ from typing import Dict, Any, Optional
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Body, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from loguru import logger
 
 from ..services.inspector_session import InspectorSession
@@ -36,6 +36,9 @@ class ConnectRequest(BaseModel):
     env_vars: Optional[Dict[str, str]] = None
     timeout: Optional[int] = 10000  # ms
 
+class ChatRequest(BaseModel):
+    message: str
+    chat_history: Optional[list] = Field(default_factory=list)
 
 # ─── URL Validation ────────────────────────────────────────────────────────────
 
@@ -224,3 +227,58 @@ async def get_logs(session_id: str):
 
     session.last_used = time.time()
     return {"logs": session.logs}
+
+@router.post("/inspector/{session_id}/chat")
+async def chat_with_tools(session_id: str, body: ChatRequest):
+    """
+    Chat endpoint that asks the LLM which tool to run.
+    It DOES NOT execute the tool — frontend does that.
+    """
+
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    session.last_used = time.time()
+
+    try:
+        # Lazy import — avoids server startup failure when GROQ_API_KEY is absent
+        from ..services.inspector_agent import choose_tool_with_llm
+
+        tools = await session.list_tools()
+
+        if not tools:
+            return {
+                "clarification_needed": True,
+                "message": "No tools available on this server."
+            }
+
+        # Call the Groq agent
+        agent_result = await choose_tool_with_llm(body.message, tools)
+
+        # Validate the response has the expected fields
+        tool_name = agent_result.get("tool_name")
+        available_names = {t["name"] for t in tools}
+        if not tool_name or not isinstance(tool_name, str) or tool_name not in available_names:
+            return {
+                "clarification_needed": True,
+                "message": "Could not determine which tool to run."
+            }
+
+        session.add_log(
+            "chat",
+            f"User: {body.message} → tool selected: {tool_name}"
+        )
+
+        return {
+            "tool_name": tool_name,
+            "params": agent_result.get("params", {})
+        }
+
+    except Exception as e:
+        logger.error(f"Inspector chat error: {e}")
+
+        return {
+            "clarification_needed": True,
+            "message": "Unable to determine which tool to run."
+        }

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -253,8 +253,10 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent
-        agent_result = await choose_tool_with_llm(body.message, tools)
+        # Call the Groq agent, passing chat history for multi-turn context
+        agent_result = await choose_tool_with_llm(
+            body.message, tools, chat_history=body.chat_history or []
+        )
 
         # Validate the response has the expected fields
         tool_name = agent_result.get("tool_name")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -210,3 +210,17 @@ async def disconnect(session_id: str):
 
     logger.info(f"Inspector: session {session_id} disconnected")
     return {"status": "disconnected"}
+
+
+@router.get("/inspector/{session_id}/logs")
+async def get_logs(session_id: str):
+    """
+    Get the execution logs for an active session.
+    Updates last_used to keep the session alive.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    session.last_used = time.time()
+    return {"logs": session.logs}

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -1,0 +1,212 @@
+import uuid
+import asyncio
+import time
+import ipaddress
+from typing import Dict, Any, Optional
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, HTTPException, Body, Depends
+from pydantic import BaseModel
+from loguru import logger
+
+from ..services.inspector_session import InspectorSession
+from ..auth import verify_token
+
+router = APIRouter(dependencies=[Depends(verify_token)])
+
+# In-memory session store: session_id -> InspectorSession
+sessions: Dict[str, InspectorSession] = {}
+
+SESSION_TTL = 1800   # 30 minutes in seconds
+CLEANUP_INTERVAL = 300  # Run cleanup every 5 minutes
+
+
+# ─── Request Models ────────────────────────────────────────────────────────────
+
+class AuthConfig(BaseModel):
+    type: str = "none"        # "none" | "bearer"
+    token: Optional[str] = None
+
+
+class ConnectRequest(BaseModel):
+    url: str
+    transport: str = "http"   # "http" | "sse" | "stdio"
+    auth: Optional[AuthConfig] = None
+    headers: Optional[Dict[str, str]] = None
+    env_vars: Optional[Dict[str, str]] = None
+    timeout: Optional[int] = 10000  # ms
+
+
+# ─── URL Validation ────────────────────────────────────────────────────────────
+
+def _validate_mcp_url(url: str) -> None:
+    """Block non-HTTP schemes and connections to private/internal network ranges."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise HTTPException(400, "Invalid URL")
+
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, "Only http/https URLs are allowed")
+
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(400, "URL must include a host")
+
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise HTTPException(400, "Connections to private/internal addresses are not allowed")
+    except ValueError:
+        pass  # hostname, not a bare IP — DNS rebinding is out of scope here
+
+
+# ─── TTL Cleanup ───────────────────────────────────────────────────────────────
+
+async def cleanup_sessions():
+    """
+    Background task: remove sessions that have been idle for SESSION_TTL seconds.
+    Runs every CLEANUP_INTERVAL seconds.
+    """
+    while True:
+        await asyncio.sleep(CLEANUP_INTERVAL)
+        now = time.time()
+
+        expired = [
+            sid for sid, session in list(sessions.items())
+            if now - session.last_used > SESSION_TTL
+        ]
+
+        for sid in expired:
+            try:
+                await sessions[sid].close()
+                logger.info(f"Inspector: expired session {sid}")
+            except Exception:
+                pass
+            sessions.pop(sid, None)
+
+
+# ─── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.post("/inspector/connect")
+async def connect_server(body: ConnectRequest):
+    """
+    Connect to an external MCP server temporarily.
+
+    Performs the MCP initialize handshake, fetches the tool list, and returns
+    everything in one response so the frontend avoids a second round trip.
+
+    The session is stored in memory and expires after SESSION_TTL seconds of
+    inactivity. Nothing is persisted to MongoDB.
+    """
+    if not body.url:
+        raise HTTPException(400, "url is required")
+
+    _validate_mcp_url(body.url)
+
+    auth_dict = body.auth.model_dump() if body.auth else {}
+
+    session = InspectorSession(
+        url=body.url,
+        transport=body.transport,
+        auth=auth_dict,
+        headers=body.headers,
+        env_vars=body.env_vars,
+        timeout=body.timeout or 10000,
+    )
+
+    # Perform MCP initialize handshake
+    try:
+        server_info = await session.initialize()
+    except Exception as e:
+        await session.close()
+        logger.warning(f"Inspector: failed to connect to {body.url} — {e}")
+        raise HTTPException(502, f"Failed to connect to MCP server: {str(e)}")
+
+    # Fetch tools immediately so frontend gets everything in one response
+    try:
+        tools = await session.list_tools()
+    except Exception as e:
+        await session.close()
+        logger.warning(f"Inspector: connected but failed to list tools for {body.url} — {e}")
+        raise HTTPException(502, f"Connected but failed to fetch tools: {str(e)}")
+
+    session_id = str(uuid.uuid4())
+    sessions[session_id] = session
+
+    logger.info(f"Inspector: new session {session_id} for {body.url} ({body.transport}), {len(tools)} tools")
+
+    return {
+        "session_id": session_id,
+        "server_info": server_info,
+        "tools": tools
+    }
+
+
+@router.get("/inspector/{session_id}/tools")
+async def list_tools(session_id: str):
+    """
+    Refresh the tool list for an active session.
+    Updates last_used to keep the session alive.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        tools = await session.list_tools()
+        return {"tools": tools, "count": len(tools)}
+    except Exception as e:
+        logger.error(f"Inspector: list_tools failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to fetch tools: {str(e)}")
+
+
+@router.post("/inspector/{session_id}/tools/{tool_name}/run")
+async def run_tool(
+    session_id: str,
+    tool_name: str,
+    arguments: Dict[str, Any] = Body(default={})
+):
+    """
+    Execute a tool on the connected MCP server.
+
+    Returns the tool result on success, or a structured error object on failure
+    so the frontend OutputViewer can display it gracefully.
+    Updates last_used to keep the session alive.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        result = await session.call_tool(tool_name, arguments)
+        return {"success": True, "result": result}
+    except Exception as e:
+        logger.warning(f"Inspector: tool '{tool_name}' failed on session {session_id} — {e}")
+        # Return structured error instead of raising — OutputViewer handles this gracefully
+        return {
+            "success": False,
+            "error": str(e),
+            "tool": tool_name
+        }
+
+
+@router.delete("/inspector/{session_id}")
+async def disconnect(session_id: str):
+    """
+    Disconnect from an MCP server and remove the session.
+    Called explicitly by the Disconnect button in the UI.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        await session.close()
+    except Exception as e:
+        logger.warning(f"Inspector: error closing session {session_id} — {e}")
+    finally:
+        sessions.pop(session_id, None)
+
+    logger.info(f"Inspector: session {session_id} disconnected")
+    return {"status": "disconnected"}

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -40,6 +40,9 @@ class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
 
+class ReadResourceRequest(BaseModel):
+    uri: str
+
 # ─── URL Validation ────────────────────────────────────────────────────────────
 
 def _validate_mcp_url(url: str) -> None:
@@ -227,6 +230,42 @@ async def get_logs(session_id: str):
 
     session.last_used = time.time()
     return {"logs": session.logs}
+
+@router.get("/inspector/{session_id}/resources")
+async def list_resources(session_id: str):
+    """
+    List all resources available on the connected MCP server.
+    Also used to discover widget resources (ui:// URIs).
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        resources = await session.list_resources()
+        return {"resources": resources, "count": len(resources)}
+    except Exception as e:
+        logger.error(f"Inspector: list_resources failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to fetch resources: {str(e)}")
+
+
+@router.post("/inspector/{session_id}/resources/read")
+async def read_resource(session_id: str, body: ReadResourceRequest):
+    """
+    Read a resource by URI from the connected MCP server.
+    Used to fetch widget HTML for ui:// resource URIs.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    try:
+        content = await session.read_resource(body.uri)
+        return content
+    except Exception as e:
+        logger.error(f"Inspector: read_resource failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to read resource: {str(e)}")
+
 
 @router.post("/inspector/{session_id}/chat")
 async def chat_with_tools(session_id: str, body: ChatRequest):

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -39,6 +39,7 @@ class ConnectRequest(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
+    system_prompt: Optional[str] = None
 
 class ReadResourceRequest(BaseModel):
     uri: str
@@ -292,9 +293,11 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent, passing chat history for multi-turn context
+        # Call the Groq agent, passing chat history and optional system prompt
         agent_result = await choose_tool_with_llm(
-            body.message, tools, chat_history=body.chat_history or []
+            body.message, tools,
+            chat_history=body.chat_history or [],
+            system_prompt=body.system_prompt or "",
         )
 
         # Validate the response has the expected fields

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -932,7 +932,7 @@ async def add_server_from_github(
     server_name = config.get("server_name")
     subdirectory = config.get("subdirectory")
     env = config.get("env", {})
-    restart_policy = config.get("restart_policy", "never")
+    restart_policy = config.get("restart_policy", "on-failure")
     max_restarts = int(config.get("max_restarts", 3))
     enabled = bool(config.get("enabled", True))
     test_before_save = bool(config.get("test_before_save", True))

--- a/fluidmcp/cli/repositories/base.py
+++ b/fluidmcp/cli/repositories/base.py
@@ -215,6 +215,35 @@ class PersistenceBackend(ABC):
         """
         pass
 
+    # ==================== Crash Event Persistence ====================
+
+    async def save_crash_event(self, event: Dict[str, Any]) -> bool:
+        """
+        Save a server crash event for diagnostics.
+
+        Args:
+            event: Crash event dict with server_id, exit_code, stderr_tail,
+                   uptime_seconds, timestamp
+
+        Returns:
+            True if the event was handled. For backends that don't persist
+            crash events, True means the event was intentionally ignored (no-op).
+        """
+        return True  # Default no-op for backends that don't persist
+
+    async def list_crash_events(self, server_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """
+        List recent crash events for a server.
+
+        Args:
+            server_id: Server identifier
+            limit: Maximum number of events to return
+
+        Returns:
+            List of crash event dicts, most recent first
+        """
+        return []
+
     def supports_rollback(self) -> bool:
         """
         Check if this backend supports model rollback/versioning.

--- a/fluidmcp/cli/repositories/database.py
+++ b/fluidmcp/cli/repositories/database.py
@@ -358,6 +358,19 @@ class DatabaseManager(PersistenceBackend):
             ])
             logger.info("Created compound index on fluidmcp_llm_model_versions for rollback queries")
 
+            # Create indexes on fluidmcp_crash_events collection
+            await self.db.fluidmcp_crash_events.create_index([("server_id", 1), ("timestamp", -1)])
+            # TTL index: auto-delete crash events older than 30 days to prevent unbounded growth
+            try:
+                ttl_days = int(os.getenv("FMCP_CRASH_EVENT_TTL_DAYS", "30"))
+            except ValueError:
+                ttl_days = 30
+            ttl_seconds = ttl_days * 86400
+            await self.db.fluidmcp_crash_events.create_index(
+                "timestamp", expireAfterSeconds=ttl_seconds
+            )
+            logger.info(f"Created TTL index on fluidmcp_crash_events (expires after {ttl_days} days)")
+
             # Create capped collection for logs (100MB max, auto-removes oldest)
             try:
                 # Check if collection exists
@@ -1150,6 +1163,34 @@ class DatabaseManager(PersistenceBackend):
             True (MongoDB backend supports versioning)
         """
         return True
+
+    # ==================== Crash Event Persistence ====================
+
+    async def save_crash_event(self, event: Dict[str, Any]) -> bool:
+        """Save a server crash event to MongoDB."""
+        try:
+            doc = dict(event)
+            doc["timestamp"] = doc.get("timestamp", datetime.utcnow())
+            await self.db.fluidmcp_crash_events.insert_one(doc)
+            logger.info(f"Saved crash event for server '{event.get('server_id')}' (exit_code={event.get('exit_code')})")
+            return True
+        except Exception as e:
+            logger.error(f"Error saving crash event: {e}")
+            return False
+
+    async def list_crash_events(self, server_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """List recent crash events for a server from MongoDB."""
+        try:
+            cursor = self.db.fluidmcp_crash_events.find(
+                {"server_id": server_id}
+            ).sort("timestamp", -1).limit(limit)
+            events = await cursor.to_list(length=limit)
+            for event in events:
+                event.pop("_id", None)
+            return events
+        except Exception as e:
+            logger.error(f"Error listing crash events for '{server_id}': {e}")
+            return []
 
     # ==================== Connection Management ====================
 

--- a/fluidmcp/cli/repositories/memory.py
+++ b/fluidmcp/cli/repositories/memory.py
@@ -26,6 +26,7 @@ class InMemoryBackend(PersistenceBackend):
         self._instances: Dict[str, Dict[str, Any]] = {}
         self._logs: Dict[str, deque] = defaultdict(lambda: deque(maxlen=1000))
         self._llm_models: Dict[str, Dict[str, Any]] = {}
+        self._crash_events: Dict[str, deque] = {}
         self._connected = False
 
     async def connect(self) -> bool:
@@ -41,6 +42,7 @@ class InMemoryBackend(PersistenceBackend):
         self._instances.clear()
         self._logs.clear()
         self._llm_models.clear()
+        self._crash_events.clear()
         self._connected = False
         logger.info("Disconnected in-memory backend")
 
@@ -134,6 +136,24 @@ class InMemoryBackend(PersistenceBackend):
         logs = list(self._logs.get(server_name, []))
         # Return most recent 'lines' logs
         return logs[-lines:] if logs else []
+
+    # ==================== Crash Event Persistence ====================
+
+    async def save_crash_event(self, event: Dict[str, Any]) -> bool:
+        """Save crash event to in-memory storage."""
+        server_id = event.get("server_id")
+        if not server_id:
+            return False
+        if server_id not in self._crash_events:
+            self._crash_events[server_id] = deque(maxlen=100)
+        self._crash_events[server_id].appendleft(dict(event))
+        logger.debug(f"Saved crash event for server '{server_id}' to memory")
+        return True
+
+    async def list_crash_events(self, server_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """List recent crash events from in-memory storage."""
+        events = list(self._crash_events.get(server_id, []))
+        return events[:limit]
 
     # ==================== LLM Model Persistence ====================
 

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -22,6 +22,7 @@ from .api.management import router as mgmt_router
 from .services.package_launcher import create_dynamic_router
 from .services.metrics import get_registry
 from .services.frontend_utils import setup_frontend_routes
+from .api.inspector import router as inspector_router, cleanup_sessions
 from .auth import verify_token
 
 
@@ -257,6 +258,10 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
     app.include_router(mgmt_router, prefix="/api", tags=["management"])
     logger.info("Management API mounted at /api")
 
+    # Include Inspector API
+    app.include_router(inspector_router, prefix="/api", tags=["inspector"])
+    logger.info("Inspector API mounted at /api")
+
     # Include Dynamic MCP Router
     mcp_router = create_dynamic_router(server_manager)
     app.include_router(mcp_router, tags=["mcp"])
@@ -377,6 +382,12 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
                 "mcp": "/{server_name}/mcp"
             }
         }
+
+    # Start Inspector session cleanup task
+    @app.on_event("startup")
+    async def start_inspector_cleanup():
+        asyncio.create_task(cleanup_sessions())
+        logger.info("Inspector session cleanup task started")
 
     # Register cleanup handler for HTTP client and Redis connections
     @app.on_event("shutdown")

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from uvicorn import Config, Server
 
 from .repositories import DatabaseManager, InMemoryBackend, PersistenceBackend
-from .services.server_manager import ServerManager
+from .services.server_manager import ServerManager, MCPHealthMonitor
 from .api.management import router as mgmt_router
 from .services.package_launcher import create_dynamic_router
 from .services.metrics import get_registry
@@ -639,6 +639,15 @@ async def main(args):
     logger.info("Starting background tasks...")
     server_manager.start_idle_cleanup_task()
 
+    # Start MCP server health monitor (detects crashes, triggers auto-restart)
+    try:
+        health_check_interval = int(os.getenv("FMCP_HEALTH_CHECK_INTERVAL", "30"))
+    except ValueError:
+        logger.warning("Invalid FMCP_HEALTH_CHECK_INTERVAL value, using default 30s")
+        health_check_interval = 30
+    health_monitor = MCPHealthMonitor(server_manager, check_interval=health_check_interval)
+    health_monitor.start()
+
     # 4. Create FastAPI app (without MCP servers)
     app = await create_app(
         db_manager=persistence,
@@ -706,6 +715,13 @@ async def main(args):
 
     # Graceful cleanup
     logger.info("Initiating graceful shutdown...")
+
+    try:
+        # Stop health monitor
+        logger.info("Stopping MCP health monitor...")
+        await health_monitor.stop()
+    except Exception as e:
+        logger.error(f"Error stopping health monitor: {e}")
 
     try:
         # Stop idle cleanup task

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -1,0 +1,111 @@
+import os
+import json
+import asyncio
+from loguru import logger
+
+
+def format_tools_for_prompt(tools):
+    """
+    Convert MCP tool schemas into a simple prompt-friendly format.
+    """
+    tool_lines = []
+
+    for tool in tools:
+        name = tool.get("name")
+        desc = tool.get("description", "")
+        schema = tool.get("inputSchema", {})
+        props = schema.get("properties", {})
+
+        params = ", ".join(props.keys())
+
+        tool_lines.append(
+            f"{name}({params}) - {desc}"
+        )
+
+    return "\n".join(tool_lines)
+
+
+async def choose_tool_with_llm(message: str, tools: list):
+    """
+    Universal MCP agent powered by Groq.
+
+    Imports and initialises the Groq client lazily so the server can start
+    even when GROQ_API_KEY is absent — the error surfaces only when the chat
+    endpoint is actually called.
+    """
+
+    if not tools:
+        raise RuntimeError("No tools available")
+
+    logger.info(f"Inspector chat message: {message}")
+
+    # Lazy imports — avoids startup failure when GROQ_API_KEY is absent
+    from dotenv import load_dotenv
+    from openai import OpenAI
+
+    load_dotenv()
+
+    groq_api_key = os.getenv("GROQ_API_KEY")
+    if not groq_api_key:
+        raise RuntimeError("GROQ_API_KEY not configured")
+
+    # Build client inside the function — no module-level side effects
+    client = OpenAI(
+        api_key=groq_api_key,
+        base_url="https://api.groq.com/openai/v1"
+    )
+
+    tool_description = format_tools_for_prompt(tools)
+
+    prompt = f"""
+You are an AI agent that selects which MCP tool to run.
+
+Available tools:
+{tool_description}
+
+User request:
+{message}
+
+Respond ONLY with JSON.
+
+Example:
+{{"tool_name": "get_current_time", "params": {{"timezone": "Asia/Tokyo"}}}}
+"""
+
+    try:
+        # The OpenAI client is synchronous — run in a thread to avoid blocking
+        # the event loop.
+        def _call_llm():
+            return client.chat.completions.create(
+                model="llama-3.1-8b-instant",
+                messages=[
+                    {"role": "system", "content": "You select MCP tools."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=0,
+                max_tokens=120
+            )
+
+        response = await asyncio.to_thread(_call_llm)
+
+        content = response.choices[0].message.content.strip()
+
+        logger.info(f"LLM raw response: {content}")
+
+        # Try parsing JSON safely
+        try:
+            result = json.loads(content)
+        except json.JSONDecodeError:
+
+            # Attempt JSON extraction
+            start = content.find("{")
+            end = content.rfind("}") + 1
+            result = json.loads(content[start:end])
+
+        logger.info(f"LLM parsed result: {result}")
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Groq agent error: {e}")
+        raise

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -6,7 +6,8 @@ from loguru import logger
 
 def format_tools_for_prompt(tools):
     """
-    Convert MCP tools into a detailed prompt format.
+    Convert MCP tools into a readable prompt format.
+    This remains dynamic → supports ANY MCP.
     """
 
     formatted = []
@@ -27,14 +28,15 @@ def format_tools_for_prompt(tools):
 
         formatted.append(
             f"""
-            Tool: {name}
-            Description: {description}
-            Parameters:
-            {param_text}
-            """
+Tool: {name}
+Description: {description}
+Parameters:
+{param_text}
+"""
         )
 
     return "\n".join(formatted)
+
 
 async def choose_tool_with_llm(message: str, tools: list):
     """
@@ -69,29 +71,21 @@ async def choose_tool_with_llm(message: str, tools: list):
     tool_description = format_tools_for_prompt(tools)
 
     prompt = f"""
-    You are an AI agent that selects which MCP tool should be executed.
+Available tools:
+{tool_description}
 
-    Available tools:
-    {tool_description}
+User request:
+{message}
 
-    User request:
-    {message}
+Instructions:
+1. Choose the BEST tool to fulfill the request.
+2. Extract parameters from the request.
+3. If parameters are missing:
+   - Infer reasonable defaults OR leave them empty
+   - DO NOT explain anything
 
-    Instructions:
-    1. Choose the BEST tool to fulfill the request.
-    2. Extract parameters from the request.
-    3. Return ONLY JSON.
-
-    Example response:
-
-    {{"tool_name": "convert_time",
-        "params": {{
-            "time": "16:00",
-            "source_timezone": "Asia/Tokyo",
-            "target_timezone": "Europe/London"
-        }}
-    }}
-    """
+Return ONLY JSON.
+"""
 
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking
@@ -100,32 +94,69 @@ async def choose_tool_with_llm(message: str, tools: list):
             return client.chat.completions.create(
                 model="llama-3.1-8b-instant",
                 messages=[
-                    {"role": "system", "content": "You select MCP tools."},
-                    {"role": "user", "content": prompt}
+                    {
+                        "role": "system",
+                        "content": """
+You are a strict JSON API for MCP tool selection.
+
+You MUST return ONLY valid JSON.
+
+Format:
+{
+  "tool_name": string,
+  "params": object
+}
+
+Rules:
+- No explanation
+- No markdown
+- No extra text
+- Always return JSON
+"""
+                    },
+                    {
+                        "role": "user",
+                        "content": prompt
+                    }
                 ],
                 temperature=0,
-                max_tokens=120
+                max_tokens=200,
+                stop=["\n\n"]
             )
 
         response = await asyncio.to_thread(_call_llm)
 
         content = response.choices[0].message.content.strip()
 
-        logger.info(f"LLM raw response: {content}")
+        logger.info(f"LLM raw response: {repr(content)}")
 
-        # Try parsing JSON safely
+        # First attempt: direct parse
         try:
             result = json.loads(content)
-        except json.JSONDecodeError:
+            logger.info(f"LLM parsed result (direct): {result}")
+            return result
 
-            # Attempt JSON extraction
+        except json.JSONDecodeError:
+            logger.warning("Direct JSON parse failed, attempting extraction...")
+
+            # Fallback: extract JSON block
             start = content.find("{")
             end = content.rfind("}") + 1
-            result = json.loads(content[start:end])
 
-        logger.info(f"LLM parsed result: {result}")
+            if start == -1 or end == 0:
+                raise ValueError(f"No JSON found in LLM response: {content}")
 
-        return result
+            json_str = content[start:end]
+
+            try:
+                result = json.loads(json_str)
+                logger.info(f"LLM parsed result (extracted): {result}")
+                return result
+
+            except Exception as e:
+                raise ValueError(
+                    f"Failed to parse extracted JSON.\nRaw response: {content}\nExtracted: {json_str}"
+                ) from e
 
     except Exception as e:
         logger.error(f"Groq agent error: {e}")

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -38,7 +38,7 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list):
+async def choose_tool_with_llm(message: str, tools: list, chat_history: list = []):
     """
     Universal MCP agent powered by Groq.
 
@@ -90,6 +90,14 @@ Return ONLY JSON.
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking
         # the event loop.
+        # Build prior turns from chat_history for multi-turn context
+        history_messages = [
+            {"role": "user" if m.get("type") == "user" else "assistant",
+             "content": str(m.get("content", ""))}
+            for m in chat_history
+            if m.get("type") in ("user", "assistant") and m.get("content")
+        ]
+
         def _call_llm():
             return client.chat.completions.create(
                 model="llama-3.1-8b-instant",
@@ -114,6 +122,7 @@ Rules:
 - Always return JSON
 """
                     },
+                    *history_messages,
                     {
                         "role": "user",
                         "content": prompt

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -6,24 +6,35 @@ from loguru import logger
 
 def format_tools_for_prompt(tools):
     """
-    Convert MCP tool schemas into a simple prompt-friendly format.
+    Convert MCP tools into a detailed prompt format.
     """
-    tool_lines = []
+
+    formatted = []
 
     for tool in tools:
         name = tool.get("name")
-        desc = tool.get("description", "")
+        description = tool.get("description", "No description")
+
         schema = tool.get("inputSchema", {})
         props = schema.get("properties", {})
 
-        params = ", ".join(props.keys())
+        params = []
+        for param_name, param_info in props.items():
+            param_type = param_info.get("type", "string")
+            params.append(f"- {param_name} ({param_type})")
 
-        tool_lines.append(
-            f"{name}({params}) - {desc}"
+        param_text = "\n".join(params) if params else "None"
+
+        formatted.append(
+            f"""
+            Tool: {name}
+            Description: {description}
+            Parameters:
+            {param_text}
+            """
         )
 
-    return "\n".join(tool_lines)
-
+    return "\n".join(formatted)
 
 async def choose_tool_with_llm(message: str, tools: list):
     """
@@ -58,19 +69,29 @@ async def choose_tool_with_llm(message: str, tools: list):
     tool_description = format_tools_for_prompt(tools)
 
     prompt = f"""
-You are an AI agent that selects which MCP tool to run.
+    You are an AI agent that selects which MCP tool should be executed.
 
-Available tools:
-{tool_description}
+    Available tools:
+    {tool_description}
 
-User request:
-{message}
+    User request:
+    {message}
 
-Respond ONLY with JSON.
+    Instructions:
+    1. Choose the BEST tool to fulfill the request.
+    2. Extract parameters from the request.
+    3. Return ONLY JSON.
 
-Example:
-{{"tool_name": "get_current_time", "params": {{"timezone": "Asia/Tokyo"}}}}
-"""
+    Example response:
+
+    {{"tool_name": "convert_time",
+        "params": {{
+            "time": "16:00",
+            "source_timezone": "Asia/Tokyo",
+            "target_timezone": "Europe/London"
+        }}
+    }}
+    """
 
     try:
         # The OpenAI client is synchronous — run in a thread to avoid blocking

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -38,7 +38,7 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list = []):
+async def choose_tool_with_llm(message: str, tools: list, chat_history: list = [], system_prompt: str = ""):
     """
     Universal MCP agent powered by Groq.
 
@@ -98,14 +98,7 @@ Return ONLY JSON.
             if m.get("type") in ("user", "assistant") and m.get("content")
         ]
 
-        def _call_llm():
-            return client.chat.completions.create(
-                model="llama-3.1-8b-instant",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": """
-You are a strict JSON API for MCP tool selection.
+        base_system = """You are a strict JSON API for MCP tool selection.
 
 You MUST return ONLY valid JSON.
 
@@ -121,12 +114,15 @@ Rules:
 - No extra text
 - Always return JSON
 """
-                    },
+        system_content = f"{system_prompt.strip()}\n\n{base_system}" if system_prompt.strip() else base_system
+
+        def _call_llm():
+            return client.chat.completions.create(
+                model="llama-3.1-8b-instant",
+                messages=[
+                    {"role": "system", "content": system_content},
                     *history_messages,
-                    {
-                        "role": "user",
-                        "content": prompt
-                    }
+                    {"role": "user", "content": prompt}
                 ],
                 temperature=0,
                 max_tokens=200,

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -36,12 +36,10 @@ class InspectorSession:
     """
     Manages a temporary connection to an external MCP server for the inspector.
 
-    Uses raw JSON-RPC over HTTP (for http transport) or SSE + HTTP POST
-    (for sse transport). No MCP SDK required — matches FluidMCP's existing
-    httpx-based pattern.
-
-    For stdio transport, the server is assumed to be already running and
-    accessible via a URL endpoint.
+    HTTP transport: raw JSON-RPC POST, response comes back in the same HTTP response.
+    SSE transport:  persistent GET /sse connection (background task) receives all
+                    responses; requests are sent via POST to the messages endpoint.
+                    This matches the MCP SSE spec — the stream must stay open.
     """
 
     def __init__(
@@ -58,279 +56,275 @@ class InspectorSession:
         self.auth = auth or {}
         self.extra_headers = headers or {}
         self.env_vars = env_vars or {}
-        self.timeout = timeout / 1000  # Convert ms to seconds
+        self.timeout = timeout / 1000  # ms → seconds
         self.created_at = time.time()
         self.last_used = time.time()
 
-        # Execution logs for this session
         self.logs: List[Dict[str, Any]] = []
 
-        # For SSE: the endpoint to POST messages to (received during SSE handshake)
-        self._sse_post_url: Optional[str] = None
-        self._sse_session_id: Optional[str] = None
+        # Auto-incrementing request ID (avoids hardcoded 1/2/3 collisions)
+        self._req_id = 0
 
-        # Shared httpx client for this session
+        # SSE state
+        self._sse_post_url: Optional[str] = None
+        self._sse_ready = asyncio.Event()      # set once endpoint URL is known
+        self._sse_pending: Dict[int, "asyncio.Future[dict]"] = {}  # id → Future
+        self._sse_task: Optional[asyncio.Task] = None
+
+        # Shared httpx client for HTTP/POST requests
         self._client: Optional[httpx.AsyncClient] = None
+
+    # ── Helpers ───────────────────────────────────────────────────────────────
+
+    def _next_id(self) -> int:
+        self._req_id += 1
+        return self._req_id
 
     def _get_client(self) -> httpx.AsyncClient:
         if self._client is None:
             self._client = httpx.AsyncClient(
                 timeout=httpx.Timeout(connect=10.0, read=self.timeout, write=10.0, pool=10.0),
-                follow_redirects=False,  # prevent redirect-based SSRF bypass
+                follow_redirects=False,
             )
         return self._client
 
     def _build_headers(self) -> Dict[str, str]:
-        """Build request headers including auth and any custom headers."""
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-
-        # Add bearer token auth if configured
-        auth_type = self.auth.get("type", "none")
-        if auth_type == "bearer":
-            token = self.auth.get("token", "")
-            if token:
-                headers["Authorization"] = f"Bearer {token}"
-
-        # Merge any custom headers (these can override defaults)
+        if self.auth.get("type") == "bearer" and self.auth.get("token"):
+            headers["Authorization"] = f"Bearer {self.auth['token']}"
         headers.update(self.extra_headers)
         return headers
 
     MAX_LOGS = 250
 
     def add_log(self, log_type: str, message: str) -> None:
-        log_entry = {
+        entry = {
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "type": log_type,
-            "message": message
+            "message": message,
         }
-        self.logs.append(log_entry)
+        self.logs.append(entry)
         if len(self.logs) > self.MAX_LOGS:
             self.logs.pop(0)
         logger.debug(f"Inspector log [{log_type}]: {message}")
 
+    # ── SSE persistent listener ───────────────────────────────────────────────
+
+    async def _sse_listener(self) -> None:
+        """
+        Background task: holds the GET /sse connection open for the entire session.
+
+        - First data event   → the POST messages endpoint URL (signals _sse_ready)
+        - Subsequent events  → JSON-RPC responses, routed to waiting callers via Futures
+        """
+        sse_url = self.url if self.url.endswith("/sse") else f"{self.url}/sse"
+        sse_headers = {**self._build_headers(), "Accept": "text/event-stream"}
+
+        # Dedicated client with no read timeout — this stream stays open indefinitely
+        sse_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0),
+            follow_redirects=False,
+        )
+        try:
+            async with sse_client.stream("GET", sse_url, headers=sse_headers) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    data_str = line[len("data:"):].strip()
+                    if not data_str:
+                        continue
+
+                    # ── First event: endpoint URL ──────────────────────────
+                    if self._sse_post_url is None:
+                        endpoint_url: Optional[str] = None
+                        if data_str.startswith("/") or data_str.startswith("http"):
+                            if data_str.startswith("/"):
+                                p = urlparse(self.url)
+                                endpoint_url = f"{p.scheme}://{p.netloc}{data_str}"
+                            else:
+                                endpoint_url = data_str
+                        else:
+                            try:
+                                ev = json.loads(data_str)
+                                if "endpoint" in ev:
+                                    endpoint_url = ev["endpoint"]
+                            except json.JSONDecodeError:
+                                pass
+
+                        if endpoint_url:
+                            try:
+                                _validate_url(endpoint_url)
+                            except ValueError as e:
+                                raise Exception(f"SSE endpoint rejected: {e}")
+
+                            base_host = urlparse(self.url).netloc
+                            ep_host = urlparse(endpoint_url).netloc
+                            if ep_host and ep_host != base_host:
+                                raise Exception(
+                                    f"SSE endpoint host mismatch — "
+                                    f"expected {base_host}, got {ep_host}"
+                                )
+
+                            self._sse_post_url = endpoint_url
+                            self._sse_ready.set()
+                            logger.debug(f"SSE messages endpoint: {endpoint_url}")
+                        continue
+
+                    # ── Subsequent events: JSON-RPC responses ──────────────
+                    try:
+                        msg = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    req_id = msg.get("id")
+                    if req_id is not None:
+                        future = self._sse_pending.pop(req_id, None)
+                        if future and not future.done():
+                            future.set_result(msg)
+
+        except asyncio.CancelledError:
+            pass  # normal shutdown
+        except Exception as e:
+            logger.warning(f"SSE listener terminated: {e}")
+            # Unblock any callers waiting on futures
+            for fut in self._sse_pending.values():
+                if not fut.done():
+                    fut.set_exception(e)
+            self._sse_pending.clear()
+            if not self._sse_ready.is_set():
+                self._sse_ready.set()
+        finally:
+            await sse_client.aclose()
+
+    async def _sse_request(self, request: dict) -> dict:
+        """POST a request and await the response that comes back on the SSE stream."""
+        await asyncio.wait_for(self._sse_ready.wait(), timeout=10.0)
+
+        if not self._sse_post_url:
+            raise Exception("SSE session not ready — no endpoint URL")
+
+        req_id = request["id"]
+        loop = asyncio.get_event_loop()
+        future: "asyncio.Future[dict]" = loop.create_future()
+        self._sse_pending[req_id] = future
+
+        try:
+            client = self._get_client()
+            resp = await client.post(
+                self._sse_post_url, json=request, headers=self._build_headers()
+            )
+            resp.raise_for_status()
+            # Server responds 202 Accepted; actual result arrives via SSE stream
+            return await asyncio.wait_for(future, timeout=self.timeout)
+        except Exception:
+            self._sse_pending.pop(req_id, None)
+            if not future.done():
+                future.cancel()
+            raise
+
+    # ── Transport dispatcher ──────────────────────────────────────────────────
+
+    def _make_request(self, method: str, params: dict) -> dict:
+        return {"jsonrpc": "2.0", "id": self._next_id(), "method": method, "params": params}
+
+    async def _send(self, request: dict) -> dict:
+        """Route request through SSE or plain HTTP depending on transport."""
+        if self.transport == "sse":
+            return await self._sse_request(request)
+
+        client = self._get_client()
+        response = await client.post(self.url, json=request, headers=self._build_headers())
+        response.raise_for_status()
+        return response.json()
+
+    # ── Public API ────────────────────────────────────────────────────────────
 
     async def initialize(self) -> Dict[str, Any]:
-        """
-        Perform the MCP initialize handshake to verify the server is reachable
-        and retrieve server info.
-
-        Returns server info dict with name and version.
-        Raises httpx.HTTPError or Exception on failure.
-        """
         self.last_used = time.time()
 
         if self.transport == "sse":
-            server_info = await self._initialize_sse()
-        else:
-            # HTTP and stdio both use JSON-RPC POST
-            server_info = await self._initialize_http()
+            # Kick off the background SSE listener before sending any requests
+            loop = asyncio.get_event_loop()
+            self._sse_task = loop.create_task(self._sse_listener())
 
-        # Log successful connection
-        self.add_log("connect", f"Connected to {server_info.get('name', 'Unknown Server')} ({self.transport.upper()})")
-        return server_info
-
-    async def _initialize_http(self) -> Dict[str, Any]:
-        """Send MCP initialize JSON-RPC request over HTTP POST."""
-        client = self._get_client()
-        headers = self._build_headers()
-
-        init_request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "FluidMCP Inspector",
-                    "version": "1.0.0"
+        init_request = self._make_request("initialize", {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "extensions": {
+                    "io.modelcontextprotocol/ui": {
+                        "mimeTypes": ["text/html+mcp", "text/html;profile=mcp-app"]
+                    }
                 }
-            }
-        }
+            },
+            "clientInfo": {"name": "FluidMCP Inspector", "version": "1.0.0"},
+        })
 
-        response = await client.post(self.url, json=init_request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
+        data = await self._send(init_request)
 
         if "error" in data:
             raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
 
         result = data.get("result", {})
         server_info = result.get("serverInfo", {})
-
-        return {
+        info = {
             "name": server_info.get("name", "Unknown MCP Server"),
             "version": server_info.get("version", "unknown"),
-            "protocol_version": result.get("protocolVersion", "unknown")
+            "protocol_version": result.get("protocolVersion", "unknown"),
         }
 
-    async def _initialize_sse(self) -> Dict[str, Any]:
-        """
-        Connect to SSE endpoint to get the POST messages URL,
-        then send the initialize request via POST.
-
-        MCP SSE pattern:
-          1. GET /sse  → streams events, first event contains the endpoint URL
-          2. POST {endpoint_url}  → send JSON-RPC messages
-        """
-        client = self._get_client()
-        headers = self._build_headers()
-        sse_headers = {**headers, "Accept": "text/event-stream"}
-
-        # Determine SSE endpoint URL
-        sse_url = self.url if self.url.endswith("/sse") else f"{self.url}/sse"
-
-        # Connect to SSE and read the first event to get the messages endpoint
-        endpoint_url = None
-        try:
-            async with client.stream("GET", sse_url, headers=sse_headers, timeout=10.0) as response:
-                response.raise_for_status()
-                async for line in response.aiter_lines():
-                    if line.startswith("data:"):
-                        data_str = line[len("data:"):].strip()
-                        # MCP SSE servers send the messages endpoint URL as first data event
-                        if data_str.startswith("/") or data_str.startswith("http"):
-                            # Relative path — make it absolute
-                            if data_str.startswith("/"):
-                                parsed = urlparse(self.url)
-                                endpoint_url = f"{parsed.scheme}://{parsed.netloc}{data_str}"
-                            else:
-                                endpoint_url = data_str
-                            break
-                        # Some servers send JSON with endpoint info
-                        try:
-                            event_data = json.loads(data_str)
-                            if "endpoint" in event_data:
-                                endpoint_url = event_data["endpoint"]
-                                break
-                        except json.JSONDecodeError:
-                            pass
-        except asyncio.TimeoutError:
-            raise Exception("SSE connection timed out waiting for endpoint URL")
-
-        if not endpoint_url:
-            raise Exception("SSE server did not provide a messages endpoint URL")
-
-        # Validate SSE-derived endpoint against SSRF blocklist
-        try:
-            _validate_url(endpoint_url)
-        except ValueError as e:
-            raise Exception(f"SSE endpoint rejected: {e}")
-
-        # Enforce same host as the original URL to prevent open-redirect abuse
-        base_host = urlparse(self.url).netloc
-        ep_host = urlparse(endpoint_url).netloc
-        if ep_host and ep_host != base_host:
-            raise Exception(f"SSE endpoint host mismatch — expected {base_host}, got {ep_host}")
-
-        self._sse_post_url = endpoint_url
-        logger.debug(f"SSE messages endpoint: {endpoint_url}")
-
-        # Now send initialize via POST to the messages endpoint
-        init_request = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "FluidMCP Inspector",
-                    "version": "1.0.0"
-                }
-            }
-        }
-
-        response = await client.post(endpoint_url, json=init_request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-
-        if "error" in data:
-            raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
-
-        result = data.get("result", {})
-        server_info = result.get("serverInfo", {})
-
-        return {
-            "name": server_info.get("name", "Unknown MCP Server"),
-            "version": server_info.get("version", "unknown"),
-            "protocol_version": result.get("protocolVersion", "unknown")
-        }
-
-    def _get_post_url(self) -> str:
-        """Get the URL to POST JSON-RPC messages to."""
-        if self.transport == "sse" and self._sse_post_url:
-            return self._sse_post_url
-        return self.url
+        self.add_log("connect", f"Connected to {info['name']} ({self.transport.upper()})")
+        return info
 
     async def list_tools(self) -> list:
-        """Fetch the list of tools available on the MCP server."""
         self.last_used = time.time()
-        client = self._get_client()
-        headers = self._build_headers()
-        post_url = self._get_post_url()
-
-        request = {
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list",
-            "params": {}
-        }
-
-        response = await client.post(post_url, json=request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
-
+        data = await self._send(self._make_request("tools/list", {}))
         if "error" in data:
             raise Exception(f"tools/list error: {data['error'].get('message', 'Unknown error')}")
-
         return data.get("result", {}).get("tools", [])
 
     async def call_tool(self, name: str, params: Dict[str, Any]) -> Any:
-        """Execute a tool on the MCP server."""
         self.last_used = time.time()
-        client = self._get_client()
-        headers = self._build_headers()
-        post_url = self._get_post_url()
-
-        # Log tool call
         self.add_log("tool_call", f"Running tool: {name}")
-
-        request = {
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": name,
-                "arguments": params
-            }
-        }
-
         try:
-            response = await client.post(post_url, json=request, headers=headers)
-            response.raise_for_status()
-            data = response.json()
-
+            data = await self._send(
+                self._make_request("tools/call", {"name": name, "arguments": params})
+            )
             if "error" in data:
-                error_msg = data['error'].get('message', 'Unknown error')
-                self.add_log("tool_error", f"Tool '{name}' failed: {error_msg}")
-                raise Exception(f"tools/call error: {error_msg}")
-
-            # NOTE: MCP servers sometimes return isError: true inside a successful result.
-            # We log tool_result here because the JSON-RPC call succeeded at transport level.
-            # The frontend ToolResult component handles isError display separately.
-            # Future improvement: check result body for isError and log tool_error instead.
+                msg = data["error"].get("message", "Unknown error")
+                self.add_log("tool_error", f"Tool '{name}' failed: {msg}")
+                raise Exception(f"tools/call error: {msg}")
             self.add_log("tool_result", f"Tool '{name}' executed successfully")
             return data.get("result", {})
         except Exception as e:
-            # Log unexpected errors
-            if not self.logs or self.logs[-1]["type"] != "tool_error":  # Only log if not already logged above
+            if not self.logs or self.logs[-1]["type"] != "tool_error":
                 self.add_log("tool_error", f"Tool '{name}' error: {str(e)}")
             raise
 
-    async def close(self):
-        """Close the httpx client."""
+    async def list_resources(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/list", {}))
+        if "error" in data:
+            raise Exception(f"resources/list error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {}).get("resources", [])
+
+    async def read_resource(self, uri: str) -> dict:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/read", {"uri": uri}))
+        if "error" in data:
+            raise Exception(f"resources/read error: {data['error'].get('message', 'Unknown error')}")
+        contents = data.get("result", {}).get("contents", [])
+        return contents[0] if contents else {}
+
+    async def close(self) -> None:
         self.add_log("disconnect", "Session closed")
+        if self._sse_task:
+            self._sse_task.cancel()
+            try:
+                await self._sse_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._sse_task = None
         if self._client is not None:
             try:
                 await self._client.aclose()

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -316,6 +316,10 @@ class InspectorSession:
                 self.add_log("tool_error", f"Tool '{name}' failed: {error_msg}")
                 raise Exception(f"tools/call error: {error_msg}")
 
+            # NOTE: MCP servers sometimes return isError: true inside a successful result.
+            # We log tool_result here because the JSON-RPC call succeeded at transport level.
+            # The frontend ToolResult component handles isError display separately.
+            # Future improvement: check result body for isError and log tool_error instead.
             self.add_log("tool_result", f"Tool '{name}' executed successfully")
             return data.get("result", {})
         except Exception as e:

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -2,7 +2,8 @@ import time
 import json
 import asyncio
 import ipaddress
-from typing import Optional, Dict, Any
+from datetime import datetime, timezone
+from typing import Optional, Dict, Any, List
 from urllib.parse import urlparse
 import httpx
 from loguru import logger
@@ -61,6 +62,9 @@ class InspectorSession:
         self.created_at = time.time()
         self.last_used = time.time()
 
+        # Execution logs for this session
+        self.logs: List[Dict[str, Any]] = []
+
         # For SSE: the endpoint to POST messages to (received during SSE handshake)
         self._sse_post_url: Optional[str] = None
         self._sse_session_id: Optional[str] = None
@@ -91,6 +95,20 @@ class InspectorSession:
         headers.update(self.extra_headers)
         return headers
 
+    MAX_LOGS = 250
+
+    def add_log(self, log_type: str, message: str) -> None:
+        log_entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "type": log_type,
+            "message": message
+        }
+        self.logs.append(log_entry)
+        if len(self.logs) > self.MAX_LOGS:
+            self.logs.pop(0)
+        logger.debug(f"Inspector log [{log_type}]: {message}")
+
+
     async def initialize(self) -> Dict[str, Any]:
         """
         Perform the MCP initialize handshake to verify the server is reachable
@@ -102,10 +120,14 @@ class InspectorSession:
         self.last_used = time.time()
 
         if self.transport == "sse":
-            return await self._initialize_sse()
+            server_info = await self._initialize_sse()
         else:
             # HTTP and stdio both use JSON-RPC POST
-            return await self._initialize_http()
+            server_info = await self._initialize_http()
+
+        # Log successful connection
+        self.add_log("connect", f"Connected to {server_info.get('name', 'Unknown Server')} ({self.transport.upper()})")
+        return server_info
 
     async def _initialize_http(self) -> Dict[str, Any]:
         """Send MCP initialize JSON-RPC request over HTTP POST."""
@@ -271,6 +293,9 @@ class InspectorSession:
         headers = self._build_headers()
         post_url = self._get_post_url()
 
+        # Log tool call
+        self.add_log("tool_call", f"Running tool: {name}")
+
         request = {
             "jsonrpc": "2.0",
             "id": 3,
@@ -281,17 +306,27 @@ class InspectorSession:
             }
         }
 
-        response = await client.post(post_url, json=request, headers=headers)
-        response.raise_for_status()
-        data = response.json()
+        try:
+            response = await client.post(post_url, json=request, headers=headers)
+            response.raise_for_status()
+            data = response.json()
 
-        if "error" in data:
-            raise Exception(f"tools/call error: {data['error'].get('message', 'Unknown error')}")
+            if "error" in data:
+                error_msg = data['error'].get('message', 'Unknown error')
+                self.add_log("tool_error", f"Tool '{name}' failed: {error_msg}")
+                raise Exception(f"tools/call error: {error_msg}")
 
-        return data.get("result", {})
+            self.add_log("tool_result", f"Tool '{name}' executed successfully")
+            return data.get("result", {})
+        except Exception as e:
+            # Log unexpected errors
+            if not self.logs or self.logs[-1]["type"] != "tool_error":  # Only log if not already logged above
+                self.add_log("tool_error", f"Tool '{name}' error: {str(e)}")
+            raise
 
     async def close(self):
         """Close the httpx client."""
+        self.add_log("disconnect", "Session closed")
         if self._client is not None:
             try:
                 await self._client.aclose()

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -1,0 +1,300 @@
+import time
+import json
+import asyncio
+import ipaddress
+from typing import Optional, Dict, Any
+from urllib.parse import urlparse
+import httpx
+from loguru import logger
+
+
+def _validate_url(url: str) -> None:
+    """Block non-HTTP schemes and connections to private/internal network ranges."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise ValueError("Invalid URL")
+
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("Only http/https URLs are allowed")
+
+    host = parsed.hostname or ""
+    if not host:
+        raise ValueError("URL must include a host")
+
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return  # hostname, not a bare IP — DNS rebinding is out of scope
+
+    if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+        raise ValueError("Connections to private/internal addresses are not allowed")
+
+
+class InspectorSession:
+    """
+    Manages a temporary connection to an external MCP server for the inspector.
+
+    Uses raw JSON-RPC over HTTP (for http transport) or SSE + HTTP POST
+    (for sse transport). No MCP SDK required — matches FluidMCP's existing
+    httpx-based pattern.
+
+    For stdio transport, the server is assumed to be already running and
+    accessible via a URL endpoint.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        transport: str,
+        auth: Optional[Dict[str, Any]] = None,
+        headers: Optional[Dict[str, str]] = None,
+        env_vars: Optional[Dict[str, str]] = None,
+        timeout: int = 10000,
+    ):
+        self.url = url.rstrip("/")
+        self.transport = transport.lower()
+        self.auth = auth or {}
+        self.extra_headers = headers or {}
+        self.env_vars = env_vars or {}
+        self.timeout = timeout / 1000  # Convert ms to seconds
+        self.created_at = time.time()
+        self.last_used = time.time()
+
+        # For SSE: the endpoint to POST messages to (received during SSE handshake)
+        self._sse_post_url: Optional[str] = None
+        self._sse_session_id: Optional[str] = None
+
+        # Shared httpx client for this session
+        self._client: Optional[httpx.AsyncClient] = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=httpx.Timeout(connect=10.0, read=self.timeout, write=10.0, pool=10.0),
+                follow_redirects=False,  # prevent redirect-based SSRF bypass
+            )
+        return self._client
+
+    def _build_headers(self) -> Dict[str, str]:
+        """Build request headers including auth and any custom headers."""
+        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+
+        # Add bearer token auth if configured
+        auth_type = self.auth.get("type", "none")
+        if auth_type == "bearer":
+            token = self.auth.get("token", "")
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
+        # Merge any custom headers (these can override defaults)
+        headers.update(self.extra_headers)
+        return headers
+
+    async def initialize(self) -> Dict[str, Any]:
+        """
+        Perform the MCP initialize handshake to verify the server is reachable
+        and retrieve server info.
+
+        Returns server info dict with name and version.
+        Raises httpx.HTTPError or Exception on failure.
+        """
+        self.last_used = time.time()
+
+        if self.transport == "sse":
+            return await self._initialize_sse()
+        else:
+            # HTTP and stdio both use JSON-RPC POST
+            return await self._initialize_http()
+
+    async def _initialize_http(self) -> Dict[str, Any]:
+        """Send MCP initialize JSON-RPC request over HTTP POST."""
+        client = self._get_client()
+        headers = self._build_headers()
+
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "FluidMCP Inspector",
+                    "version": "1.0.0"
+                }
+            }
+        }
+
+        response = await client.post(self.url, json=init_request, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
+
+        result = data.get("result", {})
+        server_info = result.get("serverInfo", {})
+
+        return {
+            "name": server_info.get("name", "Unknown MCP Server"),
+            "version": server_info.get("version", "unknown"),
+            "protocol_version": result.get("protocolVersion", "unknown")
+        }
+
+    async def _initialize_sse(self) -> Dict[str, Any]:
+        """
+        Connect to SSE endpoint to get the POST messages URL,
+        then send the initialize request via POST.
+
+        MCP SSE pattern:
+          1. GET /sse  → streams events, first event contains the endpoint URL
+          2. POST {endpoint_url}  → send JSON-RPC messages
+        """
+        client = self._get_client()
+        headers = self._build_headers()
+        sse_headers = {**headers, "Accept": "text/event-stream"}
+
+        # Determine SSE endpoint URL
+        sse_url = self.url if self.url.endswith("/sse") else f"{self.url}/sse"
+
+        # Connect to SSE and read the first event to get the messages endpoint
+        endpoint_url = None
+        try:
+            async with client.stream("GET", sse_url, headers=sse_headers, timeout=10.0) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if line.startswith("data:"):
+                        data_str = line[len("data:"):].strip()
+                        # MCP SSE servers send the messages endpoint URL as first data event
+                        if data_str.startswith("/") or data_str.startswith("http"):
+                            # Relative path — make it absolute
+                            if data_str.startswith("/"):
+                                parsed = urlparse(self.url)
+                                endpoint_url = f"{parsed.scheme}://{parsed.netloc}{data_str}"
+                            else:
+                                endpoint_url = data_str
+                            break
+                        # Some servers send JSON with endpoint info
+                        try:
+                            event_data = json.loads(data_str)
+                            if "endpoint" in event_data:
+                                endpoint_url = event_data["endpoint"]
+                                break
+                        except json.JSONDecodeError:
+                            pass
+        except asyncio.TimeoutError:
+            raise Exception("SSE connection timed out waiting for endpoint URL")
+
+        if not endpoint_url:
+            raise Exception("SSE server did not provide a messages endpoint URL")
+
+        # Validate SSE-derived endpoint against SSRF blocklist
+        try:
+            _validate_url(endpoint_url)
+        except ValueError as e:
+            raise Exception(f"SSE endpoint rejected: {e}")
+
+        # Enforce same host as the original URL to prevent open-redirect abuse
+        base_host = urlparse(self.url).netloc
+        ep_host = urlparse(endpoint_url).netloc
+        if ep_host and ep_host != base_host:
+            raise Exception(f"SSE endpoint host mismatch — expected {base_host}, got {ep_host}")
+
+        self._sse_post_url = endpoint_url
+        logger.debug(f"SSE messages endpoint: {endpoint_url}")
+
+        # Now send initialize via POST to the messages endpoint
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "FluidMCP Inspector",
+                    "version": "1.0.0"
+                }
+            }
+        }
+
+        response = await client.post(endpoint_url, json=init_request, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise Exception(f"MCP initialize error: {data['error'].get('message', 'Unknown error')}")
+
+        result = data.get("result", {})
+        server_info = result.get("serverInfo", {})
+
+        return {
+            "name": server_info.get("name", "Unknown MCP Server"),
+            "version": server_info.get("version", "unknown"),
+            "protocol_version": result.get("protocolVersion", "unknown")
+        }
+
+    def _get_post_url(self) -> str:
+        """Get the URL to POST JSON-RPC messages to."""
+        if self.transport == "sse" and self._sse_post_url:
+            return self._sse_post_url
+        return self.url
+
+    async def list_tools(self) -> list:
+        """Fetch the list of tools available on the MCP server."""
+        self.last_used = time.time()
+        client = self._get_client()
+        headers = self._build_headers()
+        post_url = self._get_post_url()
+
+        request = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }
+
+        response = await client.post(post_url, json=request, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise Exception(f"tools/list error: {data['error'].get('message', 'Unknown error')}")
+
+        return data.get("result", {}).get("tools", [])
+
+    async def call_tool(self, name: str, params: Dict[str, Any]) -> Any:
+        """Execute a tool on the MCP server."""
+        self.last_used = time.time()
+        client = self._get_client()
+        headers = self._build_headers()
+        post_url = self._get_post_url()
+
+        request = {
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": params
+            }
+        }
+
+        response = await client.post(post_url, json=request, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+
+        if "error" in data:
+            raise Exception(f"tools/call error: {data['error'].get('message', 'Unknown error')}")
+
+        return data.get("result", {})
+
+    async def close(self):
+        """Close the httpx client."""
+        if self._client is not None:
+            try:
+                await self._client.aclose()
+            except Exception:
+                pass
+            self._client = None

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -10,7 +10,7 @@ import subprocess
 import json
 import time
 import atexit
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, IO
 from pathlib import Path
 from datetime import datetime, timedelta
 from loguru import logger
@@ -55,6 +55,9 @@ class ServerManager:
         # 30s provides quick feedback (max 30s delay) while preventing excessive writes
         # when repeatedly checking the same stale server
         self._stale_pid_cache_ttl = 30.0  # seconds
+
+        # Stderr log file handles (for file-based stderr capture)
+        self._stderr_logs: Dict[str, IO] = {}
 
         # Idle cleanup configuration
         self.idle_timeout_seconds = int(os.getenv("FMCP_IDLE_TIMEOUT", "3600"))  # Default 1 hour
@@ -113,6 +116,11 @@ class ServerManager:
                 logger.error(f"Error cleaning up server '{server_id}': {e}")
 
         self.processes.clear()
+
+        # Close all stderr log file handles
+        for server_id in list(self._stderr_logs.keys()):
+            self._close_stderr_log(server_id)
+
         logger.info("All servers cleaned up")
 
     async def shutdown_all(self) -> None:
@@ -312,7 +320,7 @@ class ServerManager:
             # Check if already dead
             if process.poll() is not None:
                 logger.info(f"Server '{name}' (id: {id}) already stopped (exit code: {process.returncode})")
-                await self._cleanup_server(id, process.returncode)
+                await self._cleanup_server(id, process.returncode, intentional=True)
                 return True
 
             # Terminate process
@@ -338,7 +346,7 @@ class ServerManager:
                 exit_code = await asyncio.to_thread(process.wait)
 
             # Cleanup
-            await self._cleanup_server(id, exit_code)
+            await self._cleanup_server(id, exit_code, intentional=True)
 
             # Update metrics - server is now stopped (status code: 0)
             collector.set_server_status(0)  # 0 = stopped
@@ -805,16 +813,42 @@ class ServerManager:
             logger.debug(f"INSTALL_PATH: {install_path}")
             logger.info("Starting MCP server subprocess")
 
+            # Open stderr log file for persistent crash diagnostics
+            try:
+                stderr_fh = self._open_stderr_log(id)
+            except Exception as e:
+                logger.warning(f"Failed to open stderr log for '{name}' (id: {id}), falling back to pipe: {e}")
+                stderr_fh = subprocess.PIPE
+
+            # Set subprocess memory limit (default 0 = disabled; set FMCP_DEFAULT_MEMORY_LIMIT_MB to enable)
+            memory_limit_mb = config.get("memory_limit_mb",
+                int(os.getenv("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+            if memory_limit_mb > 0 and os.name != "nt":
+                try:
+                    import resource as _resource  # noqa: F401
+                    preexec_fn = self._create_preexec_fn(memory_limit_mb)
+                except ImportError:
+                    logger.warning(
+                        f"resource module unavailable — memory limit ({memory_limit_mb}MB) not applied to '{name}'"
+                    )
+                    preexec_fn = None
+            elif memory_limit_mb > 0:
+                logger.warning("Subprocess memory limits (RLIMIT_AS) are not supported on Windows — skipping")
+                preexec_fn = None
+            else:
+                preexec_fn = None
+
             # Spawn subprocess
             process = subprocess.Popen(
                 cmd_list,
                 cwd=str(working_dir),
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=stderr_fh,
                 env=env,
                 text=True,
-                bufsize=1
+                bufsize=1,
+                preexec_fn=preexec_fn
             )
 
             # Give process a moment to start
@@ -822,12 +856,17 @@ class ServerManager:
 
             # Check if process is still alive
             if process.poll() is not None:
-                stderr_output = "No stderr available"
-                if process.stderr:
+                self._close_stderr_log(id)
+                if stderr_fh == subprocess.PIPE and process.stderr:
                     try:
-                        stderr_output = await asyncio.to_thread(process.stderr.read)
-                    except Exception as exc:
-                        logger.exception(f"Failed to read stderr: {exc}")
+                        _, stderr_output = await asyncio.wait_for(
+                            asyncio.to_thread(process.communicate),
+                            timeout=2.0
+                        )
+                    except Exception:
+                        stderr_output = ""
+                else:
+                    stderr_output = self._read_crash_stderr(id)
                 logger.error(f"Process died immediately after spawn. stderr: {stderr_output}")
                 return None
 
@@ -835,6 +874,7 @@ class ServerManager:
             if config.get("transport") == "sse":
                 handle = await self._handshake_sse_subprocess(id, config, process)
                 if not handle:
+                    self._close_stderr_log(id)
                     logger.error(f"SSE handshake failed for server '{name}' (id: {id})")
                     return None
                 logger.info(f"[{id}] SSE server connected successfully")
@@ -847,19 +887,17 @@ class ServerManager:
 
             if not init_success:
                 logger.error(f"MCP initialization failed for server '{name}' (id: {id})")
-                # Read stderr for debugging (non-blocking)
-                stderr_output = None
-                if process.stderr:
-                    try:
-                        stderr_output = await asyncio.wait_for(
-                            asyncio.to_thread(process.stderr.read),
-                            timeout=1.0
-                        )
-                    except Exception as exc:
-                        logger.warning(f"Failed to read stderr: {exc}")
+                process.kill()
+                try:
+                    await asyncio.to_thread(lambda: process.wait(timeout=2))
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass
+                self._close_stderr_log(id)
+                stderr_output = self._read_crash_stderr(id)
                 if stderr_output:
                     logger.error(f"[{id}] Process stderr: {stderr_output[:500]}")
-                process.kill()
                 return None
 
             logger.info(f"[{id}] MCP server initialized successfully")
@@ -869,7 +907,11 @@ class ServerManager:
 
             return process
 
+        except asyncio.CancelledError:
+            self._close_stderr_log(id)
+            raise
         except Exception as e:
+            self._close_stderr_log(id)
             logger.exception(f"Error spawning process for server '{name}': {e}")
             return None
 
@@ -976,12 +1018,7 @@ class ServerManager:
         while loop.time() < deadline:
             # Guard: process must still be alive
             if process.poll() is not None:
-                stderr_out = ""
-                if process.stderr:
-                    try:
-                        stderr_out = process.stderr.read()
-                    except Exception:
-                        pass
+                stderr_out = self._read_crash_stderr(id) or ""
                 logger.error(
                     f"[{id}] SSE server process died before HTTP became ready "
                     f"(exit code {process.returncode}). stderr: {stderr_out[:500]}"
@@ -1065,30 +1102,58 @@ class ServerManager:
             # Tool discovery failure must never abort server startup
             logger.warning(f"[SSE] Tool discovery failed for '{server_id}': {e}")
 
-    async def _cleanup_server(self, id: str, exit_code: int) -> None:
+    async def _cleanup_server(self, id: str, exit_code: int, intentional: bool = False) -> None:
         """
         Clean up after server stops.
 
         Args:
             id: Server identifier
             exit_code: Process exit code
+            intentional: True if this was a deliberate stop (not a crash)
         """
+        uptime = self.get_uptime(id)
+
         # Remove from registry
         if id in self.processes:
             del self.processes[id]
         if id in self.start_times:
             del self.start_times[id]
 
+        # Close stderr log file handle
+        self._close_stderr_log(id)
+
+        # Determine state
+        if intentional or exit_code == 0:
+            state = "stopped"
+        else:
+            state = "failed"
+
         # Update database
         await self.db.save_instance_state({
             "server_id": id,
-            "state": "stopped",
+            "state": state,
             "pid": None,
             "stop_time": datetime.utcnow(),
             "exit_code": exit_code
         })
 
-        logger.info(f"Cleaned up server '{id}'")
+        # Persist crash event for non-intentional failures
+        if state == "failed":
+            stderr_tail = self._read_crash_stderr(id)
+            try:
+                await self.db.save_crash_event({
+                    "server_id": id,
+                    "exit_code": exit_code,
+                    "stderr_tail": stderr_tail,
+                    "uptime_seconds": uptime,
+                    "timestamp": datetime.utcnow()
+                })
+            except Exception as e:
+                logger.error(f"Failed to save crash event for server '{id}': {e}")
+            uptime_str = f"{uptime:.1f}s" if uptime is not None else "unknown"
+            logger.warning(f"Server '{id}' crashed (exit_code={exit_code}, uptime={uptime_str})")
+        else:
+            logger.info(f"Cleaned up server '{id}'")
 
     def get_uptime(self, server_id: str) -> Optional[float]:
         """
@@ -1120,6 +1185,106 @@ class ServerManager:
         ]
 
         return any(placeholder_indicators)
+
+    # ==================== Stderr File Logging ====================
+
+    STDERR_LOG_DIR = os.path.join(os.path.expanduser("~"), ".fluidmcp", "logs")
+    STDERR_MAX_BYTES = 10 * 1024 * 1024  # 10MB
+    STDERR_BACKUP_COUNT = 5
+
+    def _get_stderr_log_path(self, server_id: str) -> str:
+        """Get the stderr log file path for a server."""
+        safe_id = "".join(c if c.isalnum() or c in "-_" else "_" for c in server_id)
+        return os.path.join(self.STDERR_LOG_DIR, f"mcp_{safe_id}_stderr.log")
+
+    def _cleanup_old_stderr_logs(self) -> None:
+        """Delete stderr log files (and their backups) older than 30 days."""
+        if not os.path.isdir(self.STDERR_LOG_DIR):
+            return
+        cutoff = time.time() - 30 * 86400
+        try:
+            for entry in os.scandir(self.STDERR_LOG_DIR):
+                if entry.name.startswith("mcp_") and "_stderr.log" in entry.name:
+                    try:
+                        if entry.stat().st_mtime < cutoff:
+                            os.remove(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    def _open_stderr_log(self, server_id: str) -> IO:
+        """Open a stderr log file with rotation, returns file handle."""
+        self._cleanup_old_stderr_logs()
+        os.makedirs(self.STDERR_LOG_DIR, exist_ok=True)
+        log_path = self._get_stderr_log_path(server_id)
+
+        # Rotate if file exceeds max size (rotation happens at spawn time only;
+        # a long-running noisy process can exceed STDERR_MAX_BYTES mid-run)
+        if os.path.exists(log_path) and os.path.getsize(log_path) > self.STDERR_MAX_BYTES:
+            for i in range(self.STDERR_BACKUP_COUNT - 1, 0, -1):
+                src = f"{log_path}.{i}"
+                dst = f"{log_path}.{i + 1}"
+                if os.path.exists(src):
+                    os.replace(src, dst)
+            os.replace(log_path, f"{log_path}.1")
+
+        fh = open(log_path, "a", encoding="utf-8")
+        try:
+            os.chmod(log_path, 0o600)
+        except OSError:
+            pass
+        self._stderr_logs[server_id] = fh
+        return fh
+
+    def _close_stderr_log(self, server_id: str) -> None:
+        """Flush and close stderr log file handle for a server."""
+        fh = self._stderr_logs.pop(server_id, None)
+        if fh:
+            try:
+                fh.flush()
+                fh.close()
+            except Exception:
+                pass
+
+    def _read_crash_stderr(self, server_id: str, max_bytes: int = 2048) -> str:
+        """Read the tail of a server's stderr log file for crash diagnostics."""
+        log_path = self._get_stderr_log_path(server_id)
+        try:
+            if not os.path.exists(log_path):
+                return ""
+            size = os.path.getsize(log_path)
+            with open(log_path, "rb") as f:
+                if size > max_bytes:
+                    f.seek(-max_bytes, os.SEEK_END)
+                data = f.read()
+            text = data.decode("utf-8", errors="replace")
+            if size > max_bytes:
+                # Skip the first (possibly partial) line
+                lines = text.splitlines(keepends=True)
+                text = "".join(lines[1:]) if len(lines) > 1 else ""
+            return text
+        except Exception as e:
+            logger.debug(f"Failed to read stderr log for '{server_id}': {e}")
+            return ""
+
+    # ==================== Resource Limits ====================
+
+    @staticmethod
+    def _create_preexec_fn(memory_limit_mb: int):
+        """Create a preexec_fn that sets memory limits for the subprocess (Unix only)."""
+        def _set_limits():
+            try:
+                import resource
+                limit_bytes = memory_limit_mb * 1024 * 1024
+                resource.setrlimit(resource.RLIMIT_AS, (limit_bytes, limit_bytes))
+            except (ImportError, ValueError, OSError):
+                # Cannot use logger here — this runs in the forked child process
+                # where logging locks may be in an inconsistent state (deadlock risk).
+                # The parent process logs a warning after spawn if needed.
+                pass
+
+        return _set_limits
 
     # ==================== Idle Cleanup Methods ====================
 
@@ -1234,7 +1399,7 @@ class ServerManager:
                 logger.debug(f"No config found for server '{server_id}', skipping auto-restart")
                 return
 
-            restart_policy = config.get("restart_policy", "never")
+            restart_policy = config.get("restart_policy", "on-failure")
             max_restarts = config.get("max_restarts", 3)
             restart_window_sec = config.get("restart_window_sec", 300)
 
@@ -1274,3 +1439,183 @@ class ServerManager:
 
         except Exception as e:
             logger.error(f"Error during auto-restart check for server '{server_id}': {e}")
+
+
+class MCPHealthMonitor:
+    """Background health monitor for MCP server processes with automatic restart."""
+
+    MAX_BACKOFF_EXPONENT = 5  # Max 2^5 = 32x multiplier
+    DEFAULT_RESTART_DELAY = 5  # Base delay in seconds
+
+    def __init__(self, server_manager: ServerManager, check_interval: int = 30):
+        self._sm = server_manager
+        self.check_interval = check_interval
+        self._monitor_task: Optional[asyncio.Task] = None
+        self._running = False
+        self._restarts_in_progress: set = set()
+        self._restart_counts: Dict[str, int] = {}
+
+    def start(self) -> None:
+        """Start the background health monitor."""
+        if self._running:
+            logger.warning("MCP health monitor already running")
+            return
+        self._running = True
+        self._monitor_task = asyncio.create_task(self._monitor_loop())
+        logger.info(f"MCP health monitor started (interval: {self.check_interval}s)")
+
+    async def stop(self) -> None:
+        """Stop the background health monitor."""
+        if not self._running:
+            return
+        self._running = False
+        if self._monitor_task:
+            self._monitor_task.cancel()
+            try:
+                await self._monitor_task
+            except asyncio.CancelledError:
+                pass
+            self._monitor_task = None
+        logger.info("MCP health monitor stopped")
+
+    def is_running(self) -> bool:
+        return self._running and self._monitor_task is not None and not self._monitor_task.done()
+
+    def _calculate_restart_delay(self, server_id: str) -> float:
+        """Exponential backoff: base_delay * 2^min(count, MAX_BACKOFF_EXPONENT)."""
+        count = self._restart_counts.get(server_id, 0)
+        exponent = min(count, self.MAX_BACKOFF_EXPONENT)
+        return self.DEFAULT_RESTART_DELAY * (2 ** exponent)
+
+    async def _monitor_loop(self) -> None:
+        """Main monitoring loop — polls all MCP server processes."""
+        while self._running:
+            try:
+                # Snapshot to avoid mutation during iteration
+                for server_id, process in list(self._sm.processes.items()):
+                    try:
+                        await self._check_server(server_id, process)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as e:
+                        logger.error(f"Error checking MCP server '{server_id}': {e}")
+
+                await asyncio.sleep(self.check_interval)
+
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Error in MCP health monitor loop: {e}")
+                await asyncio.sleep(self.check_interval)
+
+        logger.info("MCP health monitor loop exited")
+
+    async def _check_server(self, server_id: str, process) -> None:
+        """Check a single server's health and restart if needed."""
+        is_alive = True
+
+        # Check process liveness
+        if isinstance(process, SseSubprocessHandle):
+            alive, reason = self._sm.health_checker.check_process_alive(process.pid)
+            if not alive:
+                is_alive = False
+                # Refresh returncode so exit_code is accurate for restart policy
+                try:
+                    process.poll()
+                except Exception:
+                    pass
+                logger.warning(f"MCP server '{server_id}' SSE process dead: {reason}")
+        else:
+            if process.poll() is not None:
+                is_alive = False
+                logger.warning(f"MCP server '{server_id}' process exited (code={process.returncode})")
+
+        if is_alive:
+            # Process alive — reset restart count on sustained health
+            if server_id in self._restart_counts:
+                # Reset after 5 minutes of healthy operation
+                uptime = self._sm.get_uptime(server_id)
+                if uptime and uptime > 300:
+                    self._restart_counts.pop(server_id, None)
+            return
+
+        # Process is dead — always clean up DB state
+        rc = getattr(process, "returncode", None)
+        exit_code = rc if rc is not None else -1
+
+        if server_id in self._restarts_in_progress:
+            return
+
+        # Get config to check restart policy
+        config = await self._sm.db.get_server_config(server_id)
+        if not config:
+            # Config deleted — clean up stale state but don't restart
+            op_lock = self._sm._get_operation_lock(server_id)
+            async with op_lock:
+                if self._sm.processes.get(server_id) is process:
+                    await self._sm._cleanup_server(server_id, exit_code)
+            return
+
+        restart_policy = config.get("restart_policy", "on-failure")
+        max_restarts = config.get("max_restarts", 3)
+
+        should_restart = restart_policy in ("on-failure", "always")
+
+        # on-failure: only restart on non-zero exit codes
+        if restart_policy == "on-failure" and exit_code == 0:
+            logger.info(f"MCP server '{server_id}' exited cleanly (code=0), not restarting")
+            should_restart = False
+
+        if should_restart and self._restart_counts.get(server_id, 0) >= max_restarts:
+            logger.warning(f"MCP server '{server_id}' reached max restarts ({max_restarts})")
+            should_restart = False
+
+        if not should_restart:
+            # Still clean up DB state even if not restarting
+            op_lock = self._sm._get_operation_lock(server_id)
+            async with op_lock:
+                if self._sm.processes.get(server_id) is process:
+                    await self._sm._cleanup_server(server_id, exit_code)
+            return
+
+        count = self._restart_counts.get(server_id, 0)
+
+        # Mark in-progress BEFORE first await to prevent a concurrent monitor cycle
+        # from triggering a second restart while sleeping/restarting
+        self._restarts_in_progress.add(server_id)
+        try:
+            # Exponential backoff before acquiring lock
+            delay = self._calculate_restart_delay(server_id)
+            logger.info(f"Restarting MCP server '{server_id}' in {delay:.0f}s (attempt {count + 1}/{max_restarts})")
+            await asyncio.sleep(delay)
+
+            op_lock = self._sm._get_operation_lock(server_id)
+            async with op_lock:
+                # Re-check under lock — a manual restart during backoff may have replaced the process
+                current = self._sm.processes.get(server_id)
+                if current is not None and current is not process:
+                    logger.info(f"MCP server '{server_id}' was restarted manually during backoff, skipping")
+                    return
+                await self._sm._cleanup_server(server_id, exit_code)
+                restart_timeout = float(os.getenv("FMCP_RESTART_TIMEOUT_S", "60"))
+                try:
+                    success = await asyncio.wait_for(
+                        self._sm._start_server_unlocked(server_id, config),
+                        timeout=restart_timeout
+                    )
+                except asyncio.TimeoutError:
+                    logger.error(
+                        f"MCP server '{server_id}' restart timed out after {restart_timeout}s"
+                    )
+                    success = False
+            self._restart_counts[server_id] = count + 1
+            if success:
+                logger.info(f"MCP server '{server_id}' restarted successfully")
+            else:
+                logger.error(f"MCP server '{server_id}' failed to restart")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Error restarting MCP server '{server_id}': {e}")
+        finally:
+            self._restarts_in_progress.discard(server_id)

--- a/fluidmcp/frontend/public/sandbox-proxy.html
+++ b/fluidmcp/frontend/public/sandbox-proxy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><style>*{margin:0;padding:0}body{overflow:hidden}</style></head>
+<body>
+<script>
+  var inner = document.createElement('iframe');
+  inner.setAttribute('sandbox', 'allow-scripts allow-same-origin allow-forms');
+  inner.style.cssText = 'border:none;width:100%;height:100vh;display:block';
+  document.body.appendChild(inner);
+
+  window.addEventListener('message', function(event) {
+    if (event.source === window.parent) {
+      if (event.data && event.data.method === 'ui/notifications/sandbox-resource-ready') {
+        inner.srcdoc = event.data.params.html;
+      } else {
+        inner.contentWindow && inner.contentWindow.postMessage(event.data, '*');
+      }
+    } else if (event.source === inner.contentWindow) {
+      window.parent.postMessage(event.data, '*');
+    }
+  });
+
+  window.parent.postMessage({
+    jsonrpc: '2.0',
+    method: 'ui/notifications/sandbox-proxy-ready',
+    params: {}
+  }, '*');
+</script>
+</body>
+</html>

--- a/fluidmcp/frontend/src/App.tsx
+++ b/fluidmcp/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import LLMModels from "./pages/LLMModels";
 import LLMModelDetails from "./pages/LLMModelDetails";
 import LLMPlayground from "./pages/LLMPlayground";
 import ManageServers from "./pages/ManageServers";
+import MCPInspector from "./pages/MCPInspector";
 
 function App() {
   return (
@@ -28,6 +29,7 @@ function App() {
         <Route path="/servers/manage" element={<ManageServers />} />
         <Route path="/documentation" element={<Documentation />} />
         <Route path="/servers/:serverId" element={<ServerDetails />} />
+        <Route path="/inspector" element={<MCPInspector />} />
         <Route path="/servers/:serverId/tools/:toolName" element={<ToolRunner />} />
         <Route path="/llm/models" element={<LLMModels />} />
         <Route path="/llm/models/:modelId" element={<LLMModelDetails />} />

--- a/fluidmcp/frontend/src/components/Navbar.tsx
+++ b/fluidmcp/frontend/src/components/Navbar.tsx
@@ -51,6 +51,14 @@ export const Navbar: React.FC<NavbarProps> = ({ showAddButton, onOpenAddDialog }
               Manage
             </Link>
             <Link
+              to="/inspector"
+              className={`inline-flex h-10 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-all duration-200 hover:bg-zinc-800 hover:text-white focus:bg-zinc-800 focus:text-white focus:outline-none ${
+                isActive('/inspector') ? 'text-foreground' : 'text-foreground/60'
+              }`}
+            >
+              Inspector
+            </Link>
+            <Link
               to="/documentation"
               className={`inline-flex h-10 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-all duration-200 hover:bg-zinc-800 hover:text-white focus:bg-zinc-800 focus:text-white focus:outline-none ${
                 isActive('/documentation') ? 'text-foreground' : 'text-foreground/60'

--- a/fluidmcp/frontend/src/components/Navbar.tsx
+++ b/fluidmcp/frontend/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import apiClient from "@/services/api";
 
 interface NavbarProps {
   showAddButton?: boolean;
@@ -9,10 +10,25 @@ interface NavbarProps {
 export const Navbar: React.FC<NavbarProps> = ({ showAddButton, onOpenAddDialog }) => {
   const location = useLocation();
   const isActive = (path: string) => location.pathname === path || location.pathname.startsWith(path);
+  const [apiToken, setApiToken] = React.useState("");
+  const [appliedToken, setAppliedToken] = React.useState<string | null>(null);
+  const [showSettings, setShowSettings] = React.useState(false);
+
+  React.useEffect(() => {
+    const savedToken = localStorage.getItem("api_token");
+
+    if (savedToken) {
+      setApiToken(savedToken);
+      setAppliedToken(savedToken);
+      apiClient.setToken(savedToken);
+    }
+  }, []);
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/40 bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/60 transition-all duration-200">
+    <>
+      <header className="fixed top-0 left-0 right-0 z-50 border-b border-border/40 bg-background/95 backdrop-blur-md supports-[backdrop-filter]:bg-background/60 transition-all duration-200">
       <div className="container mx-auto flex h-16 max-w-screen-xl items-center justify-between px-6">
+        {/* LEFT */}
         <div className="flex items-center space-x-8">
           <Link to="/" className="flex items-center space-x-2 group transition-all duration-200 hover:scale-105">
             <span className="text-lg font-bold bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text whitespace-nowrap">Fluid MCP</span>
@@ -68,7 +84,8 @@ export const Navbar: React.FC<NavbarProps> = ({ showAddButton, onOpenAddDialog }
             </Link>
           </nav>
         </div>
-        <div className="flex items-center space-x-3">
+        {/* RIGHT */}
+        <div className="flex items-center space-x-3" >
           {showAddButton && onOpenAddDialog && (
             <button
               onClick={onOpenAddDialog}
@@ -108,8 +125,136 @@ export const Navbar: React.FC<NavbarProps> = ({ showAddButton, onOpenAddDialog }
             </svg>
             Report Issue
           </a>
+
+          {/* Hamburger */}
+          <button
+            onClick={() => setShowSettings(true)}
+            style={{
+              padding: "0.4rem",
+              border: "1px solid #444",
+              borderRadius: "6px",
+              cursor: "pointer"
+            }}
+          >
+            ☰
+          </button>
         </div>
       </div>
+        
     </header>
+    {/* SETTINGS DRAWER */}    
+        {showSettings && (
+          <>
+            {/* Overlay */}
+            <div
+              onClick={() => setShowSettings(false)}
+              style={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                background: "rgba(0, 0, 0, 0.6)",
+                zIndex: 999
+              }}
+            />
+
+            {/* Drawer */}
+            <div
+              onClick={(e) => e.stopPropagation()}  
+              style={{
+                position: "fixed",
+                top: 0,
+                right: 0,
+                height: "100%",
+                width: "320px",
+                background: "#18181b",
+                borderLeft: "1px solid rgba(63,63,70,0.6)",
+                zIndex: 1000,
+                padding: "20px",
+                isolation: "isolate",
+                boxShadow: "-4px 0 20px rgba(0,0,0,0.5)"
+              }}
+            >
+              <h3 style={{ marginBottom: "16px" }}>Settings</h3>
+
+              {/* Token Section */}
+              <div style={{ marginBottom: "20px" }}>
+                <label style={{ fontSize: "12px", color: "#aaa" }}>
+                  API Bearer Token
+                </label>
+
+                <input
+                  type="password"
+                  value={apiToken}
+                  onChange={(e) => setApiToken(e.target.value)}
+                  style={{
+                    width: "100%",
+                    marginTop: "6px",
+                    padding: "0.5rem",
+                    borderRadius: "6px",
+                    border: "1px solid #333",
+                    background: "#000",
+                    color: "#fff"
+                  }}
+                />
+                {/* ACTIVE INDICATOR */}
+                {appliedToken && (
+                  <div style={{ fontSize: "11px", color: "#22c55e", marginTop: "4px" }}>
+                    ● Active
+                  </div>
+                )}
+                {/* BUTTONS */}
+                <div style={{ display: "flex", gap: "8px", marginTop: "10px" }}>
+                  <button
+                    onClick={() => {
+                      apiClient.setToken(apiToken || null);
+                      setAppliedToken(apiToken || null);
+                      if (apiToken) localStorage.setItem("api_token", apiToken);
+                    }}
+                    style={{
+                      padding: "6px 10px",
+                      background: "#16a34a",
+                      color: "#fff",
+                      border: "none",
+                      borderRadius: "4px",
+                      cursor: "pointer"
+                    }}
+                  >
+                    Set
+                  </button>
+
+                  <button
+                    onClick={() => {
+                      setApiToken("");
+                      setAppliedToken(null);
+                      apiClient.setToken(null);
+                      localStorage.removeItem("api_token");
+                    }}
+                    style={{
+                      padding: "6px 10px",
+                      background: "#3f3f46",
+                      color: "#fff",
+                      border: "none",
+                      borderRadius: "4px",
+                      cursor: "pointer"
+                    }}
+                  >
+                    Clear
+                  </button>
+                </div>
+              </div>
+
+              {/* Close */}
+              <button 
+                onClick={() => setShowSettings(false)}
+                style={{ marginTop: "20px" }}
+              >
+                Close
+              </button>
+            </div>
+          </>
+      )}
+    </>
   );
 };

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useRef, useState } from 'react';
+import apiClient from '@/services/api';
+
+interface WidgetSandboxProps {
+  sessionId: string;
+  resourceUri: string;
+  toolInput: Record<string, any>;
+  toolResult: any;
+}
+
+export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }: WidgetSandboxProps) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(300);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [errorMsg, setErrorMsg] = useState('');
+  // Tracks pending requests WE sent to the widget (id → resolve/reject)
+  const pendingRef = useRef<Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>>(new Map());
+  // Fallback timeout: if widget doesn't complete MCP handshake, auto-clear loading state
+  const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    // Send a message to the proxy iframe (which forwards to the inner widget iframe)
+    const sendToProxy = (data: any) => {
+      iframe.contentWindow?.postMessage(data, '*');
+    };
+
+    const handleMessage = async (event: MessageEvent) => {
+      // Only handle messages from our proxy iframe
+      if (event.source !== iframe.contentWindow) return;
+      const msg = event.data;
+      if (!msg || typeof msg !== 'object') return;
+
+      // If this is a response to a request WE sent (has id + result/error, no method)
+      if (msg.id !== undefined && !msg.method && (msg.result !== undefined || msg.error !== undefined)) {
+        const pending = pendingRef.current.get(msg.id);
+        if (pending) {
+          pendingRef.current.delete(msg.id);
+          if (msg.error) pending.reject(new Error(msg.error.message || 'Widget error'));
+          else pending.resolve(msg.result);
+        }
+        return;
+      }
+
+      // Requests / notifications FROM the widget
+      const method: string = msg.method;
+      if (!method) return;
+
+      // ── Proxy is ready: fetch widget HTML and load it ──────────────────────
+      if (method === 'ui/notifications/sandbox-proxy-ready') {
+        try {
+          const res = await apiClient.readInspectorResource(sessionId, resourceUri);
+          const html: string = res?.text || res?.content || '';
+          if (!html) {
+            setStatus('error');
+            setErrorMsg('Widget resource returned empty HTML');
+            return;
+          }
+          sendToProxy({
+            jsonrpc: '2.0',
+            method: 'ui/notifications/sandbox-resource-ready',
+            params: { html },
+          });
+          // Fallback: if the widget doesn't implement the MCP UI handshake,
+          // auto-clear the loading overlay after 2 s so the widget is visible.
+          readyTimeoutRef.current = setTimeout(() => {
+            setStatus(prev => prev === 'loading' ? 'ready' : prev);
+          }, 2000);
+        } catch (e: any) {
+          setStatus('error');
+          setErrorMsg(`Failed to load widget: ${e.message}`);
+        }
+        return;
+      }
+
+      // ── Widget handshake ───────────────────────────────────────────────────
+      if (method === 'ui/initialize') {
+        sendToProxy({
+          jsonrpc: '2.0',
+          id: msg.id,
+          result: {
+            protocolVersion: '2025-06-18',
+            hostInfo: { name: 'FluidMCP Inspector', version: '1.0.0' },
+            hostCapabilities: {},
+          },
+        });
+        return;
+      }
+
+      if (method === 'ui/notifications/initialized') {
+        if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current);
+        setStatus('ready');
+        // Send tool arguments to widget
+        sendToProxy({
+          jsonrpc: '2.0',
+          method: 'ui/notifications/tool-input',
+          params: { arguments: toolInput },
+        });
+        // Send structured result data (structuredContent for widget, not LLM)
+        const raw = toolResult?.result ?? toolResult ?? {};
+        const structuredContent = raw.structuredContent ?? null;
+        const content = raw.content ?? [];
+        if (structuredContent !== null || content.length > 0) {
+          sendToProxy({
+            jsonrpc: '2.0',
+            method: 'ui/notifications/tool-result',
+            params: { content, structuredContent },
+          });
+        }
+        return;
+      }
+
+      // ── Widget requests a tool call ────────────────────────────────────────
+      if (method === 'tools/call') {
+        const { name, arguments: args } = msg.params || {};
+        try {
+          const result = await apiClient.runInspectorTool(sessionId, name, args || {});
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, result });
+        } catch (e: any) {
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: e.message } });
+        }
+        return;
+      }
+
+      // ── Widget reads a resource ────────────────────────────────────────────
+      if (method === 'resources/read') {
+        const { uri } = msg.params || {};
+        try {
+          const result = await apiClient.readInspectorResource(sessionId, uri);
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, result });
+        } catch (e: any) {
+          sendToProxy({ jsonrpc: '2.0', id: msg.id, error: { code: -32000, message: e.message } });
+        }
+        return;
+      }
+
+      // ── Widget resizes itself ──────────────────────────────────────────────
+      if (method === 'ui/notifications/size-change') {
+        const { height: h } = msg.params || {};
+        if (typeof h === 'number' && h > 0) {
+          setHeight(Math.min(h + 20, 800));
+        }
+        return;
+      }
+
+      // ── Widget wants to open a link ────────────────────────────────────────
+      if (method === 'ui/open-link') {
+        const { url } = msg.params || {};
+        if (url) window.open(url, '_blank', 'noopener,noreferrer');
+        if (msg.id !== undefined) sendToProxy({ jsonrpc: '2.0', id: msg.id, result: {} });
+        return;
+      }
+
+      // ── Widget injects a message into chat ─────────────────────────────────
+      if (method === 'ui/message') {
+        // Future: bubble up to chat. For now, just ack.
+        if (msg.id !== undefined) sendToProxy({ jsonrpc: '2.0', id: msg.id, result: {} });
+        return;
+      }
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => {
+      window.removeEventListener('message', handleMessage);
+      pendingRef.current.clear();
+      if (readyTimeoutRef.current) clearTimeout(readyTimeoutRef.current);
+    };
+  }, [sessionId, resourceUri, toolInput, toolResult]);
+
+  if (status === 'error') {
+    return (
+      <div style={{
+        marginTop: '0.5rem', padding: '0.5rem 0.75rem',
+        fontSize: '0.75rem', color: '#fca5a5',
+        background: 'rgba(239,68,68,0.1)',
+        border: '1px solid rgba(239,68,68,0.3)',
+        borderRadius: '6px',
+      }}>
+        Widget error: {errorMsg}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{
+      marginTop: '0.6rem',
+      borderRadius: '8px',
+      overflow: 'hidden',
+      border: '1px solid rgba(99,102,241,0.35)',
+      background: '#fff',
+      position: 'relative',
+    }}>
+      {status === 'loading' && (
+        <div style={{
+          position: 'absolute', inset: 0,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'rgba(9,9,11,0.7)', fontSize: '0.75rem',
+          color: 'rgba(255,255,255,0.5)', zIndex: 1,
+        }}>
+          Loading widget...
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
+        sandbox="allow-scripts allow-same-origin allow-forms"
+        title="MCP Widget"
+        style={{
+          width: '100%',
+          height: `${height}px`,
+          border: 'none',
+          display: 'block',
+          transition: 'height 0.15s ease',
+        }}
+      />
+    </div>
+  );
+}

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -10,7 +10,7 @@ interface WidgetSandboxProps {
 
 export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }: WidgetSandboxProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState(300);
+  const [height, setHeight] = useState(400);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMsg, setErrorMsg] = useState('');
   // Tracks pending requests WE sent to the widget (id → resolve/reject)
@@ -140,7 +140,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
       if (method === 'ui/notifications/size-change') {
         const { height: h } = msg.params || {};
         if (typeof h === 'number' && h > 0) {
-          setHeight(Math.min(h + 20, 800));
+          setHeight(Math.min(h + 40, 1600));
         }
         return;
       }
@@ -184,14 +184,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
   }
 
   return (
-    <div style={{
-      marginTop: '0.6rem',
-      borderRadius: '8px',
-      overflow: 'hidden',
-      border: '1px solid rgba(99,102,241,0.35)',
-      background: '#fff',
-      position: 'relative',
-    }}>
+    <div style={{ background: '#fff', position: 'relative', overflow: 'hidden' }}>
       {status === 'loading' && (
         <div style={{
           position: 'absolute', inset: 0,
@@ -207,13 +200,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
         src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
         sandbox="allow-scripts allow-same-origin allow-forms"
         title="MCP Widget"
-        style={{
-          width: '100%',
-          height: `${height}px`,
-          border: 'none',
-          display: 'block',
-          transition: 'height 0.15s ease',
-        }}
+        style={{ width: '100%', height: `${height}px`, border: 'none', display: 'block', transition: 'height 0.15s ease' }}
       />
     </div>
   );

--- a/fluidmcp/frontend/src/components/result/ToolResult.tsx
+++ b/fluidmcp/frontend/src/components/result/ToolResult.tsx
@@ -274,8 +274,6 @@ export const ToolResult: React.FC<ToolResultProps> = ({
           border: '1px solid rgba(63, 63, 70, 0.5)',
           borderRadius: '0.5rem',
           padding: '1.5rem',
-          maxHeight: '70vh',
-          overflow: 'auto'
         }}>
           {viewMode === 'raw' ? (
             <pre style={{ 

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,5 +1,5 @@
 // import React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
@@ -17,6 +17,13 @@ interface MCPServer {
   transport: string;
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
   error?: string;
+}
+
+// Type for log entry
+interface LogEntry {
+  timestamp: string;
+  type: 'connect' | 'disconnect' | 'tool_call' | 'tool_result' | 'tool_error' | 'chat';
+  message: string;
 }
 
 // Helper to generate unique server IDs
@@ -48,8 +55,12 @@ export default function MCPInspector() {
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
     left: 25,     // percentage (right auto-calculated as 100-left)
-    logs: 40      // percentage
+    logs: 35      // percentage of left panel height
   })
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const logsRef = useRef<HTMLDivElement>(null);
+  const chatRef = useRef<HTMLDivElement>(null);
+
   const handleConnect = async () => {
     if (!url) return;
 
@@ -300,6 +311,51 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
+  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
+  useEffect(() => {
+    logsRef.current?.scrollTo({ top: 0 });
+  }, [logs]);
+
+  // Auto-scroll chat to bottom when new messages arrive
+  useEffect(() => {
+    if (chatRef.current) {
+      chatRef.current.scrollTop = chatRef.current.scrollHeight;
+    }
+  }, [chatHistory]);
+
+  // Poll for logs every 2 seconds when a session is active.
+  // Inlined to avoid stale-closure issues with fetchLogs in the dependency array.
+  useEffect(() => {
+    if (!selectedServer?.session_id) {
+      setLogs([]);   // clear stale logs when no session is active
+      return;
+    }
+    const sessionId = selectedServer.session_id;
+
+    const poll = async () => {
+      try {
+        const res = await apiClient.getInspectorLogs(sessionId);
+        setLogs(res.logs || []);
+      } catch (err) {
+        console.error("Failed to fetch logs", err);
+      }
+    };
+
+    poll();
+    const interval = setInterval(poll, 2000);
+    return () => clearInterval(interval);
+  }, [selectedServer?.session_id]);
+
+  // Color mapping for log types
+  const logColors: Record<string, string> = {
+    connect: "#10b981",
+    disconnect: "#6b7280",
+    tool_call: "#3b82f6",
+    tool_result: "#22c55e",
+    tool_error: "#ef4444",
+    chat: "#6366f1",
+  };
+
   return (
     <div
       className="dashboard"
@@ -307,16 +363,20 @@ export default function MCPInspector() {
     >
       <Navbar />
 
-      <div style={{ paddingTop: "64px", flex: 1 }}>
+      <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
         <div
           style={{
             maxWidth: "1600px",
+            width: "100%",
             margin: "0 auto",
             padding: "2rem",
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
           }}
         >
           {/* Page Header */}
-          <div style={{ marginBottom: "2rem" }}>
+          <div style={{ marginBottom: "1.5rem" }}>
             <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>
               MCP Inspector
             </h1>
@@ -325,7 +385,7 @@ export default function MCPInspector() {
             </p>
           </div>
 
-          {/* Main Layout */}
+          {/* Main Layout — fills remaining height */}
           <PanelGroup 
             direction="horizontal" 
             onLayout={(sizes) => {
@@ -335,16 +395,20 @@ export default function MCPInspector() {
                 return updated;
               });
             }}
-            style={{ minHeight: "600px" }}
+            style={{ 
+              flex: 1,
+              // Minimum height so it doesn't collapse
+              minHeight: "calc(100vh - 220px)",
+            }}
           >
-            {/* LEFT PANEL (outer) */}
+            {/* ── LEFT PANEL (outer) ─────────────────────────────────────── */}
             <Panel 
               defaultSize={panelSizes.left} 
-              minSize={20} 
+              minSize={18} 
               maxSize={50}
-              style={{ overflow: "hidden", display: "flex", flexDirection: "column" }}
+              style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}
             >
-              {/* LEFT PANEL INNER: Vertical split between Servers+Tools and Logs */}
+              {/* LEFT PANEL INNER: vertical split — Servers+Tools (top) / Logs (bottom) */}
               <PanelGroup 
                 direction="vertical" 
                 onLayout={(sizes) => {
@@ -354,649 +418,611 @@ export default function MCPInspector() {
                     return updated;
                   });
                 }}
-                style={{ flex: 1 }}
+                style={{ flex: 1, height: "100%" }}
               >
-                {/* TOP: Servers + Tools Section */}
+
+                {/* ── TOP: Servers + Tools ────────────────────────────────── */}
                 <Panel 
                   defaultSize={100 - panelSizes.logs} 
-                  minSize={40}
+                  minSize={30}
                   style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
-                >
-            {/* LEFT PANEL */}
-            <div
-              style={{
-                border: "1px solid rgba(63,63,70,0.5)",
-                borderRadius: "0.75rem",
-                padding: "1.5rem",
-                background:
-                  "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-              }}
-            >
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                }}
-              >
-                <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>
-                  Servers
-                </h2>
-
-                <button
-                  style={{
-                    background: "#fff",
-                    color: "#000",
-                    border: "none",
-                    padding: "0.35rem 0.75rem",
-                    borderRadius: "0.375rem",
-                    fontSize: "0.8rem",
-                    fontWeight: "600",
-                    cursor: "pointer",
-                  }}
-                  onClick={() => setShowAddModal(true)}
-                >
-                  + Add
-                </button>
-              </div>
-              {/* Connected Servers List or Empty State */}
-              <div
-                style={{
-                  marginTop: "1rem",
-                  padding: "1rem",
-                  border: "1px dashed rgba(63,63,70,0.6)",
-                  borderRadius: "0.5rem",
-                  textAlign: "center",
-                  color: "rgba(255,255,255,0.6)",
-                }}
-              >
-                {servers.length === 0 ? (
-                  <div> No servers connected </div>
-                ) : (
-                  servers.map((server) => {
-                    // Determine badge color and text based on status
-                    const statusConfig = {
-                      connecting: {
-                        text: "Connecting...",
-                        bg: "rgba(59,130,246,0.2)",
-                        color: "#3b82f6",
-                      },
-                      connected: {
-                        text: "Connected",
-                        bg: "rgba(16,185,129,0.2)",
-                        color: "#10b981",
-                      },
-                      disconnected: {
-                        text: "Disconnected",
-                        bg: "rgba(107,114,128,0.2)",
-                        color: "#6b7280",
-                      },
-                      failed: {
-                        text: "Failed",
-                        bg: "rgba(239,68,68,0.2)",
-                        color: "#ef4444",
-                      },
-                    };
-
-                    const statusInfo = statusConfig[server.status];
-                    const isSelected = selectedServer?.id === server.id;
-
-                    return (
-                      <div
-                        key={server.id}
-                        onClick={() => {
-                          setSelectedServerId(server.id);
-                          setSelectedTool(null);
-                          setToolResult(null);
-                        }}
-                        style={{
-                          marginTop: "1rem",
-                          padding: "1rem",
-                          border: "1px solid rgba(63,63,70,0.6)",
-                          borderRadius: "0.6rem",
-                          cursor: "pointer",
-                          background: isSelected
-                            ? "rgba(255,255,255,0.08)"
-                            : "transparent",
-                        }}
-                      >
-                        {/* HEADER */}
-                        <div
-                          style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "center",
-                          }}
-                        >
-                          <div style={{ fontWeight: "600" }}>
-                            {server?.server_info?.name || "MCP Server"}
-                          </div>
-
-                          <span
-                            style={{
-                              fontSize: "0.7rem",
-                              padding: "0.2rem 0.5rem",
-                              borderRadius: "0.3rem",
-                              background: statusInfo.bg,
-                              color: statusInfo.color,
-                            }}
-                          >
-                            {statusInfo.text}
-                          </span>
-                        </div>
-
-                        {/* URL */}
-                        <div
-                          style={{
-                            marginTop: "0.3rem",
-                            fontSize: "0.8rem",
-                            color: "rgba(255,255,255,0.6)",
-                            wordBreak: "break-all",
-                          }}
-                        >
-                          {server.url}
-                        </div>
-                        <div
-                          style={{
-                            fontSize: "0.75rem",
-                            color: "rgba(255,255,255,0.5)",
-                          }}
-                        >
-                          transport: {server.transport}
-                        </div>
-
-                        {/* ERROR MESSAGE (for failed status) */}
-                        {server.status === "failed" && server.error && (
-                          <div
-                            style={{
-                              marginTop: "0.5rem",
-                              fontSize: "0.75rem",
-                              color: "#ef4444",
-                              padding: "0.5rem",
-                              background: "rgba(239,68,68,0.1)",
-                              borderRadius: "0.3rem",
-                              wordBreak: "break-word",
-                            }}
-                          >
-                            {server.error}
-                          </div>
-                        )}
-
-                        {/* ACTION BUTTONS */}
-                        <div
-                          style={{
-                            marginTop: "0.6rem",
-                            display: "flex",
-                            justifyContent: "flex-end",
-                            gap: "0.5rem",
-                          }}
-                        >
-                          {server.status === "connected" && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDisconnect(server.id);
-                              }}
-                              style={{
-                                fontSize: "0.75rem",
-                                padding: "0.25rem 0.6rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
-                                background: "transparent",
-                                color: "#fff",
-                                cursor: "pointer",
-                              }}
-                            >
-                              Disconnect
-                            </button>
-                          )}
-
-                          {server.status === "disconnected" && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleReconnect(server.id);
-                              }}
-                              style={{
-                                fontSize: "0.75rem",
-                                padding: "0.25rem 0.6rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(107,114,128,0.6)",
-                                background: "rgba(107,114,128,0.1)",
-                                color: "#fff",
-                                cursor: "pointer",
-                              }}
-                            >
-                              Reconnect
-                            </button>
-                          )}
-
-                          {server.status === "failed" && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleReconnect(server.id);
-                              }}
-                              style={{
-                                fontSize: "0.75rem",
-                                padding: "0.25rem 0.6rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(239,68,68,0.6)",
-                                background: "rgba(239,68,68,0.1)",
-                                color: "#ef4444",
-                                cursor: "pointer",
-                              }}
-                            >
-                              Retry
-                            </button>
-                          )}
-
-                          {server.status !== "connecting" && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleRemove(server.id);
-                              }}
-                              style={{
-                                fontSize: "0.75rem",
-                                padding: "0.25rem 0.4rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
-                                background: "transparent",
-                                color: "rgba(255,255,255,0.6)",
-                                cursor: "pointer",
-                              }}
-                              title="Remove server"
-                            >
-                              ✕
-                            </button>
-                          )}
-                        </div>
-
-                        {/* TOOLS (only show when selected) */}
-                        {isSelected && server?.tools?.map((tool: any) => (
-                          <div
-                            key={tool.name}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              setSelectedTool(tool);
-                              setToolResult(null);
-                              setToolError(null);
-                            }}
-                            style={{
-                              marginLeft: "0.8rem",
-                              marginTop: "0.4rem",
-                              fontSize: "0.85rem",
-                              cursor: "pointer",
-                              color:
-                                selectedTool?.name === tool.name
-                                  ? "#fff"
-                                  : "rgba(255,255,255,0.7)",
-                            }}
-                          >
-                            • {tool.name}
-                          </div>
-                        ))}
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-
-              {/* Execution History */}
-              <div style={{ marginTop: "1.5rem" }}>
-                <h3 style={{ marginBottom: "0.5rem" }}>Execution History</h3>
-
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "0.5rem",
-                    maxHeight: "200px",
-                    overflowY: "auto"
-                  }}
-                >
-                  {executionHistory.map((item) => (
-                    <div
-                      key={item.id}
-                      onClick={() => {
-                        setToolResult(item.result)
-                        setSelectedTool( item.tool )
-                        setToolError(null)
-                      }}
-                      style={{
-                        padding: "0.5rem",
-                        borderRadius: "0.35rem",
-                        border: "1px solid rgba(63,63,70,0.6)",
-                        cursor: "pointer",
-                        background: "rgba(255,255,255,0.05)"
-                      }}
-                    >
-                      <div style={{ fontWeight: 600 }}>{item.tool.name}</div>
-                      <div style={{ fontSize: "0.8rem", opacity: 0.7 }}>
-                        {item.time}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-              <button
-                onClick={() => setExecutionHistory([])}
-                style={{
-                  marginTop: "0.5rem",
-                  fontSize: "0.75rem",
-                  padding: "0.25rem 0.6rem",
-                  borderRadius: "0.35rem",
-                  border: "1px solid rgba(63,63,70,0.6)",
-                  background: "transparent",
-                  color: "#fff",
-                  cursor: "pointer",
-                }}
-              >
-                Clear
-              </button>
-            </div>
-
-                </Panel>
-
-                {/* Vertical Divider between Servers+Tools and Logs */}
-                <PanelResizeHandle
-                  style={{
-                    backgroundColor: "rgba(63,63,70,0.3)",
-                    height: "4px",
-                    cursor: "row-resize",
-                    transition: "background 0.15s ease",
-                  }}
-                  onMouseEnter={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.5)" }}
-                  onMouseLeave={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.3)" }}
-                />
-
-                {/* BOTTOM: Logs Section (Placeholder for Phase 3) */}
-                <Panel 
-                  defaultSize={panelSizes.logs} 
-                  minSize={15}
-                  style={{ overflow: "auto", overflowY: "auto", display: "flex", flexDirection: "column" }}
                 >
                   <div
                     style={{
-                      padding: "1rem",
-                      border: "1px dashed rgba(63,63,70,0.6)",
-                      borderRadius: "0.5rem",
-                      textAlign: "center",
-                      color: "rgba(255,255,255,0.5)",
+                      border: "1px solid rgba(63,63,70,0.5)",
+                      borderRadius: "0.75rem",
+                      padding: "1.25rem",
+                      background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
                       height: "100%",
+                      boxSizing: "border-box",
                       display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
+                      flexDirection: "column",
+                      overflow: "auto",
                     }}
                   >
-                    Logs section (coming next phase)
+                    {/* Header */}
+                    <div
+                      style={{
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        flexShrink: 0,
+                      }}
+                    >
+                      <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>
+                        Servers
+                      </h2>
+
+                      <button
+                        style={{
+                          background: "#fff",
+                          color: "#000",
+                          border: "none",
+                          padding: "0.35rem 0.75rem",
+                          borderRadius: "0.375rem",
+                          fontSize: "0.8rem",
+                          fontWeight: "600",
+                          cursor: "pointer",
+                        }}
+                        onClick={() => setShowAddModal(true)}
+                      >
+                        + Add
+                      </button>
+                    </div>
+
+                    {/* Servers List or Empty State */}
+                    <div
+                      style={{
+                        marginTop: "1rem",
+                        padding: servers.length === 0 ? "1rem" : "0",
+                        border: servers.length === 0 ? "1px dashed rgba(63,63,70,0.6)" : "none",
+                        borderRadius: "0.5rem",
+                        textAlign: servers.length === 0 ? "center" : "left",
+                        color: "rgba(255,255,255,0.6)",
+                        flex: 1,
+                        overflow: "auto",
+                      }}
+                    >
+                      {servers.length === 0 ? (
+                        <div>No servers connected</div>
+                      ) : (
+                        servers.map((server) => {
+                          const statusConfig = {
+                            connecting: { text: "Connecting...", bg: "rgba(59,130,246,0.2)", color: "#3b82f6" },
+                            connected:  { text: "Connected",    bg: "rgba(16,185,129,0.2)",  color: "#10b981" },
+                            disconnected: { text: "Disconnected", bg: "rgba(107,114,128,0.2)", color: "#6b7280" },
+                            failed:     { text: "Failed",       bg: "rgba(239,68,68,0.2)",    color: "#ef4444" },
+                          };
+
+                          const statusInfo = statusConfig[server.status];
+                          const isSelected = selectedServer?.id === server.id;
+
+                          return (
+                            <div
+                              key={server.id}
+                              onClick={() => {
+                                setSelectedServerId(server.id);
+                                setSelectedTool(null);
+                                setToolResult(null);
+                              }}
+                              style={{
+                                marginTop: "0.75rem",
+                                padding: "0.9rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                borderRadius: "0.6rem",
+                                cursor: "pointer",
+                                background: isSelected ? "rgba(255,255,255,0.08)" : "transparent",
+                              }}
+                            >
+                              {/* HEADER */}
+                              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                                <div style={{ fontWeight: "600", fontSize: "0.9rem" }}>
+                                  {server?.server_info?.name || "MCP Server"}
+                                </div>
+                                <span
+                                  style={{
+                                    fontSize: "0.7rem",
+                                    padding: "0.2rem 0.5rem",
+                                    borderRadius: "0.3rem",
+                                    background: statusInfo.bg,
+                                    color: statusInfo.color,
+                                    flexShrink: 0,
+                                  }}
+                                >
+                                  {statusInfo.text}
+                                </span>
+                              </div>
+
+                              {/* URL */}
+                              <div
+                                style={{
+                                  marginTop: "0.3rem",
+                                  fontSize: "0.75rem",
+                                  color: "rgba(255,255,255,0.5)",
+                                  wordBreak: "break-all",
+                                }}
+                              >
+                                {server.url}
+                              </div>
+                              <div style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)" }}>
+                                transport: {server.transport}
+                              </div>
+
+                              {/* ERROR */}
+                              {server.status === "failed" && server.error && (
+                                <div
+                                  style={{
+                                    marginTop: "0.5rem",
+                                    fontSize: "0.75rem",
+                                    color: "#ef4444",
+                                    padding: "0.4rem",
+                                    background: "rgba(239,68,68,0.1)",
+                                    borderRadius: "0.3rem",
+                                    wordBreak: "break-word",
+                                  }}
+                                >
+                                  {server.error}
+                                </div>
+                              )}
+
+                              {/* ACTION BUTTONS */}
+                              <div style={{ marginTop: "0.6rem", display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                                {server.status === "connected" && (
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); handleDisconnect(server.id); }}
+                                    style={{
+                                      fontSize: "0.75rem", padding: "0.25rem 0.6rem",
+                                      borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
+                                      background: "transparent", color: "#fff", cursor: "pointer",
+                                    }}
+                                  >
+                                    Disconnect
+                                  </button>
+                                )}
+
+                                {server.status === "disconnected" && (
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); handleReconnect(server.id); }}
+                                    style={{
+                                      fontSize: "0.75rem", padding: "0.25rem 0.6rem",
+                                      borderRadius: "0.35rem", border: "1px solid rgba(107,114,128,0.6)",
+                                      background: "rgba(107,114,128,0.1)", color: "#fff", cursor: "pointer",
+                                    }}
+                                  >
+                                    Reconnect
+                                  </button>
+                                )}
+
+                                {server.status === "failed" && (
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); handleReconnect(server.id); }}
+                                    style={{
+                                      fontSize: "0.75rem", padding: "0.25rem 0.6rem",
+                                      borderRadius: "0.35rem", border: "1px solid rgba(239,68,68,0.6)",
+                                      background: "rgba(239,68,68,0.1)", color: "#ef4444", cursor: "pointer",
+                                    }}
+                                  >
+                                    Retry
+                                  </button>
+                                )}
+
+                                {server.status !== "connecting" && (
+                                  <button
+                                    onClick={(e) => { e.stopPropagation(); handleRemove(server.id); }}
+                                    style={{
+                                      fontSize: "0.75rem", padding: "0.25rem 0.4rem",
+                                      borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
+                                      background: "transparent", color: "rgba(255,255,255,0.6)", cursor: "pointer",
+                                    }}
+                                    title="Remove server"
+                                  >
+                                    ✕
+                                  </button>
+                                )}
+                              </div>
+
+                              {/* TOOLS (only show when selected) */}
+                              {isSelected && server?.tools?.map((tool: any) => (
+                                <div
+                                  key={tool.name}
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    setSelectedTool(tool);
+                                    setToolResult(null);
+                                    setToolError(null);
+                                  }}
+                                  style={{
+                                    marginLeft: "0.5rem",
+                                    marginTop: "0.4rem",
+                                    fontSize: "0.82rem",
+                                    cursor: "pointer",
+                                    color: selectedTool?.name === tool.name ? "#fff" : "rgba(255,255,255,0.65)",
+                                    padding: "0.2rem 0.4rem",
+                                    borderRadius: "0.25rem",
+                                    background: selectedTool?.name === tool.name ? "rgba(255,255,255,0.08)" : "transparent",
+                                  }}
+                                >
+                                  • {tool.name}
+                                </div>
+                              ))}
+                            </div>
+                          );
+                        })
+                      )}
+                    </div>
+
+                    {/* Execution History */}
+                    <div style={{ marginTop: "1.25rem", flexShrink: 0 }}>
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
+                        <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
+                        <button
+                          onClick={() => setExecutionHistory([])}
+                          style={{
+                            fontSize: "0.7rem", padding: "0.2rem 0.5rem",
+                            borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
+                            background: "transparent", color: "rgba(255,255,255,0.6)", cursor: "pointer",
+                          }}
+                        >
+                          Clear
+                        </button>
+                      </div>
+
+                      <div
+                        style={{
+                          display: "flex", flexDirection: "column", gap: "0.4rem",
+                          maxHeight: "160px", overflowY: "auto",
+                        }}
+                      >
+                        {executionHistory.map((item) => (
+                          <div
+                            key={item.id}
+                            onClick={() => {
+                              setToolResult(item.result);
+                              setSelectedTool(item.tool);
+                              setToolError(null);
+                            }}
+                            style={{
+                              padding: "0.4rem 0.5rem",
+                              borderRadius: "0.35rem",
+                              border: "1px solid rgba(63,63,70,0.6)",
+                              cursor: "pointer",
+                              background: "rgba(255,255,255,0.04)",
+                            }}
+                          >
+                            <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{item.tool.name}</div>
+                            <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>{item.time}</div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
                   </div>
                 </Panel>
+
+                {/* ── Vertical resize handle ─────────────────────────────── */}
+                <PanelResizeHandle
+                  style={{
+                    height: "5px",
+                    cursor: "row-resize",
+                    background: "rgba(63,63,70,0.4)",
+                    flexShrink: 0,
+                    transition: "background 0.15s",
+                    borderRadius: "2px",
+                  }}
+                  onMouseEnter={(e: any) => { e.currentTarget.style.background = "rgba(99,102,241,0.6)"; }}
+                  onMouseLeave={(e: any) => { e.currentTarget.style.background = "rgba(63,63,70,0.4)"; }}
+                />
+
+                {/* ── BOTTOM: Logs ─────────────────────────────────────────── */}
+                <Panel 
+                  defaultSize={panelSizes.logs} 
+                  minSize={12}
+                  style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}
+                >
+                  <div
+                    style={{
+                      border: "1px solid rgba(63,63,70,0.5)",
+                      borderRadius: "0.75rem",
+                      background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
+                      height: "100%",
+                      boxSizing: "border-box",
+                      display: "flex",
+                      flexDirection: "column",
+                      overflow: "hidden",
+                    }}
+                  >
+                    {/* Logs header */}
+                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
+                      <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
+                        LOGS
+                      </span>
+                      {logs.length > 0 && (
+                        <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
+                          {logs.length} entries
+                        </span>
+                      )}
+                    </div>
+
+                    {/* Logs content */}
+                    <div
+                      ref={logsRef}
+                      style={{
+                        flex: 1,
+                        overflowY: "auto",
+                        overflowX: "hidden",
+                        padding: "0.5rem 0.75rem",
+                        fontFamily: "monospace",
+                        fontSize: "0.78rem",
+                      }}
+                    >
+                      {logs.length === 0 ? (
+                        <div style={{
+                          display: "flex", alignItems: "center", justifyContent: "center",
+                          height: "100%", color: "rgba(255,255,255,0.35)", fontSize: "0.8rem",
+                        }}>
+                          {selectedServer?.session_id ? "No logs yet" : "Connect to a server to see logs"}
+                        </div>
+                      ) : (
+                        <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+                          {[...logs].reverse().map((log) => {
+                            const color = logColors[log.type] || "#9ca3af";
+                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
+                            return (
+                              <div
+                                key={logKey}
+                                style={{
+                                  display: "grid",
+                                  // Fixed columns: time | type | message
+                                  // time ~70px, type ~90px, message gets rest
+                                  gridTemplateColumns: "70px 90px 1fr",
+                                  gap: "0.5rem",
+                                  paddingBottom: "3px",
+                                  borderBottom: "1px solid rgba(63,63,70,0.2)",
+                                  alignItems: "start",
+                                }}
+                              >
+                                {/* Time */}
+                                <span style={{ opacity: 0.45, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                  {new Date(log.timestamp).toLocaleTimeString()}
+                                </span>
+                                {/* Type */}
+                                <span style={{ color, fontWeight: "700", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                                  {log.type.toUpperCase()}
+                                </span>
+                                {/* Message — grid child auto-constrains width, word-break works correctly */}
+                                <span style={{ color: "rgba(255,255,255,0.75)", wordBreak: "break-word", overflowWrap: "break-word" }}>
+                                  {log.message}
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </Panel>
+
               </PanelGroup>
             </Panel>
 
-            {/* Horizontal Divider between Left and Right Panels */}
+            {/* ── Horizontal resize handle ───────────────────────────────── */}
             <PanelResizeHandle
               style={{
-                backgroundColor: "rgba(63,63,70,0.3)",
-                width: "4px",
+                width: "5px",
                 cursor: "col-resize",
-                transition: "background 0.15s ease",
+                background: "rgba(63,63,70,0.4)",
+                flexShrink: 0,
+                transition: "background 0.15s",
+                borderRadius: "2px",
               }}
-              onMouseEnter={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.5)" }}
-              onMouseLeave={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.3)" }}
+              onMouseEnter={(e: any) => { e.currentTarget.style.background = "rgba(99,102,241,0.6)"; }}
+              onMouseLeave={(e: any) => { e.currentTarget.style.background = "rgba(63,63,70,0.4)"; }}
             />
 
-            {/* RIGHT PANEL */}
+            {/* ── RIGHT PANEL ───────────────────────────────────────────── */}
             <Panel 
               defaultSize={100 - panelSizes.left} 
               minSize={50}
               style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
             >
-            <div
-              style={{
-                border: "1px solid rgba(63,63,70,0.5)",
-                borderRadius: "0.75rem",
-                padding: "1.5rem",
-                background:
-                  "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-              }}
-            >
-              <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>
-                Tool Execution
-              </h2>
-              <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem" }}>
-                <button
-                  onClick={() => setMode("manual")}
-                  style={{
-                    padding: "0.35rem 0.75rem",
-                    borderRadius: "0.35rem",
-                    border: "1px solid rgba(63,63,70,0.6)",
-                    background: mode === "manual" ? "#fff" : "transparent",
-                    color: mode === "manual" ? "#000" : "#fff",
-                    cursor: "pointer"
-                  }}
-                >
-                  Manual
-                </button>
+              <div
+                style={{
+                  border: "1px solid rgba(63,63,70,0.5)",
+                  borderRadius: "0.75rem",
+                  padding: "1.5rem",
+                  background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
+                  height: "100%",
+                  boxSizing: "border-box",
+                  display: "flex",
+                  flexDirection: "column",
+                  overflow: "hidden",
+                }}
+              >
+                <h2 style={{ fontSize: "1.1rem", fontWeight: "600", flexShrink: 0 }}>
+                  Tool Execution
+                </h2>
 
-                <button
-                  onClick={() => setMode("chat")}
-                  style={{
-                    padding: "0.35rem 0.75rem",
-                    borderRadius: "0.35rem",
-                    border: "1px solid rgba(63,63,70,0.6)",
-                    background: mode === "chat" ? "#fff" : "transparent",
-                    color: mode === "chat" ? "#000" : "#fff",
-                    cursor: "pointer"
-                  }}
-                >
-                  Chat
-                </button>
-              </div>
-              {mode === "manual" && selectedServer && selectedTool && (
-                <div style={{ marginTop: "1rem" }}>
-                  <h3 style={{ marginBottom: "1rem" }}>
-                    {selectedTool.name}
-                  </h3>
+                {/* Mode tabs */}
+                <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem", flexShrink: 0 }}>
+                  <button
+                    onClick={() => setMode("manual")}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "manual" ? "#fff" : "transparent",
+                      color: mode === "manual" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Manual
+                  </button>
+                  <button
+                    onClick={() => setMode("chat")}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "chat" ? "#fff" : "transparent",
+                      color: mode === "chat" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Chat
+                  </button>
+                </div>
 
-                  {selectedServer.status === "connected" ? (
-                    <>
-                      <JsonSchemaForm
-                        schema={selectedTool.inputSchema}
-                        onSubmit={runTool}
-                        submitLabel="Run Tool"
-                        loading={executing}
-                      />
+                {/* ── MANUAL MODE ─── */}
+                <div style={{ flex: 1, overflow: "auto", marginTop: "1rem" }}>
+                  {mode === "manual" && selectedServer && selectedTool && (
+                    <div>
+                      <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
 
-                      {(toolResult || toolError) && (
-                        <div style={{ marginTop: "2rem" }}>
-                          <ToolResult
-                            result={toolResult}
-                            error={toolError || undefined}
-                            executionTime={executionTime}
+                      {selectedServer.status === "connected" ? (
+                        <>
+                          <JsonSchemaForm
+                            schema={selectedTool.inputSchema}
+                            onSubmit={runTool}
+                            submitLabel="Run Tool"
+                            loading={executing}
                           />
+
+                          {(toolResult || toolError) && (
+                            <div style={{ marginTop: "2rem" }}>
+                              <ToolResult
+                                result={toolResult}
+                                error={toolError || undefined}
+                                executionTime={executionTime}
+                              />
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <div style={{
+                          padding: "1rem", border: "1px dashed rgba(239,68,68,0.6)",
+                          borderRadius: "0.5rem", textAlign: "center", color: "rgba(239,68,68,0.8)",
+                        }}>
+                          Server is not connected. Please reconnect to run tools.
                         </div>
                       )}
-                    </>
-                  ) : (
-                    <div
-                      style={{
-                        padding: "1rem",
-                        border: "1px dashed rgba(239,68,68,0.6)",
-                        borderRadius: "0.5rem",
-                        textAlign: "center",
-                        color: "rgba(239,68,68,0.8)",
-                      }}
-                    >
-                      Server is not connected. Please reconnect to run tools.
                     </div>
                   )}
-                </div>
-              )}
-              {mode === "chat" && selectedServer && (
-                <div style={{ marginTop: "1rem", width: "100%" }}>
-                  {selectedServer.status === "connected" ? (
-                    <>
-                      {/* Chat History */}
-                      <div
-                        style={{
-                          maxHeight: "400px",
-                          overflow: "auto",
-                          marginBottom: "1rem",
-                          display: "flex",
-                          flexDirection: "column",
-                          gap: "0.5rem",
-                        }}
-                      >
-                        {chatHistory.map((msg, i) => (
+
+                  {/* ── CHAT MODE ─── */}
+                  {mode === "chat" && selectedServer && (
+                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "300px" }}>
+                      {selectedServer.status === "connected" ? (
+                        <>
+                          {/* Chat History */}
                           <div
-                            key={i}
+                            ref={chatRef}
                             style={{
-                              padding: "0.5rem",
-                              borderRadius: "0.35rem",
-                              background:
-                                msg.role === "user"
-                                  ? "rgba(255,255,255,0.1)"
-                                  : "rgba(99,102,241,0.2)",
+                              flex: 1,
+                              overflow: "auto",
+                              marginBottom: "1rem",
+                              display: "flex",
+                              flexDirection: "column",
+                              gap: "0.5rem",
                             }}
                           >
-                            <strong>{msg.role}</strong>
-                            <pre
+                            {chatHistory.map((msg, i) => (
+                              <div
+                                key={`${msg.role}-${i}-${msg.content?.slice(0,20)}`}
+                                style={{
+                                  padding: "0.5rem",
+                                  borderRadius: "0.35rem",
+                                  background: msg.role === "user" ? "rgba(255,255,255,0.1)" : "rgba(99,102,241,0.2)",
+                                }}
+                              >
+                                <strong style={{ fontSize: "0.8rem" }}>{msg.role}</strong>
+                                <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: "0.85rem" }}>
+                                  {msg.content}
+                                </pre>
+                              </div>
+                            ))}
+                          </div>
+
+                          {/* Chat Input */}
+                          <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
+                            <input
+                              value={chatInput}
+                              onChange={(e) => setChatInput(e.target.value)}
+                              placeholder="Ask something..."
+                              onKeyDown={(e) => { if (e.key === "Enter") runChatTool(); }}
                               style={{
-                                margin: 0,
-                                whiteSpace: "pre-wrap",
-                                wordBreak: "break-word",
+                                flex: 1, minWidth: 0, padding: "0.5rem",
+                                borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
+                                background: "#09090b", color: "#fff",
+                              }}
+                            />
+                            <button
+                              onClick={runChatTool}
+                              disabled={chatLoading}
+                              style={{
+                                padding: "0.5rem 0.75rem", borderRadius: "0.35rem",
+                                background: "#fff", color: "#000", fontWeight: "600", flexShrink: 0,
                               }}
                             >
-                              {msg.content}
-                            </pre>
+                              {chatLoading ? "..." : "Send"}
+                            </button>
                           </div>
-                        ))}
-                      </div>
+                        </>
+                      ) : (
+                        <div style={{
+                          padding: "1rem", border: "1px dashed rgba(239,68,68,0.6)",
+                          borderRadius: "0.5rem", textAlign: "center", color: "rgba(239,68,68,0.8)",
+                        }}>
+                          Server is not connected. Please reconnect to chat.
+                        </div>
+                      )}
+                    </div>
+                  )}
 
-                      {/* Chat Input Row */}
-                      <div style={{ display: "flex", gap: "0.5rem" }}>
-                        <input
-                          value={chatInput}
-                          onChange={(e) => setChatInput(e.target.value)}
-                          placeholder="Ask something..."
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") runChatTool();
-                          }}
-                          style={{
-                            flex: 1,
-                            minWidth: 0,
-                            padding: "0.5rem",
-                            borderRadius: "0.35rem",
-                            border: "1px solid rgba(63,63,70,0.6)",
-                            background: "#09090b",
-                            color: "#fff",
-                          }}
-                        />
-
-                        <button
-                          onClick={runChatTool}
-                          disabled={chatLoading}
-                          style={{
-                            padding: "0.5rem 0.75rem",
-                            borderRadius: "0.35rem",
-                            background: "#fff",
-                            color: "#000",
-                            fontWeight: "600",
-                            flexShrink: 0,
-                          }}
-                        >
-                          Send
-                        </button>
-                      </div>
-                    </>
-                  ) : (
-                    <div
-                      style={{
-                        padding: "1rem",
-                        border: "1px dashed rgba(239,68,68,0.6)",
-                        borderRadius: "0.5rem",
-                        textAlign: "center",
-                        color: "rgba(239,68,68,0.8)",
-                      }}
-                    >
-                      Server is not connected. Please reconnect to chat.
+                  {/* Empty states */}
+                  {mode === "manual" && (!selectedServer || !selectedTool) && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      Select a tool to execute
+                    </div>
+                  )}
+                  {mode === "chat" && (!selectedServer || selectedServer.status !== "connected") && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      {!selectedServer ? "Select a connected server to chat" : "Server is not connected. Please reconnect to chat."}
                     </div>
                   )}
                 </div>
-              )}
-              {mode === "manual" && (!selectedServer || !selectedTool) && (
-                <div
-                  style={{
-                    marginTop: "1rem",
-                    padding: "1rem",
-                    border: "1px dashed rgba(63,63,70,0.6)",
-                    borderRadius: "0.5rem",
-                    textAlign: "center",
-                    color: "rgba(255,255,255,0.6)",
-                  }}
-                >
-                  Select a tool to execute
-                </div>
-              )}
-              {mode === "chat" && (!selectedServer || selectedServer.status !== "connected") && (
-                <div
-                  style={{
-                    marginTop: "1rem",
-                    padding: "1rem",
-                    border: "1px dashed rgba(63,63,70,0.6)",
-                    borderRadius: "0.5rem",
-                    textAlign: "center",
-                    color: "rgba(255,255,255,0.6)",
-                  }}
-                >
-                  {!selectedServer
-                    ? "Select a connected server to chat"
-                    : "Server is not connected. Please reconnect to chat."}
-                </div>
-              )}
-            </div>
+              </div>
             </Panel>
+
           </PanelGroup>
         </div>
       </div>
 
+      {/* ── ADD SERVER MODAL ─────────────────────────────────────────────── */}
       {showAddModal && (
         <div
           style={{
-            position: "fixed",
-            inset: 0,
-            background: "rgba(0,0,0,0.6)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            zIndex: 1000,
+            position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)",
+            display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000,
           }}
         >
           <div
             style={{
-              background: "#18181b",
-              padding: "2rem",
-              borderRadius: "0.75rem",
-              width: "420px",
-              border: "1px solid rgba(63,63,70,0.6)",
+              background: "#18181b", padding: "2rem", borderRadius: "0.75rem",
+              width: "420px", border: "1px solid rgba(63,63,70,0.6)",
             }}
           >
-            <h2 style={{ fontSize: "1.3rem", marginBottom: "1rem" }}>
-              Connect MCP Server
-            </h2>
+            <h2 style={{ fontSize: "1.3rem", marginBottom: "1rem" }}>Connect MCP Server</h2>
 
             <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
               <input
                 placeholder="Server URL"
                 style={{
-                  padding: "0.6rem",
-                  borderRadius: "0.4rem",
+                  padding: "0.6rem", borderRadius: "0.4rem",
                   border: "1px solid rgba(63,63,70,0.6)",
-                  background: "#09090b",
-                  color: "#fff",
+                  background: "#09090b", color: "#fff",
                 }}
                 value={url}
                 onChange={(e) => setUrl(e.target.value)}
@@ -1006,11 +1032,9 @@ export default function MCPInspector() {
                 value={transport}
                 onChange={(e) => setTransport(e.target.value)}
                 style={{
-                  padding: "0.6rem",
-                  borderRadius: "0.4rem",
+                  padding: "0.6rem", borderRadius: "0.4rem",
                   border: "1px solid rgba(63,63,70,0.6)",
-                  background: "#09090b",
-                  color: "#fff",
+                  background: "#09090b", color: "#fff",
                 }}
               >
                 <option value="http">HTTP</option>
@@ -1021,11 +1045,8 @@ export default function MCPInspector() {
                 <button
                   onClick={() => setShowAddModal(false)}
                   style={{
-                    background: "transparent",
-                    border: "1px solid rgba(63,63,70,0.6)",
-                    padding: "0.5rem 1rem",
-                    borderRadius: "0.4rem",
-                    color: "#fff",
+                    background: "transparent", border: "1px solid rgba(63,63,70,0.6)",
+                    padding: "0.5rem 1rem", borderRadius: "0.4rem", color: "#fff",
                   }}
                 >
                   Cancel
@@ -1035,11 +1056,8 @@ export default function MCPInspector() {
                   onClick={handleConnect}
                   disabled={connecting}
                   style={{
-                    background: "#fff",
-                    color: "#000",
-                    padding: "0.5rem 1rem",
-                    borderRadius: "0.4rem",
-                    fontWeight: "600",
+                    background: "#fff", color: "#000",
+                    padding: "0.5rem 1rem", borderRadius: "0.4rem", fontWeight: "600",
                   }}
                 >
                   {connecting ? "Connecting..." : "Connect"}
@@ -1048,7 +1066,8 @@ export default function MCPInspector() {
             </div>
           </div>
         </div>
-      )}          
+      )}
+
       <Footer />
     </div>
   );

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -72,12 +72,30 @@ export default function MCPInspector() {
   const chatRef = useRef<HTMLDivElement>(null);
 
   const handleConnect = async () => {
+
     if (!url) return;
 
-    // Prevent duplicate servers
     if (servers.some(s => s.url === url)) {
       alert("Server already added");
       return;
+    }
+
+    // ✅ Disconnect any currently connected server before adding a new one
+    const activeServer = servers.find(s => s.status === "connected" && s.session_id);
+    if (activeServer) {
+      try {
+        await apiClient.disconnectInspectorServer(activeServer.session_id!);
+        setServers(prev =>
+          prev.map(s =>
+            s.id === activeServer.id
+              ? { ...s, session_id: null, tools: [], status: "disconnected" as const, error: undefined }
+              : s
+          )
+        );
+      } catch (err) {
+        console.warn("Could not disconnect old server:", err);
+        // Non-fatal — continue connecting the new one
+      }
     }
 
     const serverId = generateServerId();
@@ -85,57 +103,44 @@ export default function MCPInspector() {
     try {
       setConnecting(true);
 
-      // Add optimistic "connecting" state
-      setServers((prev) => [
+      setServers(prev => [
         ...prev,
-        {
-          id: serverId,
-          session_id: null,
-          url,
-          transport,
-          tools: [],
-          status: 'connecting' as const,
-        },
+        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const },
       ]);
 
-      const res = await apiClient.connectInspectorServer({
-        url,
-        transport,
-      });
+      const res = await apiClient.connectInspectorServer({ url, transport });
 
-      // Update server with connected state and fetched data
-      setServers((prev) =>
-        prev.map((s) =>
+      setServers(prev =>
+        prev.map(s =>
           s.id === serverId
-            ? {
-                ...s,
-                session_id: res.session_id,
-                server_info: res.server_info,
-                tools: res.tools || [],
-                status: 'connected' as const,
-              }
+            ? { ...s, session_id: res.session_id, server_info: res.server_info, tools: res.tools || [], status: "connected" as const }
             : s
         )
       );
 
-      // Auto-select the newly connected server
       setSelectedServerId(serverId);
+      setSelectedTool(null);
+      setToolResult(null);
+      setToolError(null);
+
+      // ✅ Clear chat and show a welcome message for the new server
+      setChatHistory([{
+        id: crypto.randomUUID(),
+        type: "assistant",
+        content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+        timestamp: Date.now(),
+      }]);
 
       setShowAddModal(false);
       setUrl("");
       setTransport("http");
+
     } catch (err: any) {
       console.error("Failed to connect", err);
-
-      // Update server with failed state
-      setServers((prev) =>
-        prev.map((s) =>
+      setServers(prev =>
+        prev.map(s =>
           s.id === serverId
-            ? {
-                ...s,
-                status: 'failed' as const,
-                error: err?.message || 'Failed to connect to MCP server',
-              }
+            ? { ...s, status: "failed" as const, error: err?.message || "Failed to connect to MCP server" }
             : s
         )
       );
@@ -591,9 +596,22 @@ export default function MCPInspector() {
                             <div
                               key={server.id}
                               onClick={() => {
+                                if (selectedServerId === server.id) return;
+
                                 setSelectedServerId(server.id);
                                 setSelectedTool(null);
                                 setToolResult(null);
+                                setToolError(null);
+                                // Reset chat
+                                setChatHistory([
+                                  {
+                                    id: crypto.randomUUID(),
+                                    type: "assistant",
+                                    content: `Switched to ${server?.server_info?.name || "server"}. Chat cleared.`,
+                                    timestamp: Date.now()
+                                  }
+                                ]);
+                                
                               }}
                               style={{
                                 marginTop: "0.75rem",
@@ -1007,61 +1025,122 @@ export default function MCPInspector() {
                               flex: 1,
                               minHeight: 0,        
                               overflowY: "auto",
-                              overflowX: "hidden",
                               marginBottom: "1rem",
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
-                              paddingRight: "4px"
+                              padding: "0.5rem 0.5rem 0.5rem 0.25rem"
                             }}
                           >
                             {chatHistory.map((msg) => {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px", maxWidth: "75%", wordBreak: "break-word" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
+                                    <div style={{
+                                      background: "#2563eb",
+                                      color: "#fff",
+                                      padding: "0.6rem 0.75rem",
+                                      borderRadius: "12px 12px 4px 12px",
+                                      maxWidth: "70%",
+                                      fontSize: "0.9rem",
+                                      lineHeight: 1.4
+                                    }}>
+                                      {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "thinking") {
                                 return (
-                                  <div key={msg.id} style={{ opacity: 0.6 }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      fontSize: "0.8rem",
+                                      opacity: 0.7,
+                                      fontStyle: "italic",
+                                      padding: "0.3rem 0.5rem"
+                                    }}>
+                                      🤖 {msg.content}...
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "tool_call") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(59,130,246,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    <strong>Calling tool:</strong> {msg.toolName}
-                                    <pre>{JSON.stringify(msg.params, null, 2)}</pre>
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(59,130,246,0.12)",
+                                      border: "1px solid rgba(59,130,246,0.35)",
+                                      borderRadius: "8px",
+                                      padding: "0.6rem",
+                                      maxWidth: "80%",
+                                      fontSize: "0.8rem"
+                                    }}>
+                                      <div style={{ fontWeight: 600, marginBottom: "0.3rem" }}>
+                                        🔧 Tool: {msg.toolName}
+                                      </div>
+
+                                      <div style={{
+                                        fontFamily: "monospace",
+                                        fontSize: "0.75rem",
+                                        background: "rgba(0,0,0,0.3)",
+                                        padding: "0.4rem",
+                                        borderRadius: "6px",
+                                        overflowX: "auto"
+                                      }}>
+                                        {JSON.stringify(msg.params, null, 2)}
+                                      </div>
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "tool_result") {
                                 return (
-                                  <div key={msg.id} style={{ maxWidth: "100%", overflowX: "auto" }}>
-                                    <ToolResult result={msg.result} />
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      borderLeft: "3px solid #22c55e",
+                                      paddingLeft: "0.5rem",
+                                      maxWidth: "85%"
+                                    }}>
+                                      <ToolResult result={msg.result} />
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(99,102,241,0.2)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(99,102,241,0.15)",
+                                      border: "1px solid rgba(99,102,241,0.3)",
+                                      padding: "0.6rem 0.75rem",
+                                      borderRadius: "12px 12px 12px 4px",
+                                      maxWidth: "70%",
+                                      fontSize: "0.9rem"
+                                    }}>
+                                      {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
 
                               if (msg.type === "error") {
                                 return (
-                                  <div key={msg.id} style={{ background: "rgba(239,68,68,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
-                                    {msg.content}
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <div style={{
+                                      background: "rgba(239,68,68,0.15)",
+                                      border: "1px solid rgba(239,68,68,0.4)",
+                                      padding: "0.6rem",
+                                      borderRadius: "8px",
+                                      color: "#fca5a5",
+                                      maxWidth: "70%"
+                                    }}>
+                                      ❌ {msg.content}
+                                    </div>
                                   </div>
                                 )
                               }
@@ -1074,24 +1153,34 @@ export default function MCPInspector() {
                           <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
                             <input
                               value={chatInput}
+                              disabled={chatLoading}
                               onChange={(e) => setChatInput(e.target.value)}
                               placeholder="Ask something..."
-                              onKeyDown={(e) => { if (e.key === "Enter") runChatTool(); }}
+                              onKeyDown={(e) => { 
+                                if (e.key === "Enter" && !e.shiftKey && chatInput.trim()) {
+                                  e.preventDefault(); 
+                                  runChatTool();
+                                } 
+                              }}
                               style={{
                                 flex: 1, minWidth: 0, padding: "0.5rem",
                                 borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
-                                background: "#09090b", color: "#fff",
+                                background: "#09090b", color: "#fff", opacity: chatLoading ? 0.6 : 1,
                               }}
                             />
                             <button
-                              onClick={runChatTool}
-                              disabled={chatLoading}
+                              onClick={()=>{
+                                if (chatInput.trim()) runChatTool();
+                              }}
+                              disabled={chatLoading || !chatInput.trim()}
                               style={{
                                 padding: "0.5rem 0.75rem", borderRadius: "0.35rem",
                                 background: "#fff", color: "#000", fontWeight: "600", flexShrink: 0,
+                                opacity: chatLoading || !chatInput.trim() ? 0.6 : 1,
+                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer"
                               }}
                             >
-                              {chatLoading ? "..." : "Send"}
+                              {chatLoading ? "Thinking..." : "Send"}
                             </button>
                           </div>
                         </>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -17,6 +17,12 @@ interface MCPServer {
   transport: string;
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
   error?: string;
+  auth?: {
+    type: "none" | "bearer" | "header"
+    token?: string
+    headerKey?: string
+    headerValue?: string
+  };
 }
 
 // Type for log entry
@@ -39,6 +45,12 @@ type ChatMessage = {
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
 export default function MCPInspector() {
+
+  const [authType, setAuthType] = useState<"none" | "bearer" | "header">("none")
+
+  const [token, setToken] = useState("")
+  const [headerKey, setHeaderKey] = useState("")
+  const [headerValue, setHeaderValue] = useState("")
 
   const [showAddModal, setShowAddModal] = useState(false);
   const [url, setUrl] = useState("");
@@ -74,13 +86,21 @@ export default function MCPInspector() {
   const handleConnect = async () => {
 
     if (!url) return;
+    if (authType === "bearer" && !token) {
+      alert("Please enter bearer token")
+      return
+    }
 
-    if (servers.some(s => s.url === url)) {
+    if (authType === "header" && (!headerKey || !headerValue)) {
+      alert("Please enter header key and value")
+      return
+    }
+    if (servers.some(s => s.url === url && s.status !== "failed")) {
       alert("Server already added");
       return;
     }
 
-    // ✅ Disconnect any currently connected server before adding a new one
+    // Disconnect any currently connected server before adding a new one
     const activeServer = servers.find(s => s.status === "connected" && s.session_id);
     if (activeServer) {
       try {
@@ -100,16 +120,37 @@ export default function MCPInspector() {
 
     const serverId = generateServerId();
 
+    const authConfig = {
+      type: authType,
+      token: token,
+      headerKey: headerKey,
+      headerValue: headerValue
+    };
+
     try {
       setConnecting(true);
 
       setServers(prev => [
-        ...prev,
-        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const },
+        ...prev.filter(s => !(s.url === url && s.status === "failed")),
+        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const, auth : authConfig
+        },
       ]);
 
-      const res = await apiClient.connectInspectorServer({ url, transport });
+      const payload: any = { url, transport }
 
+      // Bearer Token
+      if (authType === "bearer" && token) {
+        payload.auth = {type: "bearer", token: token }
+      }
+
+      // Header Token
+      if (authType === "header" && headerKey && headerValue) {
+        payload.headers = { [headerKey]: headerValue }
+      }
+
+      const res = await apiClient.connectInspectorServer(payload)
+
+      // Update server after connect
       setServers(prev =>
         prev.map(s =>
           s.id === serverId
@@ -123,7 +164,7 @@ export default function MCPInspector() {
       setToolResult(null);
       setToolError(null);
 
-      // ✅ Clear chat and show a welcome message for the new server
+      // Clear chat and show a welcome message for the new server
       setChatHistory([{
         id: crypto.randomUUID(),
         type: "assistant",
@@ -131,6 +172,10 @@ export default function MCPInspector() {
         timestamp: Date.now(),
       }]);
 
+      setAuthType("none")
+      setToken("")
+      setHeaderKey("")
+      setHeaderValue("")
       setShowAddModal(false);
       setUrl("");
       setTransport("http");
@@ -196,12 +241,33 @@ export default function MCPInspector() {
             : s
         )
       );
-
-      const res = await apiClient.connectInspectorServer({
+      // Build payload with auth
+      const payload: any = {
         url: server.url,
         transport: server.transport,
-      });
+      };
 
+      // Bearer
+      if (server.auth?.type === "bearer" && server.auth.token) {
+        payload.auth = {
+          type: "bearer",
+          token: server.auth.token,
+        };
+      }
+
+      // Header
+      if (
+        server.auth?.type === "header" &&
+        server.auth.headerKey &&
+        server.auth.headerValue
+      ) {
+        payload.headers = {
+          [server.auth.headerKey]: server.auth.headerValue,
+        };
+      }
+      
+      const res = await apiClient.connectInspectorServer(payload);
+      console.log("Reconnect auth:", server.auth)
       // Update with connected state and new session
       setServers((prev) =>
         prev.map((s) =>
@@ -450,6 +516,12 @@ export default function MCPInspector() {
     tool_error: "#ef4444",
     chat: "#6366f1",
   };
+
+  useEffect(() => {
+    setToken("")
+    setHeaderKey("")
+    setHeaderValue("")
+  }, [authType])
 
   return (
     <div
@@ -1261,6 +1333,95 @@ export default function MCPInspector() {
                 <option value="sse">SSE</option>
               </select>
 
+              {/* Auth Type */}
+              <div style={{ marginTop: "1rem" }}>
+                <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                  Auth Type
+                </label>
+
+                <select
+                  value={authType}
+                  onChange={(e) => setAuthType(e.target.value as any)}
+                  style={{
+                    width: "100%",
+                    marginTop: "0.3rem",
+                    padding: "0.5rem",
+                    borderRadius: "0.4rem",
+                    background: "#18181b",
+                    color: "#fff",
+                    border: "1px solid rgba(63,63,70,0.6)"
+                  }}
+                >
+                  <option value="none">None</option>
+                  <option value="bearer">Bearer Token</option>
+                  <option value="header">Header Token</option>
+                </select>
+              </div>
+
+              {authType === "bearer" && (
+                <div style={{ marginTop: "0.8rem" }}>
+                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                    Token
+                  </label>
+                  <input
+                    type="password"
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder="Enter bearer token"
+                    style={{
+                      width: "100%",
+                      marginTop: "0.3rem",
+                      padding: "0.5rem",
+                      borderRadius: "0.4rem",
+                      background: "#18181b",
+                      color: "#fff",
+                      border: "1px solid rgba(63,63,70,0.6)"
+                    }}
+                  />
+                </div>
+              )}
+
+              {authType === "header" && (
+                <div style={{ marginTop: "0.8rem" }}>
+                  
+                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                    Header Key
+                  </label>
+                  <input
+                    value={headerKey}
+                    onChange={(e) => setHeaderKey(e.target.value)}
+                    placeholder="X-Api-Key"
+                    style={{
+                      width: "100%",
+                      marginTop: "0.3rem",
+                      padding: "0.5rem",
+                      borderRadius: "0.4rem",
+                      background: "#18181b",
+                      color: "#fff",
+                      border: "1px solid rgba(63,63,70,0.6)"
+                    }}
+                  />
+
+                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)", marginTop: "0.5rem", display: "block" }}>
+                    Header Value
+                  </label>
+                  <input
+                    type="password"
+                    value={headerValue}
+                    onChange={(e) => setHeaderValue(e.target.value)}
+                    placeholder="Enter token"
+                    style={{
+                      width: "100%",
+                      marginTop: "0.3rem",
+                      padding: "0.5rem",
+                      borderRadius: "0.4rem",
+                      background: "#18181b",
+                      color: "#fff",
+                      border: "1px solid rgba(63,63,70,0.6)"
+                    }}
+                  />
+                </div>
+              )}
               <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
                 <button
                   onClick={() => setShowAddModal(false)}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -150,7 +150,7 @@ export default function MCPInspector() {
 
       const res = await apiClient.connectInspectorServer(payload)
 
-      // Update server after connect
+
       setServers(prev =>
         prev.map(s =>
           s.id === serverId
@@ -267,7 +267,6 @@ export default function MCPInspector() {
       }
       
       const res = await apiClient.connectInspectorServer(payload);
-      console.log("Reconnect auth:", server.auth)
       // Update with connected state and new session
       setServers((prev) =>
         prev.map((s) =>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -113,7 +113,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
 }
 
 // ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
-function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
+function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; run?: ExecutionRun; sessionId?: string }) {
   const [collapsed, setCollapsed] = useState(false);
   const thinking  = steps.find(s => s.type === "thinking");
   const toolCall  = steps.find(s => s.type === "tool_call");
@@ -206,6 +206,14 @@ function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: Executi
                 <div style={{ marginTop: "0.2rem" }}>
                   <ChatResultBubble result={toolResult.result} />
                 </div>
+                {toolResult.resourceUri && sessionId && toolCall && (
+                  <WidgetSandbox
+                    sessionId={sessionId}
+                    resourceUri={toolResult.resourceUri}
+                    toolInput={toolCall.params || {}}
+                    toolResult={toolResult.result}
+                  />
+                )}
               </div>
             </div>
           )}
@@ -235,7 +243,8 @@ import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
 import { JsonResultView } from '../components/result/JsonResultView';
 import { McpContentView } from '../components/result/McpContentView';
-import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
+import { WidgetSandbox } from '../components/WidgetSandbox';
+import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels';
 
 // Type for server object
 interface MCPServer {
@@ -270,6 +279,7 @@ type ChatMessage = {
   toolName?: string
   params?: any
   result?: any
+  resourceUri?: string // set on tool_result when tool has _meta["ui/resourceUri"]
   timestamp: number
   perfMark?: number    // high-res mark for duration math (performance.now())
 }
@@ -730,11 +740,22 @@ export default function MCPInspector() {
       res.params
     )
 
+    // Check for UI widget resource — can be on the tool definition (tools/list)
+    // or on the result itself (FastMCP puts _meta on the result, not the tool def)
+    const toolDef = selectedServer.tools.find((t: any) => t.name === res.tool_name)
+    const resourceUri: string | undefined =
+      toolDef?._meta?.["ui/resourceUri"] ||
+      toolDef?._meta?.ui?.resourceUri ||
+      result?.result?._meta?.["ui/resourceUri"] ||
+      result?.result?._meta?.ui?.resourceUri ||
+      undefined
+
     const resultMsg: ChatMessage = {
       id: generateId(),
       runId,
       type: "tool_result",
       result,
+      resourceUri,
       timestamp: Date.now(),
       perfMark: performance.now()
     }
@@ -1381,7 +1402,7 @@ export default function MCPInspector() {
                               if (group.kind === "run") {
                                 return (
                                   <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} sessionId={selectedServer?.session_id ?? undefined} />
                                   </div>
                                 );
                               }

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -96,12 +96,22 @@ interface LogEntry {
 
 type ChatMessage = {
   id: string
+  runId?: string       // groups thinking + tool_call + tool_result for one agent turn
   type: "user" | "thinking" | "tool_call" | "tool_result" | "assistant" | "error"
   content?: string
   toolName?: string
   params?: any
   result?: any
   timestamp: number
+  perfMark?: number    // high-res mark for duration math (performance.now())
+}
+
+type ExecutionRun = {
+  runId: string
+  serverId: string
+  startTime: number    // Date.now() — wall time
+  endTime?: number     // set on completion or error
+  steps: ChatMessage[] // thinking + tool_call + tool_result in order
 }
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
@@ -129,7 +139,9 @@ export default function MCPInspector() {
   const [toolError, setToolError] = useState<string | null>(null)
   const [executing, setExecuting] = useState(false)
   const [executionTime, setExecutionTime] = useState<number | null>(null)
-  const [executionHistory, setExecutionHistory] = useState<any[]>([])
+  // 3A-4: typed per-server execution history
+  const [executionHistoryByServer, setExecutionHistoryByServer] = useState<Record<string, ExecutionRun[]>>({})
+  const executionHistory = executionHistoryByServer[selectedServerId ?? ""] ?? []
 
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
@@ -399,6 +411,7 @@ export default function MCPInspector() {
     // Clean up per-server state
     setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setExecutionHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
@@ -421,16 +434,20 @@ export default function MCPInspector() {
 
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
-      setExecutionHistory((prev) => [
-        {
-          id: Date.now(),
-          tool: selectedTool,
-          params,
-          result: res,
-          time: new Date().toLocaleTimeString(),
-        },
-        ...prev,
-      ]);
+      if (selectedServerId) {
+        const runId = crypto.randomUUID();
+        const run: ExecutionRun = {
+          runId,
+          serverId: selectedServerId,
+          startTime: Date.now() - Math.round(end - start),
+          endTime: Date.now(),
+          steps: [
+            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+          ]
+        };
+        setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
+      }
     } catch (err: any) {
       console.error(err);
       setToolError(err?.message || "Tool execution failed");
@@ -447,7 +464,7 @@ export default function MCPInspector() {
 
  const runChatTool = async () => {
   // Guard against concurrent requests
-  if (!chatInput || !selectedServer?.session_id || chatLoading) return
+  if (!chatInput || !selectedServer?.session_id || chatLoading || !selectedServerId) return
 
   const message = chatInput
   setChatInput("")
@@ -456,7 +473,8 @@ export default function MCPInspector() {
     id: generateId(),
     type: "user",
     content: message,
-    timestamp: Date.now()
+    timestamp: Date.now(),
+    perfMark: performance.now()
   }
 
   // Capture history with userMsg before any state updates — used below to
@@ -465,20 +483,27 @@ export default function MCPInspector() {
 
   setChatHistory(prev => [...prev, userMsg])
 
+  // 3A-4: start an ExecutionRun for this agent turn
+  const runId = crypto.randomUUID()
+  const runStartTime = Date.now()
+  const runSteps: ChatMessage[] = []
+  const capturedServerId = selectedServerId
+
   try {
     setChatLoading(true)
 
-    // Show thinking
     const thinkingMsg: ChatMessage = {
       id: generateId(),
+      runId,
       type: "thinking",
       content: "Deciding which tool to use...",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, thinkingMsg])
+    runSteps.push(thinkingMsg)
 
-    // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
@@ -490,33 +515,39 @@ export default function MCPInspector() {
       }
     )
 
-    // Remove thinking message
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
         id: generateId(),
+        runId,
         type: "assistant",
         content: res.message,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        perfMark: performance.now()
       }
-
       updateChat(prev => [...prev, assistantMsg])
+      // save run (no tool call — just clarification)
+      setExecutionHistoryByServer(prev => ({
+        ...prev,
+        [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+      }))
       return
     }
 
-    // Tool call message
     const toolCallMsg: ChatMessage = {
       id: generateId(),
+      runId,
       type: "tool_call",
       toolName: res.tool_name,
       params: res.params,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, toolCallMsg])
+    runSteps.push(toolCallMsg)
 
-    // Execute tool
     const result = await apiClient.runInspectorTool(
       selectedServer.session_id,
       res.tool_name,
@@ -525,23 +556,41 @@ export default function MCPInspector() {
 
     const resultMsg: ChatMessage = {
       id: generateId(),
+      runId,
       type: "tool_result",
       result,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, resultMsg])
+    runSteps.push(resultMsg)
+
+    // save completed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
 
   } catch (err: any) {
 
     const errorMsg: ChatMessage = {
       id: generateId(),
+      runId,
       type: "error",
       content: err?.message || "Chat error",
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      perfMark: performance.now()
     }
 
     updateChat(prev => [...prev, errorMsg])
+    runSteps.push(errorMsg)
+
+    // save failed run
+    setExecutionHistoryByServer(prev => ({
+      ...prev,
+      [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
+    }))
   } finally {
     setChatLoading(false)
   }
@@ -911,7 +960,7 @@ export default function MCPInspector() {
                       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
                         <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
                         <button
-                          onClick={() => setExecutionHistory([])}
+                          onClick={() => selectedServerId && setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
                           style={{
                             fontSize: "0.7rem", padding: "0.2rem 0.5rem",
                             borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
@@ -928,26 +977,34 @@ export default function MCPInspector() {
                           maxHeight: "160px", overflowY: "auto",
                         }}
                       >
-                        {executionHistory.map((item) => (
-                          <div
-                            key={item.id}
-                            onClick={() => {
-                              setToolResult(item.result);
-                              setSelectedTool(item.tool);
-                              setToolError(null);
-                            }}
-                            style={{
-                              padding: "0.4rem 0.5rem",
-                              borderRadius: "0.35rem",
-                              border: "1px solid rgba(63,63,70,0.6)",
-                              cursor: "pointer",
-                              background: "rgba(255,255,255,0.04)",
-                            }}
-                          >
-                            <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{item.tool.name}</div>
-                            <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>{item.time}</div>
-                          </div>
-                        ))}
+                        {executionHistory.map((item: ExecutionRun) => {
+                          const toolCall = item.steps.find(s => s.type === "tool_call");
+                          const toolResult = item.steps.find(s => s.type === "tool_result");
+                          const duration = item.endTime ? item.endTime - item.startTime : null;
+                          return (
+                            <div
+                              key={item.runId}
+                              onClick={() => {
+                                if (toolResult) setToolResult(toolResult.result);
+                                if (toolCall?.toolName) setSelectedTool(selectedServer?.tools.find((t: any) => t.name === toolCall.toolName) || null);
+                                setToolError(null);
+                              }}
+                              style={{
+                                padding: "0.4rem 0.5rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                cursor: "pointer",
+                                background: "rgba(255,255,255,0.04)",
+                              }}
+                            >
+                              <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{toolCall?.toolName || "run"}</div>
+                              <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+                                {new Date(item.startTime).toLocaleTimeString()}
+                                {duration !== null && <span style={{ marginLeft: "0.4rem", color: "rgba(99,102,241,0.8)" }}>{duration}ms</span>}
+                              </div>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -26,8 +26,17 @@ interface LogEntry {
   message: string;
 }
 
+type ChatMessage = {
+  id: string
+  type: "user" | "thinking" | "tool_call" | "tool_result" | "assistant" | "error"
+  content?: string
+  toolName?: string
+  params?: any
+  result?: any
+  timestamp: number
+}
 // Helper to generate unique server IDs
-const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
 export default function MCPInspector() {
 
@@ -51,7 +60,8 @@ export default function MCPInspector() {
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
   const [chatInput, setChatInput] = useState("")
-  const [chatHistory, setChatHistory] = useState<any[]>([])
+  // const [chatHistory, setChatHistory] = useState<any[]>([])
+  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
     left: 25,     // percentage (right auto-calculated as 100-left)
@@ -264,41 +274,113 @@ export default function MCPInspector() {
     }
   };
 
-  const runChatTool = async () => {
-    if (!chatInput || !selectedServer?.session_id) return;
+  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
+  const generateId = () =>
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
-    try {
-      setChatLoading(true);
+ const runChatTool = async () => {
+  // Guard against concurrent requests
+  if (!chatInput || !selectedServer?.session_id || chatLoading) return
 
-      const message = chatInput;
+  const message = chatInput
+  setChatInput("")
 
-      setChatHistory((prev) => [...prev, { role: "user", content: message }]);
+  const userMsg: ChatMessage = {
+    id: generateId(),
+    type: "user",
+    content: message,
+    timestamp: Date.now()
+  }
 
-      const tool = selectedTool || selectedServer.tools?.[0];
+  // Capture history with userMsg before any state updates — used below to
+  // send an accurate chat_history to the backend (avoids stale closure).
+  const nextHistory = [...chatHistory, userMsg]
 
-      if (!tool) throw new Error("No tools available");
+  setChatHistory(prev => [...prev, userMsg])
 
-      const res = await apiClient.runInspectorTool(
-        selectedServer.session_id,
-        tool.name,
-        { location: message }
-      );
+  try {
+    setChatLoading(true)
 
-      setChatHistory((prev) => [
-        ...prev,
-        { role: "assistant", content: JSON.stringify(res, null, 2) },
-      ]);
-
-      setChatInput("");
-    } catch (err: any) {
-      setChatHistory((prev) => [
-        ...prev,
-        { role: "assistant", content: "Error running tool" },
-      ]);
-    } finally {
-      setChatLoading(false);
+    // Show thinking
+    const thinkingMsg: ChatMessage = {
+      id: generateId(),
+      type: "thinking",
+      content: "Deciding which tool to use...",
+      timestamp: Date.now()
     }
-  };
+
+    setChatHistory(prev => [...prev, thinkingMsg])
+
+    // Call backend chat endpoint
+    const res = await apiClient.chatWithInspector(
+      selectedServer.session_id,
+      {
+        message,
+        chat_history: nextHistory.slice(-8).map(m => ({
+          type: m.type,
+          content: m.content
+        }))
+      }
+    )
+
+    // Remove thinking message
+    setChatHistory(prev => prev.filter(m => m.id !== thinkingMsg.id))
+
+    if (res.clarification_needed) {
+      const assistantMsg: ChatMessage = {
+        id: generateId(),
+        type: "assistant",
+        content: res.message,
+        timestamp: Date.now()
+      }
+
+      setChatHistory(prev => [...prev, assistantMsg])
+      return
+    }
+
+    // Tool call message
+    const toolCallMsg: ChatMessage = {
+      id: generateId(),
+      type: "tool_call",
+      toolName: res.tool_name,
+      params: res.params,
+      timestamp: Date.now()
+    }
+
+    setChatHistory(prev => [...prev, toolCallMsg])
+
+    // Execute tool
+    const result = await apiClient.runInspectorTool(
+      selectedServer.session_id,
+      res.tool_name,
+      res.params
+    )
+
+    const resultMsg: ChatMessage = {
+      id: generateId(),
+      type: "tool_result",
+      result,
+      timestamp: Date.now()
+    }
+
+    setChatHistory(prev => [...prev, resultMsg])
+
+  } catch (err: any) {
+
+    const errorMsg: ChatMessage = {
+      id: generateId(),
+      type: "error",
+      content: err?.message || "Chat error",
+      timestamp: Date.now()
+    }
+
+    setChatHistory(prev => [...prev, errorMsg])
+  } finally {
+    setChatLoading(false)
+  }
+}
 
   useEffect(() => {
     setToolResult(null)
@@ -311,9 +393,9 @@ export default function MCPInspector() {
     if (saved) setPanelSizes(JSON.parse(saved))
   }, [])
 
-  // Auto-scroll logs to top when new entries arrive (logs rendered newest-first)
+  // Auto-scroll logs to bottom when new entries arrive
   useEffect(() => {
-    logsRef.current?.scrollTo({ top: 0 });
+    logsRef.current?.scrollTo({ top: logsRef.current.scrollHeight });
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
@@ -323,26 +405,34 @@ export default function MCPInspector() {
     }
   }, [chatHistory]);
 
-  // Poll for logs every 2 seconds when a session is active.
-  // Inlined to avoid stale-closure issues with fetchLogs in the dependency array.
+  // Fetch logs from the server
+  const fetchLogs = async () => {
+    if (!selectedServer?.session_id) return;
+    try {
+      const res = await apiClient.getInspectorLogs(selectedServer.session_id);
+      setLogs(res.logs || []);
+    } catch (err) {
+      console.error("Failed to fetch logs", err);
+    }
+  };
+
+  // Poll for logs every 2 seconds when a session is active
   useEffect(() => {
     if (!selectedServer?.session_id) {
-      setLogs([]);   // clear stale logs when no session is active
       return;
     }
-    const sessionId = selectedServer.session_id;
+    // NOTE FOR REVIEW: When a new server connects, its logs replace the previous server's logs.
+    // Decision needed: Should we accumulate logs across all servers (keyed by session_id)?
+    // Or is replacing on new connection acceptable?
+    // Options:
+    //   A) Current behaviour — replace logs on new connection (simple, clean)
+    //   B) Accumulate all logs — merge new logs into existing, tag each entry with server name
+    //   C) Per-server log history — store logs[serverId] map, show logs for selected server
+    // Leaning towards C if inspector gets heavy usage, but A is fine for now.
+    fetchLogs();     // Fetch immediately
 
-    const poll = async () => {
-      try {
-        const res = await apiClient.getInspectorLogs(sessionId);
-        setLogs(res.logs || []);
-      } catch (err) {
-        console.error("Failed to fetch logs", err);
-      }
-    };
+    const interval = setInterval(fetchLogs, 2000);     // Set up polling interval
 
-    poll();
-    const interval = setInterval(poll, 2000);
     return () => clearInterval(interval);
   }, [selectedServer?.session_id]);
 
@@ -763,12 +853,11 @@ export default function MCPInspector() {
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log) => {
+                          {[...logs].reverse().map((log, i) => {
                             const color = logColors[log.type] || "#9ca3af";
-                            const logKey = `${log.timestamp}-${log.type}-${log.message}`;
                             return (
                               <div
-                                key={logKey}
+                                key={i}
                                 style={{
                                   display: "grid",
                                   // Fixed columns: time | type | message
@@ -922,21 +1011,59 @@ export default function MCPInspector() {
                               gap: "0.5rem",
                             }}
                           >
-                            {chatHistory.map((msg, i) => (
-                              <div
-                                key={`${msg.role}-${i}-${msg.content?.slice(0,20)}`}
-                                style={{
-                                  padding: "0.5rem",
-                                  borderRadius: "0.35rem",
-                                  background: msg.role === "user" ? "rgba(255,255,255,0.1)" : "rgba(99,102,241,0.2)",
-                                }}
-                              >
-                                <strong style={{ fontSize: "0.8rem" }}>{msg.role}</strong>
-                                <pre style={{ margin: 0, whiteSpace: "pre-wrap", wordBreak: "break-word", fontSize: "0.85rem" }}>
-                                  {msg.content}
-                                </pre>
-                              </div>
-                            ))}
+                            {chatHistory.map((msg) => {
+
+                              if (msg.type === "user") {
+                                return (
+                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px" }}>
+                                    {msg.content}
+                                  </div>
+                                )
+                              }
+
+                              if (msg.type === "thinking") {
+                                return (
+                                  <div key={msg.id} style={{ opacity: 0.6 }}>
+                                    {msg.content}
+                                  </div>
+                                )
+                              }
+
+                              if (msg.type === "tool_call") {
+                                return (
+                                  <div key={msg.id} style={{ background: "rgba(59,130,246,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
+                                    <strong>Calling tool:</strong> {msg.toolName}
+                                    <pre>{JSON.stringify(msg.params, null, 2)}</pre>
+                                  </div>
+                                )
+                              }
+
+                              if (msg.type === "tool_result") {
+                                return (
+                                  <div key={msg.id}>
+                                    <ToolResult result={msg.result} />
+                                  </div>
+                                )
+                              }
+
+                              if (msg.type === "assistant") {
+                                return (
+                                  <div key={msg.id} style={{ background: "rgba(99,102,241,0.2)", padding: "0.5rem", borderRadius: "6px" }}>
+                                    {msg.content}
+                                  </div>
+                                )
+                              }
+
+                              if (msg.type === "error") {
+                                return (
+                                  <div key={msg.id} style={{ background: "rgba(239,68,68,0.15)", padding: "0.5rem", borderRadius: "6px" }}>
+                                    {msg.content}
+                                  </div>
+                                )
+                              }
+
+                              return null
+                            })}
                           </div>
 
                           {/* Chat Input */}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -911,7 +911,7 @@ export default function MCPInspector() {
             <Panel 
               defaultSize={100 - panelSizes.left} 
               minSize={50}
-              style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+              style={{ overflow: "hidden", display: "flex", flexDirection: "column", minHeight: 0 }}
             >
               <div
                 style={{
@@ -924,6 +924,7 @@ export default function MCPInspector() {
                   display: "flex",
                   flexDirection: "column",
                   overflow: "hidden",
+                  minHeight: 0,
                 }}
               >
                 <h2 style={{ fontSize: "1.1rem", fontWeight: "600", flexShrink: 0 }}>
@@ -959,7 +960,7 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, overflow: "auto", marginTop: "1rem" }}>
+                <div style={{ flex: 1, overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
                     <div>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
@@ -996,7 +997,7 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "300px" }}>
+                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "0", overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
                           {/* Chat History */}
@@ -1004,18 +1005,21 @@ export default function MCPInspector() {
                             ref={chatRef}
                             style={{
                               flex: 1,
-                              overflow: "auto",
+                              minHeight: 0,        
+                              overflowY: "auto",
+                              overflowX: "hidden",
                               marginBottom: "1rem",
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
+                              paddingRight: "4px"
                             }}
                           >
                             {chatHistory.map((msg) => {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px" }}>
+                                  <div key={msg.id} style={{ alignSelf: "flex-end", background: "rgba(255,255,255,0.1)", padding: "0.5rem", borderRadius: "6px", maxWidth: "75%", wordBreak: "break-word" }}>
                                     {msg.content}
                                   </div>
                                 )
@@ -1040,7 +1044,7 @@ export default function MCPInspector() {
 
                               if (msg.type === "tool_result") {
                                 return (
-                                  <div key={msg.id}>
+                                  <div key={msg.id} style={{ maxWidth: "100%", overflowX: "auto" }}>
                                     <ToolResult result={msg.result} />
                                   </div>
                                 )

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,0 +1,1055 @@
+// import React from "react";
+import { useState, useEffect } from "react";
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { apiClient } from "@/services/api";
+import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
+import { ToolResult } from '../components/result/ToolResult';
+import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
+
+// Type for server object
+interface MCPServer {
+  id: string;
+  session_id: string | null;
+  server_info?: any;
+  tools: any[];
+  url: string;
+  transport: string;
+  status: 'connecting' | 'connected' | 'disconnected' | 'failed';
+  error?: string;
+}
+
+// Helper to generate unique server IDs
+const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+export default function MCPInspector() {
+
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [url, setUrl] = useState("");
+  const [transport, setTransport] = useState("http");
+  const [servers, setServers] = useState<MCPServer[]>([]);
+  const [connecting, setConnecting] = useState(false);
+  const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
+  
+  // Derived state: always fresh selectedServer from servers array
+  const selectedServer = servers.find(s => s.id === selectedServerId) || null;
+
+  const [selectedTool, setSelectedTool] = useState<any | null>(null)
+  const [toolResult, setToolResult] = useState<any | null>(null)
+  const [toolError, setToolError] = useState<string | null>(null)
+  const [executing, setExecuting] = useState(false)
+  const [executionTime, setExecutionTime] = useState<number | null>(null)
+  const [executionHistory, setExecutionHistory] = useState<any[]>([])
+
+  const [mode, setMode] = useState<"manual" | "chat">("manual")
+
+  const [chatInput, setChatInput] = useState("")
+  const [chatHistory, setChatHistory] = useState<any[]>([])
+  const [chatLoading, setChatLoading] = useState(false)
+  const [panelSizes, setPanelSizes] = useState({
+    left: 25,     // percentage (right auto-calculated as 100-left)
+    logs: 40      // percentage
+  })
+  const handleConnect = async () => {
+    if (!url) return;
+
+    // Prevent duplicate servers
+    if (servers.some(s => s.url === url)) {
+      alert("Server already added");
+      return;
+    }
+
+    const serverId = generateServerId();
+
+    try {
+      setConnecting(true);
+
+      // Add optimistic "connecting" state
+      setServers((prev) => [
+        ...prev,
+        {
+          id: serverId,
+          session_id: null,
+          url,
+          transport,
+          tools: [],
+          status: 'connecting' as const,
+        },
+      ]);
+
+      const res = await apiClient.connectInspectorServer({
+        url,
+        transport,
+      });
+
+      // Update server with connected state and fetched data
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                session_id: res.session_id,
+                server_info: res.server_info,
+                tools: res.tools || [],
+                status: 'connected' as const,
+              }
+            : s
+        )
+      );
+
+      // Auto-select the newly connected server
+      setSelectedServerId(serverId);
+
+      setShowAddModal(false);
+      setUrl("");
+      setTransport("http");
+    } catch (err: any) {
+      console.error("Failed to connect", err);
+
+      // Update server with failed state
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                status: 'failed' as const,
+                error: err?.message || 'Failed to connect to MCP server',
+              }
+            : s
+        )
+      );
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async (serverId: string) => {
+    const server = servers.find((s) => s.id === serverId);
+    if (!server?.session_id) return;
+
+    try {
+      await apiClient.disconnectInspectorServer(server.session_id);
+
+      // Update server to disconnected state (keep in list)
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                session_id: null,
+                tools: [],
+                status: 'disconnected' as const,
+                error: undefined,
+              }
+            : s
+        )
+      );
+
+      if (selectedServer?.id === serverId) {
+        setSelectedServerId(null);
+      }
+    } catch (err) {
+      console.error("Failed to disconnect", err);
+      alert("Failed to disconnect from MCP server");
+    }
+  };
+
+  const handleReconnect = async (serverId: string) => {
+    const server = servers.find((s) => s.id === serverId);
+    if (!server) return;
+    
+    // Prevent spamming reconnect button
+    if (server.status === 'connecting') return;
+
+    try {
+      // Set to connecting state
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? { ...s, status: 'connecting' as const, error: undefined }
+            : s
+        )
+      );
+
+      const res = await apiClient.connectInspectorServer({
+        url: server.url,
+        transport: server.transport,
+      });
+
+      // Update with connected state and new session
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                session_id: res.session_id,
+                server_info: res.server_info,
+                tools: res.tools || [],
+                status: 'connected' as const,
+              }
+            : s
+        )
+      );
+    } catch (err: any) {
+      console.error("Failed to reconnect", err);
+
+      // Update with failed state
+      setServers((prev) =>
+        prev.map((s) =>
+          s.id === serverId
+            ? {
+                ...s,
+                status: 'failed' as const,
+                error: err?.message || 'Failed to reconnect to MCP server',
+              }
+            : s
+        )
+      );
+    }
+  };
+
+  const handleRemove = (serverId: string) => {
+    setServers((prev) => prev.filter((s) => s.id !== serverId));
+
+    if (selectedServerId === serverId) {
+      setSelectedServerId(null);
+    }
+  };
+
+  const runTool = async (params: any) => {
+    if (!selectedServer?.session_id || !selectedTool || executing) return;
+
+    try {
+      setExecuting(true);
+      setToolError(null);
+
+      const start = performance.now();
+
+      const res = await apiClient.runInspectorTool(
+        selectedServer.session_id,
+        selectedTool.name,
+        params
+      );
+
+      const end = performance.now();
+
+      setToolResult(res);
+      setExecutionTime((end - start) / 1000);
+      setExecutionHistory((prev) => [
+        {
+          id: Date.now(),
+          tool: selectedTool,
+          params,
+          result: res,
+          time: new Date().toLocaleTimeString(),
+        },
+        ...prev,
+      ]);
+    } catch (err: any) {
+      console.error(err);
+      setToolError(err?.message || "Tool execution failed");
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  const runChatTool = async () => {
+    if (!chatInput || !selectedServer?.session_id) return;
+
+    try {
+      setChatLoading(true);
+
+      const message = chatInput;
+
+      setChatHistory((prev) => [...prev, { role: "user", content: message }]);
+
+      const tool = selectedTool || selectedServer.tools?.[0];
+
+      if (!tool) throw new Error("No tools available");
+
+      const res = await apiClient.runInspectorTool(
+        selectedServer.session_id,
+        tool.name,
+        { location: message }
+      );
+
+      setChatHistory((prev) => [
+        ...prev,
+        { role: "assistant", content: JSON.stringify(res, null, 2) },
+      ]);
+
+      setChatInput("");
+    } catch (err: any) {
+      setChatHistory((prev) => [
+        ...prev,
+        { role: "assistant", content: "Error running tool" },
+      ]);
+    } finally {
+      setChatLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    setToolResult(null)
+    setToolError(null)
+    setExecutionTime(null)
+  }, [selectedTool])
+
+  useEffect(() => {
+    const saved = sessionStorage.getItem('inspector-panel-sizes')
+    if (saved) setPanelSizes(JSON.parse(saved))
+  }, [])
+
+  return (
+    <div
+      className="dashboard"
+      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+    >
+      <Navbar />
+
+      <div style={{ paddingTop: "64px", flex: 1 }}>
+        <div
+          style={{
+            maxWidth: "1600px",
+            margin: "0 auto",
+            padding: "2rem",
+          }}
+        >
+          {/* Page Header */}
+          <div style={{ marginBottom: "2rem" }}>
+            <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>
+              MCP Inspector
+            </h1>
+            <p style={{ color: "rgba(255,255,255,0.6)", marginTop: "0.5rem" }}>
+              Connect to any MCP server and inspect its tools.
+            </p>
+          </div>
+
+          {/* Main Layout */}
+          <PanelGroup 
+            direction="horizontal" 
+            onLayout={(sizes) => {
+              setPanelSizes(prev => {
+                const updated = { ...prev, left: sizes[0] };
+                sessionStorage.setItem('inspector-panel-sizes', JSON.stringify(updated));
+                return updated;
+              });
+            }}
+            style={{ minHeight: "600px" }}
+          >
+            {/* LEFT PANEL (outer) */}
+            <Panel 
+              defaultSize={panelSizes.left} 
+              minSize={20} 
+              maxSize={50}
+              style={{ overflow: "hidden", display: "flex", flexDirection: "column" }}
+            >
+              {/* LEFT PANEL INNER: Vertical split between Servers+Tools and Logs */}
+              <PanelGroup 
+                direction="vertical" 
+                onLayout={(sizes) => {
+                  setPanelSizes(prev => {
+                    const updated = { ...prev, logs: sizes[1] };
+                    sessionStorage.setItem('inspector-panel-sizes', JSON.stringify(updated));
+                    return updated;
+                  });
+                }}
+                style={{ flex: 1 }}
+              >
+                {/* TOP: Servers + Tools Section */}
+                <Panel 
+                  defaultSize={100 - panelSizes.logs} 
+                  minSize={40}
+                  style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+                >
+            {/* LEFT PANEL */}
+            <div
+              style={{
+                border: "1px solid rgba(63,63,70,0.5)",
+                borderRadius: "0.75rem",
+                padding: "1.5rem",
+                background:
+                  "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                }}
+              >
+                <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>
+                  Servers
+                </h2>
+
+                <button
+                  style={{
+                    background: "#fff",
+                    color: "#000",
+                    border: "none",
+                    padding: "0.35rem 0.75rem",
+                    borderRadius: "0.375rem",
+                    fontSize: "0.8rem",
+                    fontWeight: "600",
+                    cursor: "pointer",
+                  }}
+                  onClick={() => setShowAddModal(true)}
+                >
+                  + Add
+                </button>
+              </div>
+              {/* Connected Servers List or Empty State */}
+              <div
+                style={{
+                  marginTop: "1rem",
+                  padding: "1rem",
+                  border: "1px dashed rgba(63,63,70,0.6)",
+                  borderRadius: "0.5rem",
+                  textAlign: "center",
+                  color: "rgba(255,255,255,0.6)",
+                }}
+              >
+                {servers.length === 0 ? (
+                  <div> No servers connected </div>
+                ) : (
+                  servers.map((server) => {
+                    // Determine badge color and text based on status
+                    const statusConfig = {
+                      connecting: {
+                        text: "Connecting...",
+                        bg: "rgba(59,130,246,0.2)",
+                        color: "#3b82f6",
+                      },
+                      connected: {
+                        text: "Connected",
+                        bg: "rgba(16,185,129,0.2)",
+                        color: "#10b981",
+                      },
+                      disconnected: {
+                        text: "Disconnected",
+                        bg: "rgba(107,114,128,0.2)",
+                        color: "#6b7280",
+                      },
+                      failed: {
+                        text: "Failed",
+                        bg: "rgba(239,68,68,0.2)",
+                        color: "#ef4444",
+                      },
+                    };
+
+                    const statusInfo = statusConfig[server.status];
+                    const isSelected = selectedServer?.id === server.id;
+
+                    return (
+                      <div
+                        key={server.id}
+                        onClick={() => {
+                          setSelectedServerId(server.id);
+                          setSelectedTool(null);
+                          setToolResult(null);
+                        }}
+                        style={{
+                          marginTop: "1rem",
+                          padding: "1rem",
+                          border: "1px solid rgba(63,63,70,0.6)",
+                          borderRadius: "0.6rem",
+                          cursor: "pointer",
+                          background: isSelected
+                            ? "rgba(255,255,255,0.08)"
+                            : "transparent",
+                        }}
+                      >
+                        {/* HEADER */}
+                        <div
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                          }}
+                        >
+                          <div style={{ fontWeight: "600" }}>
+                            {server?.server_info?.name || "MCP Server"}
+                          </div>
+
+                          <span
+                            style={{
+                              fontSize: "0.7rem",
+                              padding: "0.2rem 0.5rem",
+                              borderRadius: "0.3rem",
+                              background: statusInfo.bg,
+                              color: statusInfo.color,
+                            }}
+                          >
+                            {statusInfo.text}
+                          </span>
+                        </div>
+
+                        {/* URL */}
+                        <div
+                          style={{
+                            marginTop: "0.3rem",
+                            fontSize: "0.8rem",
+                            color: "rgba(255,255,255,0.6)",
+                            wordBreak: "break-all",
+                          }}
+                        >
+                          {server.url}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: "0.75rem",
+                            color: "rgba(255,255,255,0.5)",
+                          }}
+                        >
+                          transport: {server.transport}
+                        </div>
+
+                        {/* ERROR MESSAGE (for failed status) */}
+                        {server.status === "failed" && server.error && (
+                          <div
+                            style={{
+                              marginTop: "0.5rem",
+                              fontSize: "0.75rem",
+                              color: "#ef4444",
+                              padding: "0.5rem",
+                              background: "rgba(239,68,68,0.1)",
+                              borderRadius: "0.3rem",
+                              wordBreak: "break-word",
+                            }}
+                          >
+                            {server.error}
+                          </div>
+                        )}
+
+                        {/* ACTION BUTTONS */}
+                        <div
+                          style={{
+                            marginTop: "0.6rem",
+                            display: "flex",
+                            justifyContent: "flex-end",
+                            gap: "0.5rem",
+                          }}
+                        >
+                          {server.status === "connected" && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDisconnect(server.id);
+                              }}
+                              style={{
+                                fontSize: "0.75rem",
+                                padding: "0.25rem 0.6rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                background: "transparent",
+                                color: "#fff",
+                                cursor: "pointer",
+                              }}
+                            >
+                              Disconnect
+                            </button>
+                          )}
+
+                          {server.status === "disconnected" && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleReconnect(server.id);
+                              }}
+                              style={{
+                                fontSize: "0.75rem",
+                                padding: "0.25rem 0.6rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(107,114,128,0.6)",
+                                background: "rgba(107,114,128,0.1)",
+                                color: "#fff",
+                                cursor: "pointer",
+                              }}
+                            >
+                              Reconnect
+                            </button>
+                          )}
+
+                          {server.status === "failed" && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleReconnect(server.id);
+                              }}
+                              style={{
+                                fontSize: "0.75rem",
+                                padding: "0.25rem 0.6rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(239,68,68,0.6)",
+                                background: "rgba(239,68,68,0.1)",
+                                color: "#ef4444",
+                                cursor: "pointer",
+                              }}
+                            >
+                              Retry
+                            </button>
+                          )}
+
+                          {server.status !== "connecting" && (
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleRemove(server.id);
+                              }}
+                              style={{
+                                fontSize: "0.75rem",
+                                padding: "0.25rem 0.4rem",
+                                borderRadius: "0.35rem",
+                                border: "1px solid rgba(63,63,70,0.6)",
+                                background: "transparent",
+                                color: "rgba(255,255,255,0.6)",
+                                cursor: "pointer",
+                              }}
+                              title="Remove server"
+                            >
+                              ✕
+                            </button>
+                          )}
+                        </div>
+
+                        {/* TOOLS (only show when selected) */}
+                        {isSelected && server?.tools?.map((tool: any) => (
+                          <div
+                            key={tool.name}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setSelectedTool(tool);
+                              setToolResult(null);
+                              setToolError(null);
+                            }}
+                            style={{
+                              marginLeft: "0.8rem",
+                              marginTop: "0.4rem",
+                              fontSize: "0.85rem",
+                              cursor: "pointer",
+                              color:
+                                selectedTool?.name === tool.name
+                                  ? "#fff"
+                                  : "rgba(255,255,255,0.7)",
+                            }}
+                          >
+                            • {tool.name}
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+
+              {/* Execution History */}
+              <div style={{ marginTop: "1.5rem" }}>
+                <h3 style={{ marginBottom: "0.5rem" }}>Execution History</h3>
+
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "0.5rem",
+                    maxHeight: "200px",
+                    overflowY: "auto"
+                  }}
+                >
+                  {executionHistory.map((item) => (
+                    <div
+                      key={item.id}
+                      onClick={() => {
+                        setToolResult(item.result)
+                        setSelectedTool( item.tool )
+                        setToolError(null)
+                      }}
+                      style={{
+                        padding: "0.5rem",
+                        borderRadius: "0.35rem",
+                        border: "1px solid rgba(63,63,70,0.6)",
+                        cursor: "pointer",
+                        background: "rgba(255,255,255,0.05)"
+                      }}
+                    >
+                      <div style={{ fontWeight: 600 }}>{item.tool.name}</div>
+                      <div style={{ fontSize: "0.8rem", opacity: 0.7 }}>
+                        {item.time}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <button
+                onClick={() => setExecutionHistory([])}
+                style={{
+                  marginTop: "0.5rem",
+                  fontSize: "0.75rem",
+                  padding: "0.25rem 0.6rem",
+                  borderRadius: "0.35rem",
+                  border: "1px solid rgba(63,63,70,0.6)",
+                  background: "transparent",
+                  color: "#fff",
+                  cursor: "pointer",
+                }}
+              >
+                Clear
+              </button>
+            </div>
+
+                </Panel>
+
+                {/* Vertical Divider between Servers+Tools and Logs */}
+                <PanelResizeHandle
+                  style={{
+                    backgroundColor: "rgba(63,63,70,0.3)",
+                    height: "4px",
+                    cursor: "row-resize",
+                    transition: "background 0.15s ease",
+                  }}
+                  onMouseEnter={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.5)" }}
+                  onMouseLeave={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.3)" }}
+                />
+
+                {/* BOTTOM: Logs Section (Placeholder for Phase 3) */}
+                <Panel 
+                  defaultSize={panelSizes.logs} 
+                  minSize={15}
+                  style={{ overflow: "auto", overflowY: "auto", display: "flex", flexDirection: "column" }}
+                >
+                  <div
+                    style={{
+                      padding: "1rem",
+                      border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem",
+                      textAlign: "center",
+                      color: "rgba(255,255,255,0.5)",
+                      height: "100%",
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
+                    Logs section (coming next phase)
+                  </div>
+                </Panel>
+              </PanelGroup>
+            </Panel>
+
+            {/* Horizontal Divider between Left and Right Panels */}
+            <PanelResizeHandle
+              style={{
+                backgroundColor: "rgba(63,63,70,0.3)",
+                width: "4px",
+                cursor: "col-resize",
+                transition: "background 0.15s ease",
+              }}
+              onMouseEnter={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.5)" }}
+              onMouseLeave={(e: any) => { e.target.style.backgroundColor = "rgba(63,63,70,0.3)" }}
+            />
+
+            {/* RIGHT PANEL */}
+            <Panel 
+              defaultSize={100 - panelSizes.left} 
+              minSize={50}
+              style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+            >
+            <div
+              style={{
+                border: "1px solid rgba(63,63,70,0.5)",
+                borderRadius: "0.75rem",
+                padding: "1.5rem",
+                background:
+                  "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
+              }}
+            >
+              <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>
+                Tool Execution
+              </h2>
+              <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem" }}>
+                <button
+                  onClick={() => setMode("manual")}
+                  style={{
+                    padding: "0.35rem 0.75rem",
+                    borderRadius: "0.35rem",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    background: mode === "manual" ? "#fff" : "transparent",
+                    color: mode === "manual" ? "#000" : "#fff",
+                    cursor: "pointer"
+                  }}
+                >
+                  Manual
+                </button>
+
+                <button
+                  onClick={() => setMode("chat")}
+                  style={{
+                    padding: "0.35rem 0.75rem",
+                    borderRadius: "0.35rem",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    background: mode === "chat" ? "#fff" : "transparent",
+                    color: mode === "chat" ? "#000" : "#fff",
+                    cursor: "pointer"
+                  }}
+                >
+                  Chat
+                </button>
+              </div>
+              {mode === "manual" && selectedServer && selectedTool && (
+                <div style={{ marginTop: "1rem" }}>
+                  <h3 style={{ marginBottom: "1rem" }}>
+                    {selectedTool.name}
+                  </h3>
+
+                  {selectedServer.status === "connected" ? (
+                    <>
+                      <JsonSchemaForm
+                        schema={selectedTool.inputSchema}
+                        onSubmit={runTool}
+                        submitLabel="Run Tool"
+                        loading={executing}
+                      />
+
+                      {(toolResult || toolError) && (
+                        <div style={{ marginTop: "2rem" }}>
+                          <ToolResult
+                            result={toolResult}
+                            error={toolError || undefined}
+                            executionTime={executionTime}
+                          />
+                        </div>
+                      )}
+                    </>
+                  ) : (
+                    <div
+                      style={{
+                        padding: "1rem",
+                        border: "1px dashed rgba(239,68,68,0.6)",
+                        borderRadius: "0.5rem",
+                        textAlign: "center",
+                        color: "rgba(239,68,68,0.8)",
+                      }}
+                    >
+                      Server is not connected. Please reconnect to run tools.
+                    </div>
+                  )}
+                </div>
+              )}
+              {mode === "chat" && selectedServer && (
+                <div style={{ marginTop: "1rem", width: "100%" }}>
+                  {selectedServer.status === "connected" ? (
+                    <>
+                      {/* Chat History */}
+                      <div
+                        style={{
+                          maxHeight: "400px",
+                          overflow: "auto",
+                          marginBottom: "1rem",
+                          display: "flex",
+                          flexDirection: "column",
+                          gap: "0.5rem",
+                        }}
+                      >
+                        {chatHistory.map((msg, i) => (
+                          <div
+                            key={i}
+                            style={{
+                              padding: "0.5rem",
+                              borderRadius: "0.35rem",
+                              background:
+                                msg.role === "user"
+                                  ? "rgba(255,255,255,0.1)"
+                                  : "rgba(99,102,241,0.2)",
+                            }}
+                          >
+                            <strong>{msg.role}</strong>
+                            <pre
+                              style={{
+                                margin: 0,
+                                whiteSpace: "pre-wrap",
+                                wordBreak: "break-word",
+                              }}
+                            >
+                              {msg.content}
+                            </pre>
+                          </div>
+                        ))}
+                      </div>
+
+                      {/* Chat Input Row */}
+                      <div style={{ display: "flex", gap: "0.5rem" }}>
+                        <input
+                          value={chatInput}
+                          onChange={(e) => setChatInput(e.target.value)}
+                          placeholder="Ask something..."
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") runChatTool();
+                          }}
+                          style={{
+                            flex: 1,
+                            minWidth: 0,
+                            padding: "0.5rem",
+                            borderRadius: "0.35rem",
+                            border: "1px solid rgba(63,63,70,0.6)",
+                            background: "#09090b",
+                            color: "#fff",
+                          }}
+                        />
+
+                        <button
+                          onClick={runChatTool}
+                          disabled={chatLoading}
+                          style={{
+                            padding: "0.5rem 0.75rem",
+                            borderRadius: "0.35rem",
+                            background: "#fff",
+                            color: "#000",
+                            fontWeight: "600",
+                            flexShrink: 0,
+                          }}
+                        >
+                          Send
+                        </button>
+                      </div>
+                    </>
+                  ) : (
+                    <div
+                      style={{
+                        padding: "1rem",
+                        border: "1px dashed rgba(239,68,68,0.6)",
+                        borderRadius: "0.5rem",
+                        textAlign: "center",
+                        color: "rgba(239,68,68,0.8)",
+                      }}
+                    >
+                      Server is not connected. Please reconnect to chat.
+                    </div>
+                  )}
+                </div>
+              )}
+              {mode === "manual" && (!selectedServer || !selectedTool) && (
+                <div
+                  style={{
+                    marginTop: "1rem",
+                    padding: "1rem",
+                    border: "1px dashed rgba(63,63,70,0.6)",
+                    borderRadius: "0.5rem",
+                    textAlign: "center",
+                    color: "rgba(255,255,255,0.6)",
+                  }}
+                >
+                  Select a tool to execute
+                </div>
+              )}
+              {mode === "chat" && (!selectedServer || selectedServer.status !== "connected") && (
+                <div
+                  style={{
+                    marginTop: "1rem",
+                    padding: "1rem",
+                    border: "1px dashed rgba(63,63,70,0.6)",
+                    borderRadius: "0.5rem",
+                    textAlign: "center",
+                    color: "rgba(255,255,255,0.6)",
+                  }}
+                >
+                  {!selectedServer
+                    ? "Select a connected server to chat"
+                    : "Server is not connected. Please reconnect to chat."}
+                </div>
+              )}
+            </div>
+            </Panel>
+          </PanelGroup>
+        </div>
+      </div>
+
+      {showAddModal && (
+        <div
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: "rgba(0,0,0,0.6)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: 1000,
+          }}
+        >
+          <div
+            style={{
+              background: "#18181b",
+              padding: "2rem",
+              borderRadius: "0.75rem",
+              width: "420px",
+              border: "1px solid rgba(63,63,70,0.6)",
+            }}
+          >
+            <h2 style={{ fontSize: "1.3rem", marginBottom: "1rem" }}>
+              Connect MCP Server
+            </h2>
+
+            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+              <input
+                placeholder="Server URL"
+                style={{
+                  padding: "0.6rem",
+                  borderRadius: "0.4rem",
+                  border: "1px solid rgba(63,63,70,0.6)",
+                  background: "#09090b",
+                  color: "#fff",
+                }}
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+              />
+
+              <select
+                value={transport}
+                onChange={(e) => setTransport(e.target.value)}
+                style={{
+                  padding: "0.6rem",
+                  borderRadius: "0.4rem",
+                  border: "1px solid rgba(63,63,70,0.6)",
+                  background: "#09090b",
+                  color: "#fff",
+                }}
+              >
+                <option value="http">HTTP</option>
+                <option value="sse">SSE</option>
+              </select>
+
+              <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                <button
+                  onClick={() => setShowAddModal(false)}
+                  style={{
+                    background: "transparent",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    padding: "0.5rem 1rem",
+                    borderRadius: "0.4rem",
+                    color: "#fff",
+                  }}
+                >
+                  Cancel
+                </button>
+
+                <button
+                  onClick={handleConnect}
+                  disabled={connecting}
+                  style={{
+                    background: "#fff",
+                    color: "#000",
+                    padding: "0.5rem 1rem",
+                    borderRadius: "0.4rem",
+                    fontWeight: "600",
+                  }}
+                >
+                  {connecting ? "Connecting..." : "Connect"}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}          
+      <Footer />
+    </div>
+  );
+}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -76,14 +76,13 @@ function ChatResultBubble({ result }: { result: unknown }) {
 // ── Animated thinking indicator ──────────────────────────────────────────────
 function ThinkingDots() {
   return (
-    <span style={{ display: "inline-flex", gap: "3px", alignItems: "center", marginLeft: "4px" }}>
-      {[0, 1, 2].map(i => (
-        <span key={i} style={{
-          width: "4px", height: "4px", borderRadius: "50%",
-          background: "rgba(255,255,255,0.55)", display: "inline-block",
-          animation: `thinking-blink 1.4s infinite ${i * 0.2}s`,
-        }} />
-      ))}
+    <span style={{ fontStyle: "italic", color: "rgba(255,255,255,0.4)", fontSize: "0.72rem" }}>
+      Thinking
+      <span style={{ display: "inline-flex", gap: "1px" }}>
+        {[0, 1, 2].map(i => (
+          <span key={i} style={{ animation: `thinking-blink 1.4s ease-in-out ${i * 0.2}s infinite` }}>.</span>
+        ))}
+      </span>
     </span>
   );
 }
@@ -182,14 +181,25 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
                 <div style={{ fontSize: "0.72rem", color: "#fbbf24", fontWeight: 600 }}>
                   Tool: {toolCall.toolName}
                 </div>
-                <pre style={{
-                  margin: "0.2rem 0 0", padding: "0.35rem 0.5rem",
-                  background: "rgba(0,0,0,0.3)", borderRadius: "6px",
-                  fontSize: "0.7rem", overflowX: "auto", whiteSpace: "pre-wrap",
-                  wordBreak: "break-all", color: "#e5e7eb", fontFamily: "ui-monospace,monospace",
-                }}>
-                  {JSON.stringify(toolCall.params, null, 2)}
-                </pre>
+                {toolCall.params && Object.keys(toolCall.params).length > 0 ? (
+                  <div style={{ marginTop: "0.25rem", display: "flex", flexDirection: "column", gap: "0.2rem" }}>
+                    {Object.entries(toolCall.params).map(([k, v]) => (
+                      <div key={k} style={{ display: "flex", gap: "0.4rem", alignItems: "baseline", fontSize: "0.7rem" }}>
+                        <span style={{ color: "#fbbf24", opacity: 0.7, fontFamily: "monospace", flexShrink: 0 }}>{k}</span>
+                        <span style={{ color: "rgba(255,255,255,0.2)", flexShrink: 0 }}>→</span>
+                        <span style={{
+                          background: "rgba(0,0,0,0.25)", borderRadius: "4px",
+                          padding: "0.05rem 0.35rem", color: "#e5e7eb", fontFamily: "monospace",
+                          wordBreak: "break-all",
+                        }}>
+                          {typeof v === "string" ? v : JSON.stringify(v)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)", fontStyle: "italic" }}>no params</span>
+                )}
               </div>
             </div>
           )}
@@ -330,10 +340,22 @@ export default function MCPInspector() {
   // Tracks how many backend logs to skip per server after a manual clear.
   // Using a ref so the polling closure always reads the latest value.
   const logsClearedOffsetRef = useRef<Record<string, number>>({})
+  // 5B: Log filter pill state
+  const [logFilter, setLogFilter] = useState<'all' | 'connect' | 'tool_call' | 'tool_error' | 'chat'>('all')
+  const filteredLogs = logFilter === 'all' ? logs : logs.filter(l =>
+    logFilter === 'tool_error' ? (l.type === 'tool_error') :
+    logFilter === 'tool_call' ? (l.type === 'tool_call' || l.type === 'tool_result') :
+    l.type === logFilter
+  )
 
   // 3A-3: Per-server chat memory
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
   const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
+
+  // 5A: System prompt + dialog state
+  const [systemPrompt, setSystemPrompt] = useState("")
+  const [systemPromptDraft, setSystemPromptDraft] = useState("")
+  const [systemPromptOpen, setSystemPromptOpen] = useState(false)
 
   // Helper to update chat for the currently selected server
   const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
@@ -697,7 +719,8 @@ export default function MCPInspector() {
         chat_history: nextHistory.slice(-8).map(m => ({
           type: m.type,
           content: m.content
-        }))
+        })),
+        ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
       }
     )
 
@@ -859,7 +882,7 @@ export default function MCPInspector() {
       className="dashboard"
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
-      <style>{`@keyframes thinking-blink{0%,80%,100%{opacity:0}40%{opacity:1}}`}</style>
+      <style>{`@keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}`}</style>
       <Navbar />
 
       <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
@@ -1012,10 +1035,12 @@ export default function MCPInspector() {
                               style={{
                                 marginTop: "0.75rem",
                                 padding: "0.9rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
+                                border: isSelected ? "1px solid rgba(99,102,241,0.5)" : "1px solid rgba(63,63,70,0.6)",
+                                borderLeft: isSelected ? "3px solid rgba(99,102,241,0.9)" : "3px solid transparent",
                                 borderRadius: "0.6rem",
                                 cursor: "pointer",
-                                background: isSelected ? "rgba(255,255,255,0.08)" : "transparent",
+                                background: isSelected ? "rgba(99,102,241,0.08)" : "transparent",
+                                transition: "background 0.15s, border-color 0.15s",
                               }}
                             >
                               {/* HEADER */}
@@ -1191,31 +1216,57 @@ export default function MCPInspector() {
                     }}
                   >
                     {/* Logs header */}
-                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                      <div>
-                        <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
-                          LOGS
-                        </span>
-                        {logs.length > 0 && (
-                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
-                            {logs.length} entries
-                          </span>
+                    <div style={{ padding: "0.6rem 0.75rem 0.4rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
+                      {/* Title row */}
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.4rem" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>LOGS</span>
+                          {logs.length > 0 && (
+                            <span style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.3)" }}>
+                              {filteredLogs.length}{logFilter !== 'all' ? `/${logs.length}` : ''}
+                            </span>
+                          )}
+                        </div>
+                        {logs.length > 0 && selectedServerId && (
+                          <button
+                            onClick={() => {
+                              if (!selectedServerId) return;
+                              const currentOffset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+                              logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [selectedServerId]: currentOffset + logs.length };
+                              setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Clear
+                          </button>
                         )}
                       </div>
-                      {logs.length > 0 && selectedServerId && (
-                        <button
-                          onClick={() => {
-                            if (!selectedServerId) return;
-                            // Advance the offset so future polls skip everything up to now
-                            const currentOffset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
-                            logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [selectedServerId]: currentOffset + logs.length };
-                            setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
-                          }}
-                          style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
-                        >
-                          Clear
-                        </button>
-                      )}
+                      {/* Filter pills */}
+                      <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
+                        {([
+                          { key: 'all', label: 'All', count: logs.length },
+                          { key: 'connect', label: 'Connect', count: logs.filter(l => l.type === 'connect').length },
+                          { key: 'tool_call', label: 'Tool', count: logs.filter(l => l.type === 'tool_call' || l.type === 'tool_result').length },
+                          { key: 'tool_error', label: 'Error', count: logs.filter(l => l.type === 'tool_error').length },
+                          { key: 'chat', label: 'Chat', count: logs.filter(l => l.type === 'chat').length },
+                        ] as const).map(pill => (
+                          <button
+                            key={pill.key}
+                            onClick={() => setLogFilter(pill.key)}
+                            style={{
+                              fontSize: "0.65rem", padding: "0.1rem 0.45rem",
+                              borderRadius: "999px", cursor: "pointer",
+                              border: logFilter === pill.key ? "1px solid rgba(99,102,241,0.7)" : "1px solid rgba(63,63,70,0.5)",
+                              background: logFilter === pill.key ? "rgba(99,102,241,0.2)" : "transparent",
+                              color: logFilter === pill.key ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.4)",
+                              fontFamily: "monospace",
+                              transition: "all 0.1s",
+                            }}
+                          >
+                            {pill.label}{pill.count > 0 ? ` (${pill.count})` : ''}
+                          </button>
+                        ))}
+                      </div>
                     </div>
 
                     {/* Logs content */}
@@ -1230,28 +1281,28 @@ export default function MCPInspector() {
                         fontSize: "0.78rem",
                       }}
                     >
-                      {logs.length === 0 ? (
+                      {filteredLogs.length === 0 ? (
                         <div style={{
                           display: "flex", alignItems: "center", justifyContent: "center",
                           height: "100%", color: "rgba(255,255,255,0.35)", fontSize: "0.8rem",
                         }}>
-                          {selectedServer?.session_id ? "No logs yet" : "Connect to a server to see logs"}
+                          {selectedServer?.session_id ? (logFilter !== 'all' ? "No matching logs" : "No logs yet") : "Connect to a server to see logs"}
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log, i) => {
+                          {[...filteredLogs].reverse().map((log, i) => {
                             const color = logColors[log.type] || "#9ca3af";
                             return (
                               <div
                                 key={i}
                                 style={{
                                   display: "grid",
-                                  // Fixed columns: time | type | message
-                                  // time ~70px, type ~90px, message gets rest
                                   gridTemplateColumns: "70px 90px 1fr",
                                   gap: "0.5rem",
                                   paddingBottom: "3px",
                                   borderBottom: "1px solid rgba(63,63,70,0.2)",
+                                  borderLeft: `2px solid ${color}`,
+                                  paddingLeft: "0.4rem",
                                   alignItems: "start",
                                 }}
                               >
@@ -1263,7 +1314,7 @@ export default function MCPInspector() {
                                 <span style={{ color, fontWeight: "700", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                                   {log.type.toUpperCase()}
                                 </span>
-                                {/* Message — grid child auto-constrains width, word-break works correctly */}
+                                {/* Message */}
                                 <span style={{ color: "rgba(255,255,255,0.75)", wordBreak: "break-word", overflowWrap: "break-word" }}>
                                   {log.message}
                                 </span>
@@ -1413,10 +1464,12 @@ export default function MCPInspector() {
                                 return (
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
                                     <div style={{
-                                      background: "#2563eb", color: "#fff",
-                                      padding: "0.6rem 0.75rem",
-                                      borderRadius: "12px 12px 4px 12px",
-                                      maxWidth: "70%", fontSize: "0.9rem", lineHeight: 1.4
+                                      background: "rgba(37,99,235,0.85)",
+                                      border: "1px solid rgba(59,130,246,0.4)",
+                                      color: "#fff",
+                                      padding: "0.55rem 0.85rem",
+                                      borderRadius: "16px 16px 4px 16px",
+                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
                                     }}>
                                       {msg.content}
                                     </div>
@@ -1426,13 +1479,20 @@ export default function MCPInspector() {
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
                                     <div style={{
-                                      background: "rgba(99,102,241,0.15)",
-                                      border: "1px solid rgba(99,102,241,0.3)",
-                                      padding: "0.6rem 0.75rem",
-                                      borderRadius: "12px 12px 12px 4px",
-                                      maxWidth: "70%", fontSize: "0.9rem"
+                                      width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
+                                      background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                      display: "flex", alignItems: "center", justifyContent: "center",
+                                      fontSize: "0.65rem",
+                                    }}>🤖</div>
+                                    <div style={{
+                                      background: "rgba(39,39,42,0.8)",
+                                      border: "1px solid rgba(63,63,70,0.6)",
+                                      padding: "0.55rem 0.85rem",
+                                      borderRadius: "4px 16px 16px 16px",
+                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                      color: "rgba(255,255,255,0.85)",
                                     }}>
                                       {msg.content}
                                     </div>
@@ -1446,48 +1506,125 @@ export default function MCPInspector() {
                           </div>
 
                           {/* Chat Input — grid row 2 (auto height, always at bottom) */}
-                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem" }}>
-                          {chatHistory.length > 1 && selectedServerId && (
-                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
+
+                            {/* ── Toolbar row: model badge · system prompt · clear ── */}
+                            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
+                              {/* Model badge */}
+                              <span style={{
+                                fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
+                                color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
+                              }}>
+                                Groq · llama-3.1-8b
+                              </span>
+
+                              {/* System prompt button */}
                               <button
-                                onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
-                                style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                                onClick={() => { setSystemPromptDraft(systemPrompt); setSystemPromptOpen(true); }}
+                                title="System prompt"
+                                style={{
+                                  fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                  background: systemPrompt ? "rgba(99,102,241,0.15)" : "transparent",
+                                  border: systemPrompt ? "1px solid rgba(99,102,241,0.4)" : "1px solid rgba(63,63,70,0.5)",
+                                  color: systemPrompt ? "rgba(165,180,252,0.9)" : "rgba(255,255,255,0.35)",
+                                  cursor: "pointer", flexShrink: 0,
+                                }}
                               >
-                                Clear Chat
+                                ⚙ {systemPrompt ? "Prompt set" : "System prompt"}
                               </button>
+
+                              {/* Spacer */}
+                              <div style={{ flex: 1 }} />
+
+                              {/* Clear chat */}
+                              {chatHistory.length > 1 && selectedServerId && (
+                                <button
+                                  onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                                  style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.4rem", flexShrink: 0 }}
+                                >
+                                  Clear Chat
+                                </button>
+                              )}
                             </div>
-                          )}
+
+                            {/* ── System prompt dialog overlay ── */}
+                            {systemPromptOpen && (
+                              <div style={{
+                                position: "fixed", inset: 0, zIndex: 50,
+                                background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center",
+                              }}
+                                onClick={(e) => { if (e.target === e.currentTarget) setSystemPromptOpen(false); }}
+                              >
+                                <div style={{
+                                  background: "#18181b", border: "1px solid rgba(63,63,70,0.7)",
+                                  borderRadius: "12px", padding: "1.25rem", width: "420px", maxWidth: "90vw",
+                                  display: "flex", flexDirection: "column", gap: "0.75rem",
+                                }}>
+                                  <div style={{ fontSize: "0.9rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>System Prompt</div>
+                                  <textarea
+                                    value={systemPromptDraft}
+                                    onChange={e => setSystemPromptDraft(e.target.value)}
+                                    placeholder="You are a helpful assistant with access to MCP tools."
+                                    rows={5}
+                                    style={{
+                                      background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                      borderRadius: "6px", padding: "0.5rem 0.6rem",
+                                      color: "#fff", fontSize: "0.8rem", resize: "vertical",
+                                      fontFamily: "inherit", lineHeight: 1.5,
+                                    }}
+                                  />
+                                  <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                                    <button
+                                      onClick={() => setSystemPromptOpen(false)}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "transparent", border: "1px solid rgba(63,63,70,0.5)", color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                                    >
+                                      Cancel
+                                    </button>
+                                    <button
+                                      onClick={() => { setSystemPrompt(systemPromptDraft); setSystemPromptOpen(false); }}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
+                                    >
+                                      Save
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* ── Message input row ── */}
                           <div style={{ display: "flex", gap: "0.5rem" }}>
                             <input
                               value={chatInput}
                               disabled={chatLoading}
                               onChange={(e) => setChatInput(e.target.value)}
                               placeholder="Ask something..."
-                              onKeyDown={(e) => { 
+                              onKeyDown={(e) => {
                                 if (e.key === "Enter" && !e.shiftKey && chatInput.trim()) {
-                                  e.preventDefault(); 
+                                  e.preventDefault();
                                   runChatTool();
-                                } 
+                                }
                               }}
                               style={{
-                                flex: 1, minWidth: 0, padding: "0.5rem",
-                                borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
-                                background: "#09090b", color: "#fff", opacity: chatLoading ? 0.6 : 1,
+                                flex: 1, minWidth: 0, padding: "0.5rem 0.75rem",
+                                borderRadius: "0.5rem", border: "1px solid rgba(63,63,70,0.6)",
+                                background: "rgba(24,24,27,0.8)", color: "#fff", opacity: chatLoading ? 0.6 : 1,
+                                fontSize: "0.875rem",
                               }}
                             />
                             <button
-                              onClick={()=>{
-                                if (chatInput.trim()) runChatTool();
-                              }}
+                              onClick={()=>{ if (chatInput.trim()) runChatTool(); }}
                               disabled={chatLoading || !chatInput.trim()}
                               style={{
-                                padding: "0.5rem 0.75rem", borderRadius: "0.35rem",
-                                background: "#fff", color: "#000", fontWeight: "600", flexShrink: 0,
-                                opacity: chatLoading || !chatInput.trim() ? 0.6 : 1,
-                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer"
+                                padding: "0.5rem 1rem", borderRadius: "0.5rem",
+                                background: "rgba(99,102,241,0.9)", color: "#fff", fontWeight: "600", flexShrink: 0,
+                                border: "none",
+                                opacity: chatLoading || !chatInput.trim() ? 0.45 : 1,
+                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer",
+                                fontSize: "0.875rem",
                               }}
                             >
-                              {chatLoading ? "Thinking..." : "Send"}
+                              {chatLoading ? <ThinkingDots /> : "Send"}
                             </button>
                           </div>
                           </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,10 +1,72 @@
 // import React from "react";
 import { useState, useEffect, useRef } from "react";
+
+// Compact collapsible result bubble for chat mode
+function ChatResultBubble({ result }: { result: unknown }) {
+  const [expanded, setExpanded] = useState(true);
+  const [viewMode, setViewMode] = useState<"formatted" | "raw">("formatted");
+  const isMcp = typeof result === "object" && result !== null &&
+    "content" in result && Array.isArray((result as any).content);
+  const isMcpArray = Array.isArray(result) && result.length > 0 &&
+    (result as any[]).every((i: any) => typeof i === "object" && i !== null && "type" in i);
+  const preview = typeof result === "object" && result !== null
+    ? `{${Object.keys(result as object).length} keys}`
+    : String(result).slice(0, 60);
+
+  const tabStyle = (active: boolean) => ({
+    padding: "0.2rem 0.5rem", borderRadius: "0.25rem", border: "none",
+    fontSize: "0.75rem", fontWeight: 500 as const, cursor: "pointer",
+    background: active ? "#fff" : "transparent",
+    color: active ? "#000" : "rgba(255,255,255,0.6)"
+  });
+
+  return (
+    <div style={{ fontSize: "0.8rem" }}>
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        <button
+          onClick={() => setExpanded(v => !v)}
+          style={{
+            background: "none", border: "none", cursor: "pointer",
+            color: "#22c55e", fontWeight: 600, padding: "0.25rem 0",
+            fontSize: "0.8rem", display: "flex", alignItems: "center", gap: "0.3rem"
+          }}
+        >
+          {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
+        </button>
+        {expanded && (
+          <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
+            <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
+            <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+          </div>
+        )}
+      </div>
+      {expanded && (
+        <div style={{
+          maxHeight: "260px", overflowY: "auto",
+          background: "rgba(0,0,0,0.3)",
+          border: "1px solid rgba(63,63,70,0.5)",
+          borderRadius: "0.5rem",
+          padding: "0.75rem",
+          marginTop: "0.25rem"
+        }}>
+          {viewMode === "raw"
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace" }}>{JSON.stringify(result, null, 2)}</pre>
+            : (isMcp || isMcpArray)
+              ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
+              : <JsonResultView data={result} />
+          }
+        </div>
+      )}
+    </div>
+  );
+}
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
 import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
 import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels'; 
 
 // Type for server object
@@ -72,16 +134,33 @@ export default function MCPInspector() {
   const [mode, setMode] = useState<"manual" | "chat">("manual")
 
   const [chatInput, setChatInput] = useState("")
-  // const [chatHistory, setChatHistory] = useState<any[]>([])
-  const [chatHistory, setChatHistory] = useState<ChatMessage[]>([])
+  // 3A-2: Per-server logs
+  const [logsByServer, setLogsByServer] = useState<Record<string, LogEntry[]>>({})
+  const logs = logsByServer[selectedServerId ?? ""] ?? []
+
+  // 3A-3: Per-server chat memory
+  const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
+  const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
+
+  // Helper to update chat for the currently selected server
+  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
+    if (!selectedServerId) return;
+    setChatHistoryByServer(prev => ({
+      ...prev,
+      [selectedServerId]: typeof updater === "function"
+        ? updater(prev[selectedServerId] ?? [])
+        : updater
+    }));
+  };
+
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
     left: 25,     // percentage (right auto-calculated as 100-left)
     logs: 35      // percentage of left panel height
   })
-  const [logs, setLogs] = useState<LogEntry[]>([])
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
+  const chatBottomRef = useRef<HTMLDivElement>(null);
 
   const handleConnect = async () => {
 
@@ -164,13 +243,16 @@ export default function MCPInspector() {
       setToolResult(null);
       setToolError(null);
 
-      // Clear chat and show a welcome message for the new server
-      setChatHistory([{
-        id: crypto.randomUUID(),
-        type: "assistant",
-        content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
-        timestamp: Date.now(),
-      }]);
+      // Set welcome message for this server (preserve other servers' histories)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [{
+          id: crypto.randomUUID(),
+          type: "assistant",
+          content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+          timestamp: Date.now(),
+        }]
+      }));
 
       setAuthType("none")
       setToken("")
@@ -281,6 +363,19 @@ export default function MCPInspector() {
             : s
         )
       );
+      // Append reconnect notice to existing chat history (don't wipe it)
+      setChatHistoryByServer(prev => ({
+        ...prev,
+        [serverId]: [
+          ...(prev[serverId] ?? []),
+          {
+            id: crypto.randomUUID(),
+            type: "assistant" as const,
+            content: `Reconnected to ${res.server_info?.name || "server"}.`,
+            timestamp: Date.now(),
+          }
+        ]
+      }));
     } catch (err: any) {
       console.error("Failed to reconnect", err);
 
@@ -301,10 +396,10 @@ export default function MCPInspector() {
 
   const handleRemove = (serverId: string) => {
     setServers((prev) => prev.filter((s) => s.id !== serverId));
-
-    if (selectedServerId === serverId) {
-      setSelectedServerId(null);
-    }
+    // Clean up per-server state
+    setLogsByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    setChatHistoryByServer(prev => { const n = { ...prev }; delete n[serverId]; return n; });
+    if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
   const runTool = async (params: any) => {
@@ -381,7 +476,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, thinkingMsg])
+    updateChat(prev => [...prev, thinkingMsg])
 
     // Call backend chat endpoint
     const res = await apiClient.chatWithInspector(
@@ -396,7 +491,7 @@ export default function MCPInspector() {
     )
 
     // Remove thinking message
-    setChatHistory(prev => prev.filter(m => m.id !== thinkingMsg.id))
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
@@ -406,7 +501,7 @@ export default function MCPInspector() {
         timestamp: Date.now()
       }
 
-      setChatHistory(prev => [...prev, assistantMsg])
+      updateChat(prev => [...prev, assistantMsg])
       return
     }
 
@@ -419,7 +514,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, toolCallMsg])
+    updateChat(prev => [...prev, toolCallMsg])
 
     // Execute tool
     const result = await apiClient.runInspectorTool(
@@ -435,7 +530,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, resultMsg])
+    updateChat(prev => [...prev, resultMsg])
 
   } catch (err: any) {
 
@@ -446,7 +541,7 @@ export default function MCPInspector() {
       timestamp: Date.now()
     }
 
-    setChatHistory(prev => [...prev, errorMsg])
+    updateChat(prev => [...prev, errorMsg])
   } finally {
     setChatLoading(false)
   }
@@ -469,18 +564,19 @@ export default function MCPInspector() {
   }, [logs]);
 
   // Auto-scroll chat to bottom when new messages arrive
+  // Uses rAF so scroll runs after the DOM (including dynamic result content) has painted
   useEffect(() => {
-    if (chatRef.current) {
-      chatRef.current.scrollTop = chatRef.current.scrollHeight;
-    }
-  }, [chatHistory]);
+    requestAnimationFrame(() => {
+      chatBottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    });
+  }, [chatHistoryByServer, selectedServerId]);
 
-  // Fetch logs from the server
+  // Fetch logs from the server (3A-2: stored per-server)
   const fetchLogs = async () => {
-    if (!selectedServer?.session_id) return;
+    if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogs(res.logs || []);
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -488,21 +584,9 @@ export default function MCPInspector() {
 
   // Poll for logs every 2 seconds when a session is active
   useEffect(() => {
-    if (!selectedServer?.session_id) {
-      return;
-    }
-    // NOTE FOR REVIEW: When a new server connects, its logs replace the previous server's logs.
-    // Decision needed: Should we accumulate logs across all servers (keyed by session_id)?
-    // Or is replacing on new connection acceptable?
-    // Options:
-    //   A) Current behaviour — replace logs on new connection (simple, clean)
-    //   B) Accumulate all logs — merge new logs into existing, tag each entry with server name
-    //   C) Per-server log history — store logs[serverId] map, show logs for selected server
-    // Leaning towards C if inspector gets heavy usage, but A is fine for now.
-    fetchLogs();     // Fetch immediately
-
-    const interval = setInterval(fetchLogs, 2000);     // Set up polling interval
-
+    if (!selectedServer?.session_id) return;
+    fetchLogs();
+    const interval = setInterval(fetchLogs, 2000);
     return () => clearInterval(interval);
   }, [selectedServer?.session_id]);
 
@@ -673,15 +757,7 @@ export default function MCPInspector() {
                                 setSelectedTool(null);
                                 setToolResult(null);
                                 setToolError(null);
-                                // Reset chat
-                                setChatHistory([
-                                  {
-                                    id: crypto.randomUUID(),
-                                    type: "assistant",
-                                    content: `Switched to ${server?.server_info?.name || "server"}. Chat cleared.`,
-                                    timestamp: Date.now()
-                                  }
-                                ]);
+                                // 3A-3: preserve chat history on switch (no reset)
                                 
                               }}
                               style={{
@@ -910,14 +986,24 @@ export default function MCPInspector() {
                     }}
                   >
                     {/* Logs header */}
-                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
-                      <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
-                        LOGS
-                      </span>
-                      {logs.length > 0 && (
-                        <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
-                          {logs.length} entries
+                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                      <div>
+                        <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
+                          LOGS
                         </span>
+                        {logs.length > 0 && (
+                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
+                            {logs.length} entries
+                          </span>
+                        )}
+                      </div>
+                      {logs.length > 0 && selectedServerId && (
+                        <button
+                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                        >
+                          Clear
+                        </button>
                       )}
                     </div>
 
@@ -1049,7 +1135,7 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
+                <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
                     <div>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
@@ -1086,21 +1172,19 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: "0", overflow: "hidden" }}>
+                    <div style={{ display: "grid", gridTemplateRows: "1fr auto", flex: 1, minHeight: 0, overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
-                          {/* Chat History */}
+                          {/* Chat History — grid row 1 (1fr = all remaining space) */}
                           <div
                             ref={chatRef}
                             style={{
-                              flex: 1,
-                              minHeight: 0,        
                               overflowY: "auto",
-                              marginBottom: "1rem",
+                              minHeight: 0,
                               display: "flex",
                               flexDirection: "column",
                               gap: "0.5rem",
-                              padding: "0.5rem 0.5rem 0.5rem 0.25rem"
+                              padding: "0.5rem 0.5rem 0.75rem 0.25rem"
                             }}
                           >
                             {chatHistory.map((msg) => {
@@ -1173,10 +1257,10 @@ export default function MCPInspector() {
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
                                     <div style={{
                                       borderLeft: "3px solid #22c55e",
-                                      paddingLeft: "0.5rem",
+                                      paddingLeft: "0.6rem",
                                       maxWidth: "85%"
                                     }}>
-                                      <ToolResult result={msg.result} />
+                                      <ChatResultBubble result={msg.result} />
                                     </div>
                                   </div>
                                 )
@@ -1218,10 +1302,22 @@ export default function MCPInspector() {
 
                               return null
                             })}
+                            <div ref={chatBottomRef} />
                           </div>
 
-                          {/* Chat Input */}
-                          <div style={{ display: "flex", gap: "0.5rem", flexShrink: 0 }}>
+                          {/* Chat Input — grid row 2 (auto height, always at bottom) */}
+                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem" }}>
+                          {chatHistory.length > 1 && selectedServerId && (
+                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                              <button
+                                onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                                style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                              >
+                                Clear Chat
+                              </button>
+                            </div>
+                          )}
+                          <div style={{ display: "flex", gap: "0.5rem" }}>
                             <input
                               value={chatInput}
                               disabled={chatLoading}
@@ -1253,6 +1349,7 @@ export default function MCPInspector() {
                             >
                               {chatLoading ? "Thinking..." : "Send"}
                             </button>
+                          </div>
                           </div>
                         </>
                       ) : (

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -34,32 +34,200 @@ function ChatResultBubble({ result }: { result: unknown }) {
           {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
         </button>
         {expanded && (
-          <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
-            <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
-            <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+            <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
+              <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
+              <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
+            </div>
+            <button
+              onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
+              style={{ ...tabStyle(false), border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.25rem" }}
+              title="Copy to clipboard"
+            >
+              Copy
+            </button>
           </div>
         )}
       </div>
       {expanded && (
         <div style={{
-          maxHeight: "260px", overflowY: "auto",
+          maxHeight: "260px", overflowY: "auto", overflowX: "hidden",
           background: "rgba(0,0,0,0.3)",
           border: "1px solid rgba(63,63,70,0.5)",
           borderRadius: "0.5rem",
           padding: "0.75rem",
-          marginTop: "0.25rem"
+          marginTop: "0.25rem",
+          width: "100%", boxSizing: "border-box",
         }}>
           {viewMode === "raw"
-            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace" }}>{JSON.stringify(result, null, 2)}</pre>
-            : (isMcp || isMcpArray)
-              ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
-              : <JsonResultView data={result} />
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-all", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
+            : <div style={{ minWidth: 0, width: "100%", overflow: "hidden" }}>
+                {(isMcp || isMcpArray)
+                  ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
+                  : <JsonResultView data={result} />
+                }
+              </div>
           }
         </div>
       )}
     </div>
   );
 }
+// ── Animated thinking indicator ──────────────────────────────────────────────
+function ThinkingDots() {
+  return (
+    <span style={{ display: "inline-flex", gap: "3px", alignItems: "center", marginLeft: "4px" }}>
+      {[0, 1, 2].map(i => (
+        <span key={i} style={{
+          width: "4px", height: "4px", borderRadius: "50%",
+          background: "rgba(255,255,255,0.55)", display: "inline-block",
+          animation: `thinking-blink 1.4s infinite ${i * 0.2}s`,
+        }} />
+      ))}
+    </span>
+  );
+}
+
+// ── Group flat chat messages into standalone + run blocks ─────────────────────
+type DisplayGroup =
+  | { kind: "standalone"; msg: ChatMessage }
+  | { kind: "run"; runId: string; steps: ChatMessage[]; run?: ExecutionRun }
+
+function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): DisplayGroup[] {
+  const runMap = new Map(execHistory.map(r => [r.runId, r]));
+  const seen = new Set<string>();
+  return messages.reduce<DisplayGroup[]>((acc, msg) => {
+    if (!msg.runId) {
+      acc.push({ kind: "standalone", msg });
+    } else if (!seen.has(msg.runId)) {
+      seen.add(msg.runId);
+      acc.push({
+        kind: "run",
+        runId: msg.runId,
+        steps: messages.filter(m => m.runId === msg.runId),
+        run: runMap.get(msg.runId),
+      });
+    }
+    return acc;
+  }, []);
+}
+
+// ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
+function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const thinking  = steps.find(s => s.type === "thinking");
+  const toolCall  = steps.find(s => s.type === "tool_call");
+  const toolResult = steps.find(s => s.type === "tool_result");
+  const errorStep = steps.find(s => s.type === "error");
+  const isActive  = !toolResult && !errorStep; // run still in progress
+
+  const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
+  const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
+    ? Math.round(toolCall.perfMark - thinking.perfMark) : null;
+  const toolMs     = (toolResult?.perfMark && toolCall?.perfMark)
+    ? Math.round(toolResult.perfMark - toolCall.perfMark) : null;
+
+  const dot = (color: string) => (
+    <div style={{ width: "7px", height: "7px", borderRadius: "50%", background: color, marginTop: "4px", flexShrink: 0 }} />
+  );
+
+  return (
+    <div style={{ maxWidth: "90%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px", overflow: "hidden" }}>
+      {/* Header */}
+      <div
+        onClick={() => setCollapsed(v => !v)}
+        style={{
+          display: "flex", alignItems: "center", gap: "0.5rem",
+          padding: "0.45rem 0.75rem",
+          background: "rgba(255,255,255,0.04)", cursor: "pointer",
+          borderBottom: collapsed ? "none" : "1px solid rgba(63,63,70,0.25)",
+        }}
+      >
+        <span style={{ fontSize: "0.7rem", opacity: 0.45 }}>{collapsed ? "▶" : "▼"}</span>
+        <span style={{ fontSize: "0.8rem", fontWeight: 600 }}>
+          {toolCall ? `🔧 ${toolCall.toolName}` : errorStep ? "❌ Error" : "🤖 Thinking"}
+        </span>
+        {isActive && <ThinkingDots />}
+        {totalMs !== null && (
+          <span style={{ marginLeft: "auto", fontSize: "0.7rem", color: "rgba(99,102,241,0.7)", fontFamily: "monospace" }}>
+            {totalMs}ms
+          </span>
+        )}
+      </div>
+
+      {!collapsed && (
+        <div style={{ padding: "0.6rem 0.75rem", display: "flex", flexDirection: "column", gap: "0.55rem" }}>
+          {/* Thinking step */}
+          {thinking && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#3b82f6")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#60a5fa", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Thinking
+                  {thinkingMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{thinkingMs}ms</span>}
+                  {isActive && <ThinkingDots />}
+                </div>
+                <div style={{ fontSize: "0.73rem", opacity: 0.6, fontStyle: "italic", marginTop: "0.15rem" }}>
+                  {thinking.content}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Tool call step */}
+          {toolCall && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#f59e0b")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fbbf24", fontWeight: 600 }}>
+                  Tool: {toolCall.toolName}
+                </div>
+                <pre style={{
+                  margin: "0.2rem 0 0", padding: "0.35rem 0.5rem",
+                  background: "rgba(0,0,0,0.3)", borderRadius: "6px",
+                  fontSize: "0.7rem", overflowX: "auto", whiteSpace: "pre-wrap",
+                  wordBreak: "break-all", color: "#e5e7eb", fontFamily: "ui-monospace,monospace",
+                }}>
+                  {JSON.stringify(toolCall.params, null, 2)}
+                </pre>
+              </div>
+            </div>
+          )}
+
+          {/* Result step */}
+          {toolResult && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#22c55e")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#4ade80", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                  Result
+                  {toolMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{toolMs}ms</span>}
+                </div>
+                <div style={{ marginTop: "0.2rem" }}>
+                  <ChatResultBubble result={toolResult.result} />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Error step */}
+          {errorStep && (
+            <div style={{ display: "flex", gap: "0.6rem" }}>
+              {dot("#ef4444")}
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: "0.72rem", color: "#fca5a5", fontWeight: 600 }}>Error</div>
+                <div style={{ fontSize: "0.73rem", color: "#fca5a5", marginTop: "0.15rem" }}>
+                  {errorStep.content}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
@@ -670,6 +838,7 @@ export default function MCPInspector() {
       className="dashboard"
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
+      <style>{`@keyframes thinking-blink{0%,80%,100%{opacity:0}40%{opacity:1}}`}</style>
       <Navbar />
 
       <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
@@ -965,58 +1134,6 @@ export default function MCPInspector() {
                       )}
                     </div>
 
-                    {/* Execution History */}
-                    <div style={{ marginTop: "1.25rem", flexShrink: 0 }}>
-                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.5rem" }}>
-                        <h3 style={{ fontSize: "0.9rem", fontWeight: "600" }}>Execution History</h3>
-                        <button
-                          onClick={() => selectedServerId && setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
-                          style={{
-                            fontSize: "0.7rem", padding: "0.2rem 0.5rem",
-                            borderRadius: "0.3rem", border: "1px solid rgba(63,63,70,0.6)",
-                            background: "transparent", color: "rgba(255,255,255,0.6)", cursor: "pointer",
-                          }}
-                        >
-                          Clear
-                        </button>
-                      </div>
-
-                      <div
-                        style={{
-                          display: "flex", flexDirection: "column", gap: "0.4rem",
-                          maxHeight: "160px", overflowY: "auto",
-                        }}
-                      >
-                        {executionHistory.map((item: ExecutionRun) => {
-                          const toolCall = item.steps.find(s => s.type === "tool_call");
-                          const toolResult = item.steps.find(s => s.type === "tool_result");
-                          const duration = item.endTime ? item.endTime - item.startTime : null;
-                          return (
-                            <div
-                              key={item.runId}
-                              onClick={() => {
-                                if (toolResult) setToolResult(toolResult.result);
-                                if (toolCall?.toolName) setSelectedTool(selectedServer?.tools.find((t: any) => t.name === toolCall.toolName) || null);
-                                setToolError(null);
-                              }}
-                              style={{
-                                padding: "0.4rem 0.5rem",
-                                borderRadius: "0.35rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
-                                cursor: "pointer",
-                                background: "rgba(255,255,255,0.04)",
-                              }}
-                            >
-                              <div style={{ fontWeight: 600, fontSize: "0.8rem" }}>{toolCall?.toolName || "run"}</div>
-                              <div style={{ fontSize: "0.75rem", opacity: 0.6 }}>
-                                {new Date(item.startTime).toLocaleTimeString()}
-                                {duration !== null && <span style={{ marginLeft: "0.4rem", color: "rgba(99,102,241,0.8)" }}>{duration}ms</span>}
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </div>
                   </div>
                 </Panel>
 
@@ -1260,83 +1377,30 @@ export default function MCPInspector() {
                               padding: "0.5rem 0.5rem 0.75rem 0.25rem"
                             }}
                           >
-                            {chatHistory.map((msg) => {
+                            {groupMessages(chatHistory, executionHistory).map((group) => {
+                              if (group.kind === "run") {
+                                return (
+                                  <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                  </div>
+                                );
+                              }
+
+                              const msg = group.msg;
 
                               if (msg.type === "user") {
                                 return (
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
                                     <div style={{
-                                      background: "#2563eb",
-                                      color: "#fff",
+                                      background: "#2563eb", color: "#fff",
                                       padding: "0.6rem 0.75rem",
                                       borderRadius: "12px 12px 4px 12px",
-                                      maxWidth: "70%",
-                                      fontSize: "0.9rem",
-                                      lineHeight: 1.4
+                                      maxWidth: "70%", fontSize: "0.9rem", lineHeight: 1.4
                                     }}>
                                       {msg.content}
                                     </div>
                                   </div>
-                                )
-                              }
-
-                              if (msg.type === "thinking") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      fontSize: "0.8rem",
-                                      opacity: 0.7,
-                                      fontStyle: "italic",
-                                      padding: "0.3rem 0.5rem"
-                                    }}>
-                                      🤖 {msg.content}...
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              if (msg.type === "tool_call") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      background: "rgba(59,130,246,0.12)",
-                                      border: "1px solid rgba(59,130,246,0.35)",
-                                      borderRadius: "8px",
-                                      padding: "0.6rem",
-                                      maxWidth: "80%",
-                                      fontSize: "0.8rem"
-                                    }}>
-                                      <div style={{ fontWeight: 600, marginBottom: "0.3rem" }}>
-                                        🔧 Tool: {msg.toolName}
-                                      </div>
-
-                                      <div style={{
-                                        fontFamily: "monospace",
-                                        fontSize: "0.75rem",
-                                        background: "rgba(0,0,0,0.3)",
-                                        padding: "0.4rem",
-                                        borderRadius: "6px",
-                                        overflowX: "auto"
-                                      }}>
-                                        {JSON.stringify(msg.params, null, 2)}
-                                      </div>
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              if (msg.type === "tool_result") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      borderLeft: "3px solid #22c55e",
-                                      paddingLeft: "0.6rem",
-                                      maxWidth: "85%"
-                                    }}>
-                                      <ChatResultBubble result={msg.result} />
-                                    </div>
-                                  </div>
-                                )
+                                );
                               }
 
                               if (msg.type === "assistant") {
@@ -1347,33 +1411,15 @@ export default function MCPInspector() {
                                       border: "1px solid rgba(99,102,241,0.3)",
                                       padding: "0.6rem 0.75rem",
                                       borderRadius: "12px 12px 12px 4px",
-                                      maxWidth: "70%",
-                                      fontSize: "0.9rem"
+                                      maxWidth: "70%", fontSize: "0.9rem"
                                     }}>
                                       {msg.content}
                                     </div>
                                   </div>
-                                )
+                                );
                               }
 
-                              if (msg.type === "error") {
-                                return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <div style={{
-                                      background: "rgba(239,68,68,0.15)",
-                                      border: "1px solid rgba(239,68,68,0.4)",
-                                      padding: "0.6rem",
-                                      borderRadius: "8px",
-                                      color: "#fca5a5",
-                                      maxWidth: "70%"
-                                    }}>
-                                      ❌ {msg.content}
-                                    </div>
-                                  </div>
-                                )
-                              }
-
-                              return null
+                              return null;
                             })}
                             <div ref={chatBottomRef} />
                           </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -149,6 +149,9 @@ export default function MCPInspector() {
   // 3A-2: Per-server logs
   const [logsByServer, setLogsByServer] = useState<Record<string, LogEntry[]>>({})
   const logs = logsByServer[selectedServerId ?? ""] ?? []
+  // Tracks how many backend logs to skip per server after a manual clear.
+  // Using a ref so the polling closure always reads the latest value.
+  const logsClearedOffsetRef = useRef<Record<string, number>>({})
 
   // 3A-3: Per-server chat memory
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
@@ -241,6 +244,9 @@ export default function MCPInspector() {
 
       const res = await apiClient.connectInspectorServer(payload)
 
+
+      // Reset log offset for this server — new session, fresh log stream
+      logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
 
       setServers(prev =>
         prev.map(s =>
@@ -361,6 +367,8 @@ export default function MCPInspector() {
       }
       
       const res = await apiClient.connectInspectorServer(payload);
+      // Reset log offset — reconnect starts a new session with a fresh log stream
+      logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
       // Update with connected state and new session
       setServers((prev) =>
         prev.map((s) =>
@@ -625,7 +633,9 @@ export default function MCPInspector() {
     if (!selectedServer?.session_id || !selectedServerId) return;
     try {
       const res = await apiClient.getInspectorLogs(selectedServer.session_id);
-      setLogsByServer(prev => ({ ...prev, [selectedServerId]: res.logs || [] }));
+      const allLogs: LogEntry[] = res.logs || [];
+      const offset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+      setLogsByServer(prev => ({ ...prev, [selectedServerId]: allLogs.slice(offset) }));
     } catch (err) {
       console.error("Failed to fetch logs", err);
     }
@@ -1056,7 +1066,13 @@ export default function MCPInspector() {
                       </div>
                       {logs.length > 0 && selectedServerId && (
                         <button
-                          onClick={() => setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                          onClick={() => {
+                            if (!selectedServerId) return;
+                            // Advance the offset so future polls skip everything up to now
+                            const currentOffset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+                            logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [selectedServerId]: currentOffset + logs.length };
+                            setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
+                          }}
                           style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
                         >
                           Clear

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,17 +1,28 @@
-// import React from "react";
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 // Compact collapsible result bubble for chat mode
-function ChatResultBubble({ result }: { result: unknown }) {
+function ChatResultBubble({ result, initialView = "formatted", hideTabSwitcher = false }: { result: unknown; initialView?: "formatted" | "raw"; hideTabSwitcher?: boolean }) {
   const [expanded, setExpanded] = useState(true);
-  const [viewMode, setViewMode] = useState<"formatted" | "raw">("formatted");
+  const [viewMode, setViewMode] = useState<"formatted" | "raw">(initialView);
+  useEffect(() => { setViewMode(initialView); }, [initialView]);
   const isMcp = typeof result === "object" && result !== null &&
     "content" in result && Array.isArray((result as any).content);
   const isMcpArray = Array.isArray(result) && result.length > 0 &&
     (result as any[]).every((i: any) => typeof i === "object" && i !== null && "type" in i);
-  const preview = typeof result === "object" && result !== null
-    ? `{${Object.keys(result as object).length} keys}`
-    : String(result).slice(0, 60);
+  const preview = (() => {
+    if (isMcp) {
+      const texts = ((result as any).content || []).filter((c: any) => c.type === "text" && c.text);
+      if (texts.length > 0) return String(texts[0].text).slice(0, 80);
+      return `[${(result as any).content?.length || 0} items]`;
+    }
+    if (isMcpArray) {
+      const texts = (result as any[]).filter((c: any) => c.type === "text" && c.text);
+      if (texts.length > 0) return String(texts[0].text).slice(0, 80);
+      return `[${(result as any[]).length} items]`;
+    }
+    if (typeof result === "object" && result !== null) return `{${Object.keys(result as object).length} keys}`;
+    return String(result).slice(0, 60);
+  })();
 
   const tabStyle = (active: boolean) => ({
     padding: "0.2rem 0.5rem", borderRadius: "0.25rem", border: "none",
@@ -33,7 +44,7 @@ function ChatResultBubble({ result }: { result: unknown }) {
         >
           {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
         </button>
-        {expanded && (
+        {expanded && !hideTabSwitcher && (
           <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
             <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
               <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
@@ -51,16 +62,17 @@ function ChatResultBubble({ result }: { result: unknown }) {
       </div>
       {expanded && (
         <div style={{
-          maxHeight: "260px", overflowY: "auto", overflowX: "hidden",
           background: "rgba(0,0,0,0.3)",
           border: "1px solid rgba(63,63,70,0.5)",
           borderRadius: "0.5rem",
           padding: "0.75rem",
           marginTop: "0.25rem",
           width: "100%", boxSizing: "border-box",
+          maxHeight: "350px",
+          overflowY: "auto",
         }}>
           {viewMode === "raw"
-            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-all", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
             : <div style={{ minWidth: 0, width: "100%", overflow: "hidden" }}>
                 {(isMcp || isMcpArray)
                   ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
@@ -112,7 +124,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
 }
 
 // ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
-function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; run?: ExecutionRun; sessionId?: string }) {
+function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
   const [collapsed, setCollapsed] = useState(false);
   const thinking  = steps.find(s => s.type === "thinking");
   const toolCall  = steps.find(s => s.type === "tool_call");
@@ -131,7 +143,7 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
   );
 
   return (
-    <div style={{ maxWidth: "90%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px", overflow: "hidden" }}>
+    <div style={{ width: "100%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px" }}>
       {/* Header */}
       <div
         onClick={() => setCollapsed(v => !v)}
@@ -209,21 +221,15 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
             <div style={{ display: "flex", gap: "0.6rem" }}>
               {dot("#22c55e")}
               <div style={{ flex: 1 }}>
+                {/* Result label */}
                 <div style={{ fontSize: "0.72rem", color: "#4ade80", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
                   Result
                   {toolMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{toolMs}ms</span>}
                 </div>
+                {/* Result bubble — always shows Formatted/Raw tabs */}
                 <div style={{ marginTop: "0.2rem" }}>
                   <ChatResultBubble result={toolResult.result} />
                 </div>
-                {toolResult.resourceUri && sessionId && toolCall && (
-                  <WidgetSandbox
-                    sessionId={sessionId}
-                    resourceUri={toolResult.resourceUri}
-                    toolInput={toolCall.params || {}}
-                    toolResult={toolResult.result}
-                  />
-                )}
               </div>
             </div>
           )}
@@ -247,7 +253,6 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
 }
 
 import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
 import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
@@ -312,6 +317,7 @@ export default function MCPInspector() {
   const [headerKey, setHeaderKey] = useState("")
   const [headerValue, setHeaderValue] = useState("")
 
+  const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [url, setUrl] = useState("");
   const [transport, setTransport] = useState("http");
@@ -689,7 +695,7 @@ export default function MCPInspector() {
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
 
-  setChatHistory(prev => [...prev, userMsg])
+  updateChat(prev => [...prev, userMsg])
 
   // 3A-4: start an ExecutionRun for this agent turn
   const runId = crypto.randomUUID()
@@ -880,36 +886,69 @@ export default function MCPInspector() {
   return (
     <div
       className="dashboard"
-      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+      style={inspectorFullscreen
+        ? { position: "fixed", inset: 0, zIndex: 1000, height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden", background: "#09090b", maxWidth: "none", margin: 0, padding: 0 }
+        : { height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden", maxWidth: "100%", padding: 0 }
+      }
     >
       <style>{`@keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}`}</style>
-      <Navbar />
+      {!inspectorFullscreen && <Navbar />}
 
-      <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
+      <div style={{ paddingTop: inspectorFullscreen ? "0" : "64px", flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
         <div
           style={{
-            maxWidth: "1600px",
+            maxWidth: inspectorFullscreen ? "none" : "1600px",
             width: "100%",
-            margin: "0 auto",
-            padding: "2rem",
+            margin: inspectorFullscreen ? "0" : "0 auto",
+            padding: inspectorFullscreen ? "0.4rem 0.5rem" : "2rem",
             flex: 1,
+            minHeight: 0,
             display: "flex",
             flexDirection: "column",
+            overflow: "hidden",
           }}
         >
-          {/* Page Header */}
-          <div style={{ marginBottom: "1.5rem" }}>
-            <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>
-              MCP Inspector
-            </h1>
-            <p style={{ color: "rgba(255,255,255,0.6)", marginTop: "0.5rem" }}>
-              Connect to any MCP server and inspect its tools.
-            </p>
-          </div>
+          {/* Page Header — hidden in fullscreen to maximise space */}
+          {inspectorFullscreen ? (
+            <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.4rem", flexShrink: 0 }}>
+              <button
+                onClick={() => setInspectorFullscreen(false)}
+                style={{
+                  background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
+                  borderRadius: "0.4rem", cursor: "pointer", padding: "0.3rem 0.6rem",
+                  fontSize: "0.75rem", color: "rgba(255,255,255,0.7)", display: "flex", alignItems: "center", gap: "0.4rem",
+                }}
+              >
+                ✕ Exit Fullscreen
+              </button>
+            </div>
+          ) : (
+            <div style={{ marginBottom: "1.5rem", flexShrink: 0, display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+              <div>
+                <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>MCP Inspector</h1>
+                <p style={{ color: "rgba(255,255,255,0.6)", marginTop: "0.5rem" }}>
+                  Connect to any MCP server and inspect its tools.
+                </p>
+              </div>
+              <button
+                onClick={() => setInspectorFullscreen(true)}
+                title="Fullscreen"
+                style={{
+                  background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
+                  borderRadius: "0.4rem", cursor: "pointer", padding: "0.4rem 0.75rem",
+                  fontSize: "0.8rem", color: "rgba(255,255,255,0.7)", display: "flex", alignItems: "center", gap: "0.4rem",
+                  marginTop: "0.25rem", flexShrink: 0,
+                }}
+              >
+                ⤢ Fullscreen
+              </button>
+            </div>
+          )}
 
-          {/* Main Layout — fills remaining height */}
-          <PanelGroup 
-            direction="horizontal" 
+          {/* Main Layout — fills remaining height, never grows beyond it */}
+          <PanelGroup
+            key={inspectorFullscreen ? "fs" : "normal"}
+            direction="horizontal"
             onLayout={(sizes) => {
               setPanelSizes(prev => {
                 const updated = { ...prev, left: sizes[0] };
@@ -917,17 +956,13 @@ export default function MCPInspector() {
                 return updated;
               });
             }}
-            style={{ 
-              flex: 1,
-              // Minimum height so it doesn't collapse
-              minHeight: "calc(100vh - 220px)",
-            }}
+            style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
           >
             {/* ── LEFT PANEL (outer) ─────────────────────────────────────── */}
-            <Panel 
-              defaultSize={panelSizes.left} 
-              minSize={18} 
-              maxSize={50}
+            <Panel
+              defaultSize={inspectorFullscreen ? Math.min(panelSizes.left, 25) : panelSizes.left}
+              minSize={inspectorFullscreen ? 12 : 18}
+              maxSize={inspectorFullscreen ? 30 : 50}
               style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}
             >
               {/* LEFT PANEL INNER: vertical split — Servers+Tools (top) / Logs (bottom) */}
@@ -940,14 +975,14 @@ export default function MCPInspector() {
                     return updated;
                   });
                 }}
-                style={{ flex: 1, height: "100%" }}
+                style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
               >
 
                 {/* ── TOP: Servers + Tools ────────────────────────────────── */}
                 <Panel 
                   defaultSize={100 - panelSizes.logs} 
                   minSize={30}
-                  style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+                  style={{ overflow: "hidden", display: "flex", flexDirection: "column", minHeight: 0 }}
                 >
                   <div
                     style={{
@@ -955,11 +990,12 @@ export default function MCPInspector() {
                       borderRadius: "0.75rem",
                       padding: "1.25rem",
                       background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-                      height: "100%",
+                      flex: 1,
+                      minHeight: 0,
                       boxSizing: "border-box",
                       display: "flex",
                       flexDirection: "column",
-                      overflow: "auto",
+                      overflow: "hidden",
                     }}
                   >
                     {/* Header */}
@@ -1356,12 +1392,12 @@ export default function MCPInspector() {
                   borderRadius: "0.75rem",
                   padding: "1.5rem",
                   background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-                  height: "100%",
+                  flex: 1,
+                  minHeight: 0,
                   boxSizing: "border-box",
                   display: "flex",
                   flexDirection: "column",
                   overflow: "hidden",
-                  minHeight: 0,
                 }}
               >
                 <h2 style={{ fontSize: "1.1rem", fontWeight: "600", flexShrink: 0 }}>
@@ -1399,7 +1435,7 @@ export default function MCPInspector() {
                 {/* ── MANUAL MODE ─── */}
                 <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
-                    <div>
+                    <div style={{ overflowY: "auto", flex: 1, minHeight: 0, paddingBottom: "0.5rem" }}>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
 
                       {selectedServer.status === "connected" ? (
@@ -1434,27 +1470,62 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "grid", gridTemplateRows: "1fr auto", flex: 1, minHeight: 0, overflow: "hidden" }}>
+                    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
-                          {/* Chat History — grid row 1 (1fr = all remaining space) */}
+                          {/* Chat History — fills remaining flex space, scrolls */}
                           <div
                             ref={chatRef}
                             style={{
-                              overflowY: "auto",
+                              flex: 1,
                               minHeight: 0,
-                              display: "flex",
-                              flexDirection: "column",
-                              gap: "0.5rem",
-                              padding: "0.5rem 0.5rem 0.75rem 0.25rem"
+                              overflowY: "auto",
+                              padding: "0.5rem 0.5rem 2rem 0.25rem"
                             }}
                           >
-                            {groupMessages(chatHistory, executionHistory).map((group) => {
+                            {/* Inner wrapper: flex layout for gap spacing.
+                                Kept separate from the scroll container so flex items
+                                don't shrink-to-fit and prevent overflow scrolling. */}
+                            <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                            {groupMessages(chatHistory, executionHistory).map((group, _idx, _arr) => {
+                              const isLast = _idx === _arr.length - 1;
                               if (group.kind === "run") {
+                                const toolResult = group.steps.find(s => s.type === "tool_result");
+                                const toolCall = group.steps.find(s => s.type === "tool_call");
+                                const sessionId = selectedServer?.session_id ?? undefined;
+                                const hasWidget = !!(toolResult?.resourceUri && sessionId && toolCall);
                                 return (
-                                  <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <ExecutionRunBlock steps={group.steps} run={group.run} sessionId={selectedServer?.session_id ?? undefined} />
-                                  </div>
+                                  <React.Fragment key={group.runId}>
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                    {hasWidget && (
+                                      <div style={{
+                                        width: "100%",
+                                        border: "1px solid rgba(99,102,241,0.3)",
+                                        borderRadius: "10px",
+                                        overflow: "hidden",
+                                        background: "rgba(99,102,241,0.04)",
+                                      }}>
+                                        <div style={{
+                                          padding: "0.4rem 0.75rem",
+                                          borderBottom: "1px solid rgba(99,102,241,0.15)",
+                                          fontSize: "0.72rem", fontWeight: 600,
+                                          color: "rgba(99,102,241,0.8)",
+                                          display: "flex", alignItems: "center", gap: "0.4rem",
+                                          background: "rgba(99,102,241,0.06)",
+                                        }}>
+                                          <span>⬡</span> Widget
+                                        </div>
+                                        <WidgetSandbox
+                                          sessionId={sessionId!}
+                                          resourceUri={toolResult!.resourceUri!}
+                                          toolInput={toolCall!.params || {}}
+                                          toolResult={toolResult!.result}
+                                        />
+                                      </div>
+                                    )}
+                                    {/* Scroll anchor: AFTER widget so auto-scroll reveals the full widget */}
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
@@ -1462,51 +1533,57 @@ export default function MCPInspector() {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
-                                    <div style={{
-                                      background: "rgba(37,99,235,0.85)",
-                                      border: "1px solid rgba(59,130,246,0.4)",
-                                      color: "#fff",
-                                      padding: "0.55rem 0.85rem",
-                                      borderRadius: "16px 16px 4px 16px",
-                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                    }}>
-                                      {msg.content}
+                                  <React.Fragment key={msg.id}>
+                                    <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                                      <div style={{
+                                        background: "rgba(37,99,235,0.85)",
+                                        border: "1px solid rgba(59,130,246,0.4)",
+                                        color: "#fff",
+                                        padding: "0.55rem 0.85rem",
+                                        borderRadius: "16px 16px 4px 16px",
+                                        maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                      }}>
+                                        {msg.content}
+                                      </div>
                                     </div>
-                                  </div>
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
-                                    <div style={{
-                                      width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
-                                      background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
-                                      display: "flex", alignItems: "center", justifyContent: "center",
-                                      fontSize: "0.65rem",
-                                    }}>🤖</div>
-                                    <div style={{
-                                      background: "rgba(39,39,42,0.8)",
-                                      border: "1px solid rgba(63,63,70,0.6)",
-                                      padding: "0.55rem 0.85rem",
-                                      borderRadius: "4px 16px 16px 16px",
-                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                      color: "rgba(255,255,255,0.85)",
-                                    }}>
-                                      {msg.content}
+                                  <React.Fragment key={msg.id}>
+                                    <div style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
+                                      <div style={{
+                                        width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
+                                        background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                        display: "flex", alignItems: "center", justifyContent: "center",
+                                        fontSize: "0.65rem",
+                                      }}>🤖</div>
+                                      <div style={{
+                                        background: "rgba(39,39,42,0.8)",
+                                        border: "1px solid rgba(63,63,70,0.6)",
+                                        padding: "0.55rem 0.85rem",
+                                        borderRadius: "4px 16px 16px 16px",
+                                        maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                        color: "rgba(255,255,255,0.85)",
+                                      }}>
+                                        {msg.content}
+                                      </div>
                                     </div>
-                                  </div>
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
                               return null;
                             })}
-                            <div ref={chatBottomRef} />
+                            </div>{/* close inner flex wrapper */}
                           </div>
 
-                          {/* Chat Input — grid row 2 (auto height, always at bottom) */}
-                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
+                          {/* Chat Input — always at bottom, shrinks to its content */}
+                          <div style={{ flexShrink: 0, display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
 
                             {/* ── Toolbar row: model badge · system prompt · clear ── */}
                             <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
@@ -1822,7 +1899,6 @@ export default function MCPInspector() {
         </div>
       )}
 
-      <Footer />
     </div>
   );
 }

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -315,6 +315,13 @@ class ApiClient {
       body: JSON.stringify({ message }),
     });
   }
+
+  async getInspectorLogs(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/logs`, {
+      method: "GET",
+    });
+  }
+
   /**
    * Clone a GitHub repository and register its MCP server(s).
    *

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -328,6 +328,17 @@ class ApiClient {
     });
   }
 
+  async listInspectorResources(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/resources`);
+  }
+
+  async readInspectorResource(sessionId: string, uri: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/resources/read`, {
+      method: "POST",
+      body: JSON.stringify({ uri }),
+    });
+  }
+
   /**
    * Clone a GitHub repository and register its MCP server(s).
    *

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -55,6 +55,7 @@ function mergeAbortSignals(...signals: AbortSignal[]): AbortSignal {
 
 class ApiClient {
   private baseUrl: string;
+  private token: string | null = null;
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl;
@@ -80,6 +81,7 @@ class ApiClient {
       const response = await fetch(`${this.baseUrl}${endpoint}`, {
         headers: {
           'Content-Type': 'application/json',
+          ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
           ...options?.headers,
         },
         ...options,
@@ -116,6 +118,9 @@ class ApiClient {
     return this.request<ServersListResponse>(url, options);
   }
 
+  setToken(token: string | null) {
+    this.token = token;
+  }
   async getServerDetails(serverId: string, options?: { signal?: AbortSignal }): Promise<ServerDetailsResponse> {
     return this.request<ServerDetailsResponse>(`/api/servers/${serverId}`, options);
   }

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -321,6 +321,12 @@ class ApiClient {
       method: "GET",
     });
   }
+  async chatWithInspector(sessionId: string, data: any): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/chat`, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  }
 
   /**
    * Clone a GitHub repository and register its MCP server(s).

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -276,6 +276,40 @@ class ApiClient {
     });
   }
 
+  // Inspector Tools APIs
+  async connectInspectorServer(payload: { url: string; transport: string }): Promise<any> {
+    return this.request(`/api/inspector/connect`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async disconnectInspectorServer(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}`, {
+      method: "DELETE",
+    });
+  }
+
+  async runInspectorTool(
+    sessionId: string,
+    toolName: string,
+    params: Record<string, any>
+  ): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/tools/${toolName}/run`, {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+  }
+  
+  async runInspectorChat(
+    sessionId: string,
+    message: string
+  ): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/chat`, {
+      method: "POST",
+      body: JSON.stringify({ message }),
+    });
+  }
   /**
    * Clone a GitHub repository and register its MCP server(s).
    *


### PR DESCRIPTION
## Summary
- **Fix chat scroll completely broken** -- the scroll container was also a flex container, causing children to shrink-to-fit instead of overflowing. Separated into outer scroll div + inner flex wrapper.
- **Cap result bubble at 350px** with internal scroll (WhatsApp-style cards) so the widget below is always reachable without scrolling through hundreds of lines of JSON.
- **Move auto-scroll anchor after widget** so `scrollIntoView` reveals the full widget, not just the result above it.
- **Override `.dashboard` CSS class** constraints (`max-width: 1200px`, `padding: 32px`) that clipped inspector content in normal mode.
- **Increase WidgetSandbox default height** from 280px to 400px and clean up redundant double-border wrapper.
- **Remove double maxHeight** constraint from ToolResult manual mode.

## Test plan
- [ ] Connect to a weather-ui MCP server (or any server with `_meta["ui/resourceUri"]`)
- [ ] In Chat mode, send a query that triggers a tool with a widget (e.g. "weather in Delhi")
- [ ] Verify: result card is capped at ~350px with its own scrollbar for large JSON
- [ ] Verify: widget renders fully below the result and is scrolled into view automatically
- [ ] Verify: in normal (non-fullscreen) mode, content is not clipped at the bottom
- [ ] Verify: Manual mode results still scroll properly
- [ ] Test in fullscreen mode -- same scroll behavior should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)