### PR TITLE
FLUIDAI-832; fix: allow re-clone after MCP server deletion without manual MongoDB cleanup

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1281,6 +1281,9 @@ async def delete_server(
     if id in manager.configs:
         del manager.configs[id]
 
+    # Clean up stale instance state so a re-clone of the same server ID starts fresh
+    await manager.db.reset_instance_state(id)
+
     from datetime import datetime
     deleted_at = datetime.utcnow().isoformat()
     logger.info(f"Soft deleted server configuration: {id}")

--- a/fluidmcp/cli/repositories/base.py
+++ b/fluidmcp/cli/repositories/base.py
@@ -122,6 +122,23 @@ class PersistenceBackend(ABC):
         pass
 
     @abstractmethod
+    # TODO(auth): add user_id param to scope cleanup per-user once multi-user auth lands
+    async def reset_instance_state(self, server_id: str) -> bool:
+        """
+        Delete the instance state for a server.
+
+        Called when a server is soft-deleted so a subsequent re-clone starts
+        with a clean instance record (no stale PID, exit codes, etc.).
+
+        Args:
+            server_id: Server identifier
+
+        Returns:
+            True if the state was removed (or did not exist)
+        """
+        pass
+
+    @abstractmethod
     async def save_log_entry(self, log_entry: Dict[str, Any]) -> None:
         """
         Save log entry.

--- a/fluidmcp/cli/repositories/database.py
+++ b/fluidmcp/cli/repositories/database.py
@@ -624,6 +624,7 @@ class DatabaseManager(PersistenceBackend):
             logger.error(f"Error soft deleting server config: {e}")
             return False
 
+    # TODO(auth): add user_id param to scope cleanup per-user once multi-user auth lands
     async def reset_instance_state(self, server_id: str) -> bool:
         """
         Delete the instance state document for a server.
@@ -638,6 +639,8 @@ class DatabaseManager(PersistenceBackend):
             True if the document was removed (or did not exist)
         """
         try:
+            # TODO(auth): decide if delete should wipe all users' state or only the requesting user's;
+            # if per-user, change to delete_many({"server_id": server_id, "user_id": user_id})
             await self.db.fluidmcp_server_instances.delete_one({"server_id": server_id})
             return True
         except Exception as e:

--- a/fluidmcp/cli/repositories/database.py
+++ b/fluidmcp/cli/repositories/database.py
@@ -498,11 +498,14 @@ class DatabaseManager(PersistenceBackend):
             # Remove created_at from config to avoid conflict with $setOnInsert
             update_config = {k: v for k, v in config.items() if k != "created_at"}
 
-            # Upsert: update if exists, insert if not
+            # Upsert: update if exists, insert if not.
+            # $unset deleted_at so that re-saving a previously soft-deleted server
+            # (e.g. after the user deletes then re-clones the same repo) resurrects it.
             result = await self.db.fluidmcp_servers.update_one(
                 {"id": config["id"]},
                 {
                     "$set": update_config,
+                    "$unset": {"deleted_at": ""},
                     "$setOnInsert": {"created_at": datetime.utcnow()}
                 },
                 upsert=True
@@ -619,6 +622,26 @@ class DatabaseManager(PersistenceBackend):
             return result.modified_count > 0
         except Exception as e:
             logger.error(f"Error soft deleting server config: {e}")
+            return False
+
+    async def reset_instance_state(self, server_id: str) -> bool:
+        """
+        Delete the instance state document for a server.
+
+        Called when a server is soft-deleted so that a subsequent re-clone
+        starts with a clean instance record (no stale PID, exit codes, etc.).
+
+        Args:
+            server_id: Server identifier
+
+        Returns:
+            True if the document was removed (or did not exist)
+        """
+        try:
+            await self.db.fluidmcp_server_instances.delete_one({"server_id": server_id})
+            return True
+        except Exception as e:
+            logger.error(f"Error resetting instance state for '{server_id}': {e}")
             return False
 
     # ==================== Server Instance Operations ====================

--- a/fluidmcp/cli/repositories/memory.py
+++ b/fluidmcp/cli/repositories/memory.py
@@ -112,6 +112,12 @@ class InMemoryBackend(PersistenceBackend):
             return dict(state)
         return None
 
+    # TODO(auth): add user_id param to scope cleanup per-user once multi-user auth lands
+    async def reset_instance_state(self, server_id: str) -> bool:
+        """Delete instance state for a server from memory."""
+        self._instances.pop(server_id, None)
+        return True
+
     async def save_log_entry(self, log_entry: Dict[str, Any]) -> None:
         """Save log to memory (capped at 1000 lines per server)."""
         server_name = log_entry.get("server_name")


### PR DESCRIPTION
## Problem

When a user deletes an MCP server from the frontend and then tries to clone the same server again, the re-clone appeared to succeed but the server would disappear after a backend restart — requiring developer intervention to manually remove the stale MongoDB document.

**Root cause:** Deletion performs a soft delete (sets `deleted_at` on the MongoDB document). On re-clone, `save_server_config()` uses an upsert that matches the soft-deleted document and updates its fields — but never removes `deleted_at`. All queries filter `deleted_at: {$exists: False}`, so the record remains invisible after every restart even though the user successfully re-cloned it.

A secondary issue: the stale instance state (`fluidmcp_server_instances`) from the deleted server (old PID, exit codes) was left behind, confusing the UI after re-clone.

## Changes

**`fluidmcp/cli/repositories/database.py`**
- Added `$unset: {"deleted_at": ""}` to the `save_server_config()` upsert operation so re-saving a previously soft-deleted document automatically resurrects it.
- Added `reset_instance_state(server_id)` method that deletes the stale `fluidmcp_server_instances` document for a given server ID.

**`fluidmcp/cli/api/management.py`**
- `DELETE /servers/{id}` now calls `reset_instance_state()` after the soft delete so a subsequent re-clone starts with a clean instance record.

## Behaviour after fix

| Step | Before | After |
|------|--------|-------|
| Delete server | Soft-deleted in MongoDB | Same |
| Re-clone same server | Succeeds in-session only | Succeeds and persists across restarts |
| Backend restart | Server invisible (still soft-deleted) | Server visible and available |
| Instance state after re-clone | Stale PID / exit codes from old run | Clean state |

## Test plan

- [ ] Register a GitHub MCP server via `POST /api/servers/from-github`
- [ ] Delete it via `DELETE /api/servers/{id}` — confirm `deleted_at` is set in MongoDB
- [ ] Re-clone the same repo — should return 200 with no 409 conflict
- [ ] Restart the backend — server should still be listed and functional
- [ ] Confirm instance state shows no stale PID or exit codes after re-clone
- [ ] Run existing test suite: `pytest tests/`