### PR TITLE
MCP-487: Fix restart policy default

### DIFF
--- a/fluidmcp/cli/models/api.py
+++ b/fluidmcp/cli/models/api.py
@@ -32,7 +32,7 @@ class AddServerRequest(BaseModel):
     enabled: bool = Field(default=True, description="Whether server is enabled")
     mcp_config: MCPConfigRequest = Field(..., description="MCP server configuration")
     restart_policy: str = Field(
-        default="never",
+        default="on-failure",
         description="Restart policy: never, on-failure, or always",
         pattern="^(never|on-failure|always)$"
     )
@@ -160,7 +160,7 @@ class ServerListResponse(BaseModel):
                             "args": ["-y", "@modelcontextprotocol/server-filesystem"],
                             "env": {}
                         },
-                        "restart_policy": "never",
+                        "restart_policy": "on-failure",
                         "restart_window_sec": 300,
                         "max_restarts": 3,
                         "tools": [],
@@ -271,7 +271,7 @@ class AddServerFromGitHubRequest(BaseModel):
         description="Whether created server(s) should be enabled",
     )
     restart_policy: str = Field(
-        default="never",
+        default="on-failure",
         description="Restart policy: never, on-failure, or always",
         pattern="^(never|on-failure|always)$",
     )

--- a/fluidmcp/cli/models/models.py
+++ b/fluidmcp/cli/models/models.py
@@ -21,7 +21,7 @@ class ServerConfigDocument:
     enabled: bool = True                     # Whether server is enabled
     mcp_config: Dict[str, Any] = field(default_factory=dict)  # Nested: {command, args, env}
     env_metadata: Optional[Dict[str, Dict[str, Any]]] = None  # Metadata for env vars: {var_name: {required, description}}
-    restart_policy: str = "never"            # "never", "on-failure", "always"
+    restart_policy: str = "on-failure"        # "never", "on-failure", "always"
     restart_window_sec: int = 300            # Restart time window
     max_restarts: int = 3                    # Max restart attempts
     tools: List[Dict[str, Any]] = field(default_factory=list)  # Cached tool schemas

--- a/fluidmcp/cli/services/github_utils.py
+++ b/fluidmcp/cli/services/github_utils.py
@@ -475,7 +475,7 @@ class GitHubService:
         server_name: Optional[str] = None,
         subdirectory: Optional[str] = None,
         env: Optional[Dict] = None,
-        restart_policy: str = "never",
+        restart_policy: str = "on-failure",
         max_restarts: int = 3,
         enabled: bool = True,
         created_by: Optional[str] = None,


### PR DESCRIPTION
## Problem
MCP servers were defaulting to `restart_policy: "never"` when added without an explicit policy. This caused servers to stay in `failed` state permanently after a crash — the health monitor was running correctly but had no reason to act.

## Fix
Changed the default `restart_policy` from `"never"` to `"on-failure"` in:
- `ServerConfigDocument` (MongoDB schema)
- `AddServerRequest` (API model)
- `AddServerFromGitHubRequest` (GitHub add API model)
- `build_server_configs()` in `github_utils.py`

## Validation
- Confirmed `airbnb` server (with `on-failure` policy) auto-restarted within 35s after `kill -9`
- New PID assigned, `state: running`, `restart_count: 1`
- All 38 existing tests pass

## Impact
All new servers created after this change will automatically recover from crashes without requiring manual intervention.
