### PR TITLE
MCP-483: MCP Inspector 4B: Resources + Prompts tabs

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -274,7 +274,7 @@ async def read_resource(session_id: str, body: ReadResourceRequest):
 
 
 class GetPromptRequest(BaseModel):
-    name: str
+    name: str = Field(min_length=1, max_length=512)
     arguments: Optional[dict] = Field(default_factory=dict)
 
 
@@ -289,7 +289,7 @@ async def list_prompts(session_id: str):
         return {"prompts": prompts, "count": len(prompts)}
     except Exception as e:
         logger.error(f"Inspector: list_prompts failed for session {session_id} — {e}")
-        raise HTTPException(500, f"Failed to fetch prompts: {str(e)}")
+        raise HTTPException(500, "Failed to fetch prompts")
 
 
 @router.post("/inspector/{session_id}/prompts/get")
@@ -303,7 +303,7 @@ async def get_prompt(session_id: str, body: GetPromptRequest):
         return result
     except Exception as e:
         logger.error(f"Inspector: get_prompt failed for session {session_id} — {e}")
-        raise HTTPException(500, f"Failed to get prompt: {str(e)}")
+        raise HTTPException(500, "Failed to get prompt")
 
 
 @router.post("/inspector/{session_id}/chat")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -243,7 +243,9 @@ async def list_resources(session_id: str):
 
     try:
         resources = await session.list_resources()
-        return {"resources": resources, "count": len(resources)}
+        templates = await session.list_resource_templates()
+        combined = resources + templates
+        return {"resources": combined, "count": len(combined)}
     except Exception as e:
         logger.error(f"Inspector: list_resources failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to fetch resources: {str(e)}")
@@ -269,6 +271,39 @@ async def read_resource(session_id: str, body: ReadResourceRequest):
     except Exception as e:
         logger.error(f"Inspector: read_resource failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to read resource: {str(e)}")
+
+
+class GetPromptRequest(BaseModel):
+    name: str
+    arguments: Optional[dict] = Field(default_factory=dict)
+
+
+@router.get("/inspector/{session_id}/prompts")
+async def list_prompts(session_id: str):
+    """List all prompts available on the connected MCP server."""
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    try:
+        prompts = await session.list_prompts()
+        return {"prompts": prompts, "count": len(prompts)}
+    except Exception as e:
+        logger.error(f"Inspector: list_prompts failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to fetch prompts: {str(e)}")
+
+
+@router.post("/inspector/{session_id}/prompts/get")
+async def get_prompt(session_id: str, body: GetPromptRequest):
+    """Get a prompt by name with optional arguments."""
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    try:
+        result = await session.get_prompt(body.name, body.arguments or {})
+        return result
+    except Exception as e:
+        logger.error(f"Inspector: get_prompt failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to get prompt: {str(e)}")
 
 
 @router.post("/inspector/{session_id}/chat")

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -309,7 +309,36 @@ class InspectorSession:
         data = await self._send(self._make_request("resources/list", {}))
         if "error" in data:
             raise Exception(f"resources/list error: {data['error'].get('message', 'Unknown error')}")
-        return data.get("result", {}).get("resources", [])
+        resources = data.get("result", {}).get("resources", [])
+        for r in resources:
+            r["isTemplate"] = False
+        return resources
+
+    async def list_resource_templates(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/templates/list", {}))
+        if "error" in data:
+            return []  # not all servers implement templates — silently skip
+        templates = data.get("result", {}).get("resourceTemplates", [])
+        # Normalise: rename uriTemplate → uri so the frontend uses one field
+        for t in templates:
+            t["uri"] = t.pop("uriTemplate", t.get("uri", ""))
+            t["isTemplate"] = True
+        return templates
+
+    async def list_prompts(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("prompts/list", {}))
+        if "error" in data:
+            raise Exception(f"prompts/list error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {}).get("prompts", [])
+
+    async def get_prompt(self, name: str, arguments: dict) -> dict:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("prompts/get", {"name": name, "arguments": arguments}))
+        if "error" in data:
+            raise Exception(f"prompts/get error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {})
 
     async def read_resource(self, uri: str) -> dict:
         self.last_used = time.time()

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -306,6 +306,14 @@ type ExecutionRun = {
   endTime?: number     // set on completion or error
   steps: ChatMessage[] // thinking + tool_call + tool_result in order
 }
+interface MCPResource {
+  uri: string;
+  name?: string;
+  mimeType?: string;
+  description?: string;
+  isTemplate?: boolean;
+}
+
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
@@ -337,7 +345,26 @@ export default function MCPInspector() {
   const [executionHistoryByServer, setExecutionHistoryByServer] = useState<Record<string, ExecutionRun[]>>({})
   const executionHistory = executionHistoryByServer[selectedServerId ?? ""] ?? []
 
-  const [mode, setMode] = useState<"manual" | "chat">("manual")
+  const [mode, setMode] = useState<"manual" | "chat" | "resources" | "prompts">("manual")
+
+  // 4B: Resources tab state
+  const [resourcesByServer, setResourcesByServer] = useState<Record<string, MCPResource[]>>({})
+  const resources = resourcesByServer[selectedServerId ?? ""] ?? []
+  const [selectedResourceUri, setSelectedResourceUri] = useState<string | null>(null)
+  const [resourceContent, setResourceContent] = useState<{ text?: string; blob?: string; mimeType?: string } | null>(null)
+  const [resourcesLoading, setResourcesLoading] = useState(false)
+  const [resourceContentLoading, setResourceContentLoading] = useState(false)
+  // Template param inputs: { paramName → value }
+  const [templateParams, setTemplateParams] = useState<Record<string, string>>({})
+
+  // 4B: Prompts tab state
+  const [promptsByServer, setPromptsByServer] = useState<Record<string, any[]>>({})
+  const prompts = promptsByServer[selectedServerId ?? ""] ?? []
+  const [selectedPrompt, setSelectedPrompt] = useState<any | null>(null)
+  const [promptArgs, setPromptArgs] = useState<Record<string, string>>({})
+  const [promptResult, setPromptResult] = useState<any | null>(null)
+  const [promptsLoading, setPromptsLoading] = useState(false)
+  const [promptResultLoading, setPromptResultLoading] = useState(false)
 
   const [chatInput, setChatInput] = useState("")
   // 3A-2: Per-server logs
@@ -827,6 +854,42 @@ export default function MCPInspector() {
     setToolError(null)
     setExecutionTime(null)
   }, [selectedTool])
+
+  // 4B: Fetch prompts list when Prompts tab becomes active
+  useEffect(() => {
+    if (mode !== "prompts") return;
+    const sessionId = selectedServer?.session_id;
+    if (!sessionId) return;
+    if (promptsByServer[selectedServerId!]) return;
+    setPromptsLoading(true);
+    apiClient.listInspectorPrompts(sessionId)
+      .then(res => {
+        setPromptsByServer(prev => ({ ...prev, [selectedServerId!]: res?.prompts ?? [] }));
+      })
+      .catch(() => {
+        setPromptsByServer(prev => ({ ...prev, [selectedServerId!]: [] }));
+      })
+      .finally(() => setPromptsLoading(false));
+  }, [mode, selectedServer?.session_id])
+
+  // 4B: Fetch resource list when Resources tab becomes active
+  useEffect(() => {
+    if (mode !== "resources") return;
+    const sessionId = selectedServer?.session_id;
+    if (!sessionId) return;
+    // Already cached for this server — no refetch needed
+    if (resourcesByServer[selectedServerId!]) return;
+    setResourcesLoading(true);
+    apiClient.listInspectorResources(sessionId)
+      .then(res => {
+        const list: MCPResource[] = res?.resources ?? [];
+        setResourcesByServer(prev => ({ ...prev, [selectedServerId!]: list }));
+      })
+      .catch(() => {
+        setResourcesByServer(prev => ({ ...prev, [selectedServerId!]: [] }));
+      })
+      .finally(() => setResourcesLoading(false));
+  }, [mode, selectedServer?.session_id])
 
   useEffect(() => {
     const saved = sessionStorage.getItem('inspector-panel-sizes')
@@ -1430,6 +1493,39 @@ export default function MCPInspector() {
                   >
                     Chat
                   </button>
+                  <button
+                    onClick={() => {
+                      setMode("resources");
+                      setSelectedResourceUri(null);
+                      setResourceContent(null);
+                    }}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "resources" ? "#fff" : "transparent",
+                      color: mode === "resources" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Resources
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMode("prompts");
+                      setSelectedPrompt(null);
+                      setPromptArgs({});
+                      setPromptResult(null);
+                    }}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "prompts" ? "#fff" : "transparent",
+                      color: mode === "prompts" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Prompts
+                  </button>
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
@@ -1707,6 +1803,226 @@ export default function MCPInspector() {
                     </div>
                   )}
 
+                  {/* ── RESOURCES MODE ─── */}
+                  {mode === "resources" && selectedServer?.status === "connected" && (
+                    <div style={{ display: "flex", flex: 1, minHeight: 0, gap: "0.75rem", overflow: "hidden" }}>
+
+                      {/* Resource list — left column */}
+                      <div style={{
+                        width: "38%", flexShrink: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        <div style={{
+                          padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                          display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0,
+                          background: "rgba(24,24,27,0.6)",
+                        }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "rgba(255,255,255,0.7)" }}>
+                            Resources {resources.length > 0 && <span style={{ color: "rgba(255,255,255,0.35)", fontWeight: 400 }}>({resources.length})</span>}
+                          </span>
+                          <button
+                            onClick={() => {
+                              if (!selectedServer?.session_id || !selectedServerId) return;
+                              setResourcesByServer(prev => { const next = { ...prev }; delete next[selectedServerId]; return next; });
+                              setSelectedResourceUri(null);
+                              setResourceContent(null);
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Refresh
+                          </button>
+                        </div>
+                        <div style={{ flex: 1, overflowY: "auto" }}>
+                          {resourcesLoading ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                              Loading resources...
+                            </div>
+                          ) : resources.length === 0 ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                              No resources found
+                            </div>
+                          ) : (
+                            resources.map(r => {
+                              const isSelected = r.uri === selectedResourceUri;
+                              // Extract {param} names from template URIs
+                              const templateVars = r.isTemplate
+                                ? (r.uri.match(/\{([^}]+)\}/g) ?? []).map(v => v.slice(1, -1))
+                                : [];
+                              const loadResource = async (uri: string) => {
+                                setSelectedResourceUri(r.uri);
+                                setResourceContent(null);
+                                setResourceContentLoading(true);
+                                try {
+                                  const res = await apiClient.readInspectorResource(selectedServer.session_id!, uri);
+                                  const first = res?.contents?.[0];
+                                  setResourceContent({
+                                    text: first?.text ?? first?.content ?? res?.text ?? "",
+                                    blob: first?.blob,
+                                    mimeType: first?.mimeType ?? r.mimeType ?? "text/plain",
+                                  });
+                                } catch {
+                                  setResourceContent({ text: "Failed to load resource.", mimeType: "text/plain" });
+                                } finally {
+                                  setResourceContentLoading(false);
+                                }
+                              };
+                              return (
+                                <div
+                                  key={r.uri}
+                                  onClick={() => {
+                                    if (r.isTemplate) {
+                                      // Just select — param form shows in right panel
+                                      setSelectedResourceUri(r.uri);
+                                      setResourceContent(null);
+                                      setTemplateParams({});
+                                    } else {
+                                      if (isSelected) return;
+                                      loadResource(r.uri);
+                                    }
+                                  }}
+                                  style={{
+                                    padding: "0.55rem 0.75rem",
+                                    borderBottom: "1px solid rgba(63,63,70,0.25)",
+                                    cursor: "pointer",
+                                    background: isSelected ? "rgba(99,102,241,0.12)" : "transparent",
+                                    borderLeft: isSelected ? "2px solid rgba(99,102,241,0.8)" : "2px solid transparent",
+                                    transition: "background 0.1s",
+                                  }}
+                                >
+                                  <div style={{ fontSize: "0.75rem", fontWeight: 600, color: isSelected ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.85)", wordBreak: "break-all" }}>
+                                    {r.name || r.uri}
+                                  </div>
+                                  {r.name && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.3)", marginTop: "0.1rem", wordBreak: "break-all" }}>
+                                      {r.uri}
+                                    </div>
+                                  )}
+                                  <div style={{ display: "flex", gap: "0.35rem", marginTop: "0.25rem", flexWrap: "wrap" }}>
+                                    {r.mimeType && (
+                                      <span style={{
+                                        fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                        background: "rgba(99,102,241,0.15)", border: "1px solid rgba(99,102,241,0.3)",
+                                        color: "rgba(165,180,252,0.8)", fontFamily: "monospace",
+                                      }}>
+                                        {r.mimeType}
+                                      </span>
+                                    )}
+                                    {r.isTemplate && (
+                                      <span style={{
+                                        fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                        background: "rgba(245,158,11,0.15)", border: "1px solid rgba(245,158,11,0.3)",
+                                        color: "rgba(252,211,77,0.9)", fontFamily: "monospace",
+                                      }}>
+                                        template
+                                      </span>
+                                    )}
+                                  </div>
+                                  {r.description && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", marginTop: "0.2rem" }}>
+                                      {r.description}
+                                    </div>
+                                  )}
+                                  {/* Inline param form for selected templates */}
+                                  {r.isTemplate && isSelected && templateVars.length > 0 && (
+                                    <div
+                                      onClick={e => e.stopPropagation()}
+                                      style={{ marginTop: "0.5rem", display: "flex", flexDirection: "column", gap: "0.35rem" }}
+                                    >
+                                      {templateVars.map(v => (
+                                        <div key={v} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                          <span style={{ fontSize: "0.65rem", color: "rgba(252,211,77,0.8)", fontFamily: "monospace", flexShrink: 0 }}>{v}</span>
+                                          <input
+                                            value={templateParams[v] ?? ""}
+                                            onChange={e => setTemplateParams(prev => ({ ...prev, [v]: e.target.value }))}
+                                            placeholder={v}
+                                            style={{
+                                              flex: 1, padding: "0.2rem 0.4rem", fontSize: "0.7rem",
+                                              background: "rgba(0,0,0,0.3)", border: "1px solid rgba(63,63,70,0.6)",
+                                              borderRadius: "4px", color: "#fff",
+                                            }}
+                                          />
+                                        </div>
+                                      ))}
+                                      <button
+                                        onClick={() => {
+                                          let uri = r.uri;
+                                          templateVars.forEach(v => { uri = uri.replace(`{${v}}`, encodeURIComponent(templateParams[v] ?? "")); });
+                                          loadResource(uri);
+                                        }}
+                                        style={{
+                                          marginTop: "0.15rem", padding: "0.25rem 0.5rem", fontSize: "0.7rem",
+                                          background: "rgba(99,102,241,0.8)", border: "none", borderRadius: "4px",
+                                          color: "#fff", cursor: "pointer", alignSelf: "flex-end",
+                                        }}
+                                      >
+                                        Load
+                                      </button>
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Resource content viewer — right column */}
+                      <div style={{
+                        flex: 1, minWidth: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        {!selectedResourceUri ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.3)", fontSize: "0.8rem" }}>
+                            Select a resource to view its content
+                          </div>
+                        ) : resourceContentLoading ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                            Loading...
+                          </div>
+                        ) : resourceContent ? (() => {
+                          const mime = resourceContent.mimeType ?? "text/plain";
+                          const text = resourceContent.text ?? "";
+                          const isImage = mime.startsWith("image/");
+                          const isJson = mime.includes("json") || (() => { try { JSON.parse(text); return text.trim().startsWith("{") || text.trim().startsWith("["); } catch { return false; } })();
+                          return (
+                            <>
+                              <div style={{
+                                padding: "0.4rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                                display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0,
+                                background: "rgba(24,24,27,0.6)",
+                              }}>
+                                <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.5)", wordBreak: "break-all", flex: 1 }}>{selectedResourceUri}</span>
+                                <span style={{
+                                  fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px", flexShrink: 0,
+                                  background: "rgba(99,102,241,0.15)", border: "1px solid rgba(99,102,241,0.3)",
+                                  color: "rgba(165,180,252,0.8)", fontFamily: "monospace",
+                                }}>{mime}</span>
+                              </div>
+                              <div style={{ flex: 1, overflow: "auto", padding: "0.75rem" }}>
+                                {isImage ? (
+                                  <img
+                                    src={resourceContent.blob ? `data:${mime};base64,${resourceContent.blob}` : text}
+                                    alt={selectedResourceUri}
+                                    style={{ maxWidth: "100%", borderRadius: "4px" }}
+                                  />
+                                ) : (
+                                  <pre style={{
+                                    margin: 0, fontSize: "0.75rem", lineHeight: 1.6,
+                                    color: isJson ? "#a5f3fc" : "rgba(255,255,255,0.8)",
+                                    fontFamily: "ui-monospace, monospace",
+                                    whiteSpace: "pre-wrap", wordBreak: "break-word",
+                                  }}>
+                                    {isJson ? (() => { try { return JSON.stringify(JSON.parse(text), null, 2); } catch { return text; } })() : text}
+                                  </pre>
+                                )}
+                              </div>
+                            </>
+                          );
+                        })() : null}
+                      </div>
+                    </div>
+                  )}
+
                   {/* Empty states */}
                   {mode === "manual" && (!selectedServer || !selectedTool) && (
                     <div style={{
@@ -1722,6 +2038,233 @@ export default function MCPInspector() {
                       borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
                     }}>
                       {!selectedServer ? "Select a connected server to chat" : "Server is not connected. Please reconnect to chat."}
+                    </div>
+                  )}
+                  {mode === "resources" && (!selectedServer || selectedServer.status !== "connected") && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      {!selectedServer ? "Select a connected server to browse resources" : "Server is not connected."}
+                    </div>
+                  )}
+
+                  {/* ── PROMPTS MODE ─── */}
+                  {mode === "prompts" && selectedServer?.status === "connected" && (
+                    <div style={{ display: "flex", flex: 1, minHeight: 0, gap: "0.75rem", overflow: "hidden" }}>
+
+                      {/* Prompt list — left column */}
+                      <div style={{
+                        width: "38%", flexShrink: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        <div style={{
+                          padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                          display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0,
+                          background: "rgba(24,24,27,0.6)",
+                        }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "rgba(255,255,255,0.7)" }}>
+                            Prompts {prompts.length > 0 && <span style={{ color: "rgba(255,255,255,0.35)", fontWeight: 400 }}>({prompts.length})</span>}
+                          </span>
+                          <button
+                            onClick={() => {
+                              if (!selectedServerId) return;
+                              setPromptsByServer(prev => { const n = { ...prev }; delete n[selectedServerId]; return n; });
+                              setSelectedPrompt(null); setPromptArgs({}); setPromptResult(null);
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Refresh
+                          </button>
+                        </div>
+                        <div style={{ flex: 1, overflowY: "auto" }}>
+                          {promptsLoading ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>Loading prompts...</div>
+                          ) : prompts.length === 0 ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>No prompts found</div>
+                          ) : (
+                            prompts.map((p: any) => {
+                              const isSelected = selectedPrompt?.name === p.name;
+                              const argCount = p.arguments?.length ?? 0;
+                              return (
+                                <div
+                                  key={p.name}
+                                  onClick={() => {
+                                    setSelectedPrompt(p);
+                                    setPromptArgs({});
+                                    setPromptResult(null);
+                                  }}
+                                  style={{
+                                    padding: "0.55rem 0.75rem",
+                                    borderBottom: "1px solid rgba(63,63,70,0.25)",
+                                    cursor: "pointer",
+                                    background: isSelected ? "rgba(99,102,241,0.12)" : "transparent",
+                                    borderLeft: isSelected ? "2px solid rgba(99,102,241,0.8)" : "2px solid transparent",
+                                    transition: "background 0.1s",
+                                  }}
+                                >
+                                  <div style={{ fontSize: "0.75rem", fontWeight: 600, color: isSelected ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.85)" }}>
+                                    {p.name}
+                                  </div>
+                                  {p.description && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", marginTop: "0.15rem" }}>
+                                      {p.description}
+                                    </div>
+                                  )}
+                                  {argCount > 0 && (
+                                    <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
+                                      {p.arguments.map((a: any) => (
+                                        <span key={a.name} style={{
+                                          fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                          background: a.required ? "rgba(99,102,241,0.15)" : "rgba(63,63,70,0.4)",
+                                          border: `1px solid ${a.required ? "rgba(99,102,241,0.3)" : "rgba(63,63,70,0.6)"}`,
+                                          color: a.required ? "rgba(165,180,252,0.9)" : "rgba(255,255,255,0.4)",
+                                          fontFamily: "monospace",
+                                        }}>
+                                          {a.name}{a.required ? "" : "?"}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Prompt detail + result — right column */}
+                      <div style={{
+                        flex: 1, minWidth: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        {!selectedPrompt ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.3)", fontSize: "0.8rem" }}>
+                            Select a prompt to fill its arguments
+                          </div>
+                        ) : (
+                          <>
+                            {/* Header */}
+                            <div style={{
+                              padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                              background: "rgba(24,24,27,0.6)", flexShrink: 0,
+                            }}>
+                              <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>{selectedPrompt.name}</div>
+                              {selectedPrompt.description && (
+                                <div style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)", marginTop: "0.15rem" }}>{selectedPrompt.description}</div>
+                              )}
+                            </div>
+
+                            {/* Argument form */}
+                            <div style={{ padding: "0.75rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
+                              {(selectedPrompt.arguments?.length ?? 0) === 0 ? (
+                                <div style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.35)", fontStyle: "italic" }}>No arguments required</div>
+                              ) : (
+                                <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                                  {selectedPrompt.arguments.map((a: any) => (
+                                    <div key={a.name}>
+                                      <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.5)", marginBottom: "0.2rem", fontFamily: "monospace" }}>
+                                        {a.name}{a.required ? <span style={{ color: "rgba(239,68,68,0.8)" }}> *</span> : <span style={{ color: "rgba(255,255,255,0.25)" }}> (optional)</span>}
+                                      </div>
+                                      {a.description && (
+                                        <div style={{ fontSize: "0.62rem", color: "rgba(255,255,255,0.3)", marginBottom: "0.2rem" }}>{a.description}</div>
+                                      )}
+                                      <input
+                                        value={promptArgs[a.name] ?? ""}
+                                        onChange={e => setPromptArgs(prev => ({ ...prev, [a.name]: e.target.value }))}
+                                        placeholder={a.name}
+                                        style={{
+                                          width: "100%", boxSizing: "border-box",
+                                          padding: "0.3rem 0.5rem", fontSize: "0.75rem",
+                                          background: "rgba(0,0,0,0.3)", border: "1px solid rgba(63,63,70,0.6)",
+                                          borderRadius: "4px", color: "#fff",
+                                        }}
+                                      />
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              <button
+                                disabled={promptResultLoading}
+                                onClick={async () => {
+                                  if (!selectedServer?.session_id) return;
+                                  setPromptResultLoading(true);
+                                  setPromptResult(null);
+                                  try {
+                                    const res = await apiClient.getInspectorPrompt(selectedServer.session_id, selectedPrompt.name, promptArgs);
+                                    setPromptResult(res);
+                                  } catch (e: any) {
+                                    setPromptResult({ error: e.message });
+                                  } finally {
+                                    setPromptResultLoading(false);
+                                  }
+                                }}
+                                style={{
+                                  marginTop: "0.6rem", padding: "0.35rem 0.85rem",
+                                  background: "rgba(99,102,241,0.85)", border: "none", borderRadius: "6px",
+                                  color: "#fff", fontWeight: 600, fontSize: "0.75rem",
+                                  cursor: promptResultLoading ? "not-allowed" : "pointer",
+                                  opacity: promptResultLoading ? 0.6 : 1,
+                                }}
+                              >
+                                {promptResultLoading ? "Loading..." : "Get Prompt"}
+                              </button>
+                            </div>
+
+                            {/* Messages preview */}
+                            <div style={{ flex: 1, overflowY: "auto", padding: "0.75rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                              {promptResult?.error ? (
+                                <div style={{ fontSize: "0.75rem", color: "#fca5a5", padding: "0.5rem", background: "rgba(239,68,68,0.1)", borderRadius: "6px", border: "1px solid rgba(239,68,68,0.3)" }}>
+                                  Error: {promptResult.error}
+                                </div>
+                              ) : promptResult?.messages ? (
+                                promptResult.messages.map((msg: any, i: number) => {
+                                  // Unwrap role from nested message objects if SDK wraps them
+                                  const role = msg.role ?? msg?.content?.role ?? "user";
+                                  const rawContent = msg.content ?? msg;
+                                  const text = typeof rawContent === "string"
+                                    ? rawContent
+                                    : typeof rawContent?.text === "string"
+                                      ? rawContent.text
+                                      : Array.isArray(rawContent)
+                                        ? rawContent.map((c: any) => c.text ?? JSON.stringify(c)).join("\n")
+                                        : typeof rawContent === "object" && rawContent !== null && "text" in rawContent
+                                          ? rawContent.text
+                                          : JSON.stringify(rawContent, null, 2);
+                                  return (
+                                  <div key={i} style={{
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "8px",
+                                    background: role === "user" ? "rgba(37,99,235,0.15)" : "rgba(39,39,42,0.8)",
+                                    border: `1px solid ${role === "user" ? "rgba(59,130,246,0.3)" : "rgba(63,63,70,0.5)"}`,
+                                  }}>
+                                    <div style={{ fontSize: "0.62rem", fontWeight: 700, color: role === "user" ? "rgba(147,197,253,0.9)" : "rgba(165,180,252,0.9)", marginBottom: "0.3rem", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                                      {role}
+                                    </div>
+                                    <div style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.8)", whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
+                                      {text}
+                                    </div>
+                                  </div>
+                                  );
+                                })
+                              ) : !promptResultLoading && (
+                                <div style={{ color: "rgba(255,255,255,0.25)", fontSize: "0.75rem", textAlign: "center", marginTop: "1rem" }}>
+                                  Fill in arguments and click Get Prompt
+                                </div>
+                              )}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {mode === "prompts" && (!selectedServer || selectedServer.status !== "connected") && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      {!selectedServer ? "Select a connected server to browse prompts" : "Server is not connected."}
                     </div>
                   )}
                 </div>

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -339,6 +339,17 @@ class ApiClient {
     });
   }
 
+  async listInspectorPrompts(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/prompts`);
+  }
+
+  async getInspectorPrompt(sessionId: string, name: string, args: Record<string, string>): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/prompts/get`, {
+      method: "POST",
+      body: JSON.stringify({ name, arguments: args }),
+    });
+  }
+
   /**
    * Clone a GitHub repository and register its MCP server(s).
    *


### PR DESCRIPTION
## Summary

- **Resources tab**: browse all MCP resources and resource templates from a connected server. Supports reading resource content with a JSON/text/image viewer. Template resources (parametric URIs like `ui://dashboard/{city}`) show an inline param form before fetching.
- **Prompts tab**: list all prompts exposed by the server, fill argument forms, and preview the rendered message output inline.
- **Backend**: new `resources/templates/list` support in `InspectorSession` (merged with `resources/list`); new `prompts/list` + `prompts/get` endpoints in both `inspector_session.py` and `inspector.py`.
- **API client**: added `listInspectorPrompts` and `getInspectorPrompt` methods to `api.ts`.

## Stacking

This PR is stacked on top of #617 (4A). Base branch: `mcp-jam-phase4-scroll-fixes`.

## Test plan

- [x] Connect to a server that exposes resources (e.g. weather-mcp) — Resources tab shows list with mimeType badges
- [x] Resource templates (parametric URIs) show param input form; fetching fills the content viewer
- [x] Connect to a server with prompts — Prompts tab shows list with argument badges
- [x] Fill prompt args and click "Get Prompt" — messages render in the preview panel
- [x] Servers without resources/prompts show "None available" empty state gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)