### PR TITLE
MCP-490: MCP Inspector 5A: multi-provider LLM + model selector

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -398,6 +398,11 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
         except Exception:
             pass
 
+        # Redact API key values echoed back in provider error messages
+        # e.g. "Incorrect API key provided: sk-abc123" or "provided: aaaaaaaaa"
+        import re as _re
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+
         is_auth = any(kw in err_str.lower() for kw in (
             "api key", "apikey", "invalid_api_key", "unauthorized",
             "authentication", "403", "401", "permission", "incorrect api key",

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -40,6 +40,10 @@ class ConnectRequest(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
+    provider: Optional[str] = "groq"       # "groq" | "openai" | "anthropic" | "gemini"
+    model: Optional[str] = None            # None → use provider default
+    api_key: Optional[str] = None          # None → fall back to env var
+    system_prompt: Optional[str] = None
 
 class ReadResourceRequest(BaseModel):
     uri: str
@@ -345,9 +349,15 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent, passing chat history for multi-turn context
+        # Call the agent with the requested provider/model/key
         agent_result = await choose_tool_with_llm(
-            body.message, tools, chat_history=body.chat_history or []
+            body.message,
+            tools,
+            chat_history=body.chat_history or [],
+            provider=body.provider or "groq",
+            model=body.model or None,
+            api_key=body.api_key or None,
+            system_prompt=body.system_prompt or None,
         )
 
         # Validate the response has the expected fields
@@ -371,8 +381,40 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
 
     except Exception as e:
         logger.error(f"Inspector chat error: {e}")
+        err_str = str(e)
+
+        # Try to extract just the human-readable message from provider error dicts
+        # e.g. "Error code: 401 - {'error': {'message': 'Incorrect API key...', ...}}"
+        user_message = err_str
+        try:
+            import re, ast
+            match = re.search(r"\{.*\}", err_str, re.DOTALL)
+            if match:
+                parsed = ast.literal_eval(match.group())
+                if isinstance(parsed, dict):
+                    inner = parsed.get("error", parsed)
+                    if isinstance(inner, dict) and "message" in inner:
+                        user_message = inner["message"]
+        except Exception:
+            pass
+
+        is_auth = any(kw in err_str.lower() for kw in (
+            "api key", "apikey", "invalid_api_key", "unauthorized",
+            "authentication", "403", "401", "permission", "incorrect api key",
+            "no api key provided", "insufficient_quota", "quota",
+        ))
+
+        if is_auth:
+            is_quota = any(kw in err_str.lower() for kw in ("quota", "insufficient_quota", "429"))
+            prefix = "Quota exceeded" if is_quota else "Authentication failed"
+            return {
+                "clarification_needed": True,
+                "message": f"{prefix}: {user_message}",
+                "error_type": "auth",
+            }
 
         return {
             "clarification_needed": True,
-            "message": "Unable to determine which tool to run."
+            "message": f"LLM error: {user_message}",
+            "error_type": "llm",
         }

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -4,6 +4,15 @@ import asyncio
 from loguru import logger
 
 
+# Default models per provider
+PROVIDER_DEFAULTS = {
+    "groq":      {"label": "Groq",      "model": "llama-3.1-8b-instant", "base_url": "https://api.groq.com/openai/v1"},
+    "openai":    {"label": "OpenAI",    "model": "gpt-4o-mini",           "base_url": "https://api.openai.com/v1"},
+    "gemini":    {"label": "Gemini",    "model": "gemini-2.0-flash",      "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"},
+    "anthropic": {"label": "Anthropic", "model": "claude-haiku-4-5-20251001", "base_url": None},
+}
+
+
 def format_tools_for_prompt(tools):
     """
     Convert MCP tools into a readable prompt format.
@@ -38,13 +47,24 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list | None = None):
+async def choose_tool_with_llm(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+):
     """
-    Universal MCP agent powered by Groq.
+    Universal MCP agent with multi-provider support.
 
-    Imports and initialises the Groq client lazily so the server can start
-    even when GROQ_API_KEY is absent — the error surfaces only when the chat
-    endpoint is actually called.
+    Supported providers: groq, openai, anthropic, gemini
+    - groq/openai/gemini: use the openai-compatible client
+    - anthropic: use the anthropic SDK directly
+
+    API keys are passed in from the frontend (stored in localStorage per provider).
+    Falls back to environment variables if no key is provided.
     """
 
     if chat_history is None:
@@ -53,23 +73,8 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list | N
     if not tools:
         raise RuntimeError("No tools available")
 
-    logger.info(f"Inspector chat message: {message}")
-
-    # Lazy imports — avoids startup failure when GROQ_API_KEY is absent
-    from dotenv import load_dotenv
-    from openai import OpenAI
-
-    load_dotenv()
-
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    if not groq_api_key:
-        raise RuntimeError("GROQ_API_KEY not configured")
-
-    # Build client inside the function — no module-level side effects
-    client = OpenAI(
-        api_key=groq_api_key,
-        base_url="https://api.groq.com/openai/v1"
-    )
+    provider = provider.lower()
+    logger.info(f"Inspector chat — provider={provider}, message={message!r}")
 
     tool_description = format_tools_for_prompt(tools)
 
@@ -87,24 +92,7 @@ Instructions:
 Return ONLY JSON.
 """
 
-    try:
-        # The OpenAI client is synchronous — run in a thread to avoid blocking
-        # the event loop.
-        # Build prior turns from chat_history for multi-turn context
-        history_messages = [
-            {"role": "user" if m.get("type") == "user" else "assistant",
-             "content": str(m.get("content", ""))}
-            for m in chat_history
-            if m.get("type") in ("user", "assistant") and m.get("content")
-        ]
-
-        def _call_llm():
-            return client.chat.completions.create(
-                model="llama-3.1-8b-instant",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": """
+    sys_content = system_prompt.strip() if system_prompt and system_prompt.strip() else """
 You are a strict JSON API for MCP tool selection.
 
 You MUST return ONLY valid JSON.
@@ -121,51 +109,158 @@ Rules:
 - No extra text
 - Always return JSON
 """
-                    },
-                    *history_messages,
-                    {
-                        "role": "user",
-                        "content": prompt
-                    }
-                ],
-                temperature=0,
-                max_tokens=200
-            )
 
-        response = await asyncio.to_thread(_call_llm)
+    history_messages = [
+        {"role": "user" if m.get("type") == "user" else "assistant",
+         "content": str(m.get("content", ""))}
+        for m in chat_history
+        if m.get("type") in ("user", "assistant") and m.get("content")
+    ]
 
-        content = response.choices[0].message.content.strip()
+    if provider == "anthropic":
+        return await _call_anthropic(
+            message=prompt,
+            sys_content=sys_content,
+            history_messages=history_messages,
+            model=model,
+            api_key=api_key,
+        )
+    else:
+        return await _call_openai_compatible(
+            message=prompt,
+            sys_content=sys_content,
+            history_messages=history_messages,
+            provider=provider,
+            model=model,
+            api_key=api_key,
+        )
 
-        logger.info(f"LLM raw response: {repr(content)}")
 
-        # First attempt: direct parse
-        try:
-            result = json.loads(content)
-            logger.info(f"LLM parsed result (direct): {result}")
-            return result
+async def _call_openai_compatible(
+    message: str,
+    sys_content: str,
+    history_messages: list,
+    provider: str,
+    model: str | None,
+    api_key: str | None,
+):
+    """Call Groq, OpenAI, or Gemini via the OpenAI-compatible client."""
+    from openai import OpenAI
+    from dotenv import load_dotenv
 
-        except json.JSONDecodeError:
-            logger.warning("Direct JSON parse failed, attempting extraction...")
+    load_dotenv()
 
-            # Fallback: extract JSON block
-            start = content.find("{")
-            end = content.rfind("}") + 1
+    defaults = PROVIDER_DEFAULTS.get(provider)
+    if not defaults:
+        raise RuntimeError(f"Unknown provider: {provider!r}")
 
-            if start == -1 or end == 0:
-                raise ValueError(f"No JSON found in LLM response: {content}")
+    resolved_model = model or defaults["model"]
+    base_url = defaults["base_url"]
 
-            json_str = content[start:end]
+    # Key resolution: explicit > env var
+    env_key_names = {
+        "groq":   "GROQ_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+    }
+    resolved_key = api_key or os.getenv(env_key_names.get(provider, ""), "")
+    if not resolved_key:
+        raise RuntimeError(
+            f"No API key provided for {defaults['label']}. "
+            "Please add your API key in the LLM settings."
+        )
 
-            try:
-                result = json.loads(json_str)
-                logger.info(f"LLM parsed result (extracted): {result}")
-                return result
+    # Gemini's OpenAI-compatible endpoint requires the key as a query param.
+    # Use default_query so the OpenAI client appends ?key=... to every request
+    # without corrupting the path (appending to base_url breaks path construction).
+    if provider == "gemini":
+        client = OpenAI(api_key="not-used", base_url=base_url, default_query={"key": resolved_key})
+    else:
+        client = OpenAI(api_key=resolved_key, base_url=base_url)
 
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to parse extracted JSON.\nRaw response: {content}\nExtracted: {json_str}"
-                ) from e
+    def _call():
+        return client.chat.completions.create(
+            model=resolved_model,
+            messages=[
+                {"role": "system", "content": sys_content},
+                *history_messages,
+                {"role": "user", "content": message},
+            ],
+            temperature=0,
+            max_tokens=200,
+        )
 
+    response = await asyncio.to_thread(_call)
+    content = response.choices[0].message.content.strip()
+    logger.info(f"[{provider}] raw response: {repr(content)}")
+    return _parse_json_response(content)
+
+
+async def _call_anthropic(
+    message: str,
+    sys_content: str,
+    history_messages: list,
+    model: str | None,
+    api_key: str | None,
+):
+    """Call Anthropic Claude via the anthropic SDK."""
+    from anthropic import Anthropic
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    resolved_model = model or "claude-haiku-4-5-20251001"
+    resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
+    if not resolved_key:
+        raise RuntimeError(
+            "No API key provided for Anthropic. "
+            "Please add your API key in the LLM settings."
+        )
+
+    client = Anthropic(api_key=resolved_key)
+
+    # Anthropic uses system param separately; convert history
+    anthropic_messages = []
+    for m in history_messages:
+        anthropic_messages.append({"role": m["role"], "content": m["content"]})
+    anthropic_messages.append({"role": "user", "content": message})
+
+    def _call():
+        return client.messages.create(
+            model=resolved_model,
+            system=sys_content,
+            messages=anthropic_messages,
+            temperature=0,
+            max_tokens=200,
+        )
+
+    response = await asyncio.to_thread(_call)
+    content = response.content[0].text.strip()
+    logger.info(f"[anthropic] raw response: {repr(content)}")
+    return _parse_json_response(content)
+
+
+def _parse_json_response(content: str) -> dict:
+    """Parse JSON from LLM response, with fallback extraction."""
+    try:
+        result = json.loads(content)
+        logger.info(f"LLM parsed result (direct): {result}")
+        return result
+    except json.JSONDecodeError:
+        logger.warning("Direct JSON parse failed, attempting extraction...")
+
+    start = content.find("{")
+    end = content.rfind("}") + 1
+
+    if start == -1 or end == 0:
+        raise ValueError(f"No JSON found in LLM response: {content}")
+
+    json_str = content[start:end]
+    try:
+        result = json.loads(json_str)
+        logger.info(f"LLM parsed result (extracted): {result}")
+        return result
     except Exception as e:
-        logger.error(f"Groq agent error: {e}")
-        raise
+        raise ValueError(
+            f"Failed to parse extracted JSON.\nRaw: {content}\nExtracted: {json_str}"
+        ) from e

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -130,7 +130,7 @@ function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: Executi
   const toolCall  = steps.find(s => s.type === "tool_call");
   const toolResult = steps.find(s => s.type === "tool_result");
   const errorStep = steps.find(s => s.type === "error");
-  const isActive  = !toolResult && !errorStep; // run still in progress
+  const isActive  = !toolResult && !errorStep && !run?.endTime; // run still in progress
 
   const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
   const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
@@ -424,6 +424,69 @@ export default function MCPInspector() {
   const [systemPrompt, setSystemPrompt] = useState("")
   const [systemPromptDraft, setSystemPromptDraft] = useState("")
   const [systemPromptOpen, setSystemPromptOpen] = useState(false)
+
+  // 5A: Multi-provider LLM selector
+  type LLMProvider = "groq" | "openai" | "anthropic" | "gemini"
+  const PROVIDER_DEFAULTS: Record<LLMProvider, { model: string; label: string; models: { id: string; label: string }[] }> = {
+    groq: {
+      label: "Groq", model: "llama-3.1-8b-instant",
+      models: [
+        { id: "llama-3.1-8b-instant",  label: "Llama 3.1 8B (fast)" },
+        { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B" },
+        { id: "llama-3.1-70b-versatile", label: "Llama 3.1 70B" },
+        { id: "mixtral-8x7b-32768",    label: "Mixtral 8x7B" },
+      ],
+    },
+    openai: {
+      label: "OpenAI", model: "gpt-4o-mini",
+      models: [
+        { id: "gpt-4o-mini",  label: "GPT-4o Mini (fast)" },
+        { id: "gpt-4o",       label: "GPT-4o" },
+        { id: "gpt-4-turbo",  label: "GPT-4 Turbo" },
+        { id: "o1-mini",      label: "o1 Mini" },
+      ],
+    },
+    anthropic: {
+      label: "Anthropic", model: "claude-haiku-4-5-20251001",
+      models: [
+        { id: "claude-haiku-4-5-20251001",  label: "Claude Haiku 4.5 (fast)" },
+        { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+        { id: "claude-opus-4-5",   label: "Claude Opus 4.5" },
+      ],
+    },
+    gemini: {
+      label: "Gemini", model: "gemini-2.0-flash",
+      models: [
+        { id: "gemini-2.0-flash",      label: "Gemini 2.0 Flash (fast)" },
+        { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
+        { id: "gemini-1.5-pro",        label: "Gemini 1.5 Pro" },
+        { id: "gemini-1.5-flash",      label: "Gemini 1.5 Flash" },
+      ],
+    },
+  }
+  const loadLLMSettings = () => {
+    try {
+      const raw = localStorage.getItem("fmcp_llm_settings")
+      if (raw) return JSON.parse(raw)
+    } catch { /* ignore */ }
+    return { provider: "groq", model: "llama-3.1-8b-instant", apiKeys: {} }
+  }
+  const [llmSettings, setLLMSettings] = useState<{
+    provider: LLMProvider; model: string; apiKeys: Record<string, string>
+  }>(loadLLMSettings)
+  const [llmSelectorOpen, setLLMSelectorOpen] = useState(false)
+  const [llmDraft, setLLMDraft] = useState(llmSettings)
+
+  const saveLLMSettings = (next: typeof llmSettings) => {
+    const providerChanged = next.provider !== llmSettings.provider || next.model !== llmSettings.model
+    setLLMSettings(next)
+    localStorage.setItem("fmcp_llm_settings", JSON.stringify(next))
+    // Clear chat for all servers when provider/model changes — history from a
+    // different model context is misleading and can confuse the new model
+    if (providerChanged) {
+      setChatHistoryByServer({})
+    }
+  }
 
   // Helper to update chat for the currently selected server
   const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
@@ -818,6 +881,11 @@ export default function MCPInspector() {
           type: m.type,
           content: m.content
         })),
+        provider: llmSettings.provider,
+        model: llmSettings.model,
+        ...(llmSettings.apiKeys[llmSettings.provider]
+          ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
+          : {}),
         ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
       }
     )
@@ -825,16 +893,20 @@ export default function MCPInspector() {
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
+      const isAuthError = res.error_type === "auth" || res.error_type === "llm"
+      // No runId — renders as a standalone red bubble below the (now-closed) run block
       const assistantMsg: ChatMessage = {
         id: generateId(),
-        runId,
         type: "assistant",
-        content: res.message,
+        content: isAuthError
+          ? res.message
+          : (res.message || "Could not determine which tool to run."),
         timestamp: Date.now(),
-        perfMark: performance.now()
+        perfMark: performance.now(),
+        ...(isAuthError ? { errorType: res.error_type } : {})
       }
       updateChat(prev => [...prev, assistantMsg])
-      // save run (no tool call — just clarification)
+      // Save run with endTime so isActive becomes false in ExecutionRunBlock
       setExecutionHistoryByServer(prev => ({
         ...prev,
         [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
@@ -892,17 +964,20 @@ export default function MCPInspector() {
 
   } catch (err: any) {
 
+    // Always clear the thinking bubble before showing the error
+    updateChat(prev => prev.filter((m: ChatMessage) => m.type !== "thinking"))
+
+    // No runId — renders as a standalone red bubble below the (now-closed) run block
     const errorMsg: ChatMessage = {
       id: generateId(),
-      runId,
-      type: "error",
-      content: err?.message || "Chat error",
+      type: "assistant",
+      content: err?.message || "Something went wrong. Check your LLM settings.",
       timestamp: Date.now(),
-      perfMark: performance.now()
-    }
+      perfMark: performance.now(),
+      errorType: "llm",
+    } as any
 
     updateChat(prev => [...prev, errorMsg])
-    runSteps.push(errorMsg)
 
     // save failed run
     setExecutionHistoryByServer(prev => ({
@@ -1761,24 +1836,39 @@ export default function MCPInspector() {
                               }
 
                               if (msg.type === "assistant") {
+                                const isErrMsg = !!(msg as any).errorType
                                 return (
                                   <React.Fragment key={msg.id}>
                                     <div style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
                                       <div style={{
                                         width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
-                                        background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                        background: isErrMsg ? "rgba(239,68,68,0.15)" : "rgba(99,102,241,0.2)",
+                                        border: `1px solid ${isErrMsg ? "rgba(239,68,68,0.4)" : "rgba(99,102,241,0.4)"}`,
                                         display: "flex", alignItems: "center", justifyContent: "center",
                                         fontSize: "0.65rem",
-                                      }}>🤖</div>
+                                      }}>{isErrMsg ? "⚠" : "🤖"}</div>
                                       <div style={{
-                                        background: "rgba(39,39,42,0.8)",
-                                        border: "1px solid rgba(63,63,70,0.6)",
+                                        background: isErrMsg ? "rgba(239,68,68,0.08)" : "rgba(39,39,42,0.8)",
+                                        border: `1px solid ${isErrMsg ? "rgba(239,68,68,0.35)" : "rgba(63,63,70,0.6)"}`,
                                         padding: "0.55rem 0.85rem",
                                         borderRadius: "4px 16px 16px 16px",
                                         maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                        color: "rgba(255,255,255,0.85)",
+                                        color: isErrMsg ? "rgba(252,165,165,0.9)" : "rgba(255,255,255,0.85)",
+                                        display: "flex", flexDirection: "column", gap: "0.5rem",
                                       }}>
-                                        {msg.content}
+                                        <span>{msg.content}</span>
+                                        {isErrMsg && (
+                                          <button
+                                            onClick={() => { setLLMDraft(llmSettings); setLLMSelectorOpen(true); }}
+                                            style={{
+                                              fontSize: "0.7rem", padding: "0.25rem 0.6rem", borderRadius: "6px", cursor: "pointer",
+                                              background: "rgba(239,68,68,0.15)", border: "1px solid rgba(239,68,68,0.35)",
+                                              color: "rgba(252,165,165,0.9)", alignSelf: "flex-start",
+                                            }}
+                                          >
+                                            Fix LLM settings
+                                          </button>
+                                        )}
                                       </div>
                                     </div>
                                     {isLast && <div ref={chatBottomRef} />}
@@ -1796,14 +1886,19 @@ export default function MCPInspector() {
 
                             {/* ── Toolbar row: model badge · system prompt · clear ── */}
                             <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
-                              {/* Model badge */}
-                              <span style={{
-                                fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
-                                background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
-                                color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
-                              }}>
-                                Groq · llama-3.1-8b
-                              </span>
+                              {/* Model badge — clickable to open LLM selector */}
+                              <button
+                                onClick={() => { setLLMDraft(llmSettings); setLLMSelectorOpen(true); }}
+                                title="Change LLM provider / model"
+                                style={{
+                                  fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                  background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
+                                  color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
+                                  cursor: "pointer",
+                                }}
+                              >
+                                {PROVIDER_DEFAULTS[llmSettings.provider]?.label ?? llmSettings.provider} · {llmSettings.model.length > 20 ? llmSettings.model.slice(0, 20) + "…" : llmSettings.model}
+                              </button>
 
                               {/* System prompt button */}
                               <button
@@ -1869,6 +1964,139 @@ export default function MCPInspector() {
                                     </button>
                                     <button
                                       onClick={() => { setSystemPrompt(systemPromptDraft); setSystemPromptOpen(false); }}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
+                                    >
+                                      Save
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* ── LLM selector dialog ── */}
+                            {llmSelectorOpen && (
+                              <div style={{
+                                position: "fixed", inset: 0, zIndex: 50,
+                                background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center",
+                              }}
+                                onClick={(e) => { if (e.target === e.currentTarget) setLLMSelectorOpen(false); }}
+                              >
+                                <div style={{
+                                  background: "#18181b", border: "1px solid rgba(63,63,70,0.7)",
+                                  borderRadius: "12px", padding: "1.25rem", width: "420px", maxWidth: "90vw",
+                                  display: "flex", flexDirection: "column", gap: "0.85rem",
+                                }}>
+                                  <div style={{ fontSize: "0.9rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>LLM Settings</div>
+
+                                  {/* Warning when provider/model differs from saved */}
+                                  {(llmDraft.provider !== llmSettings.provider || llmDraft.model !== llmSettings.model) && chatHistory.length > 0 && (
+                                    <div style={{
+                                      fontSize: "0.72rem", padding: "0.4rem 0.65rem", borderRadius: "6px",
+                                      background: "rgba(234,179,8,0.1)", border: "1px solid rgba(234,179,8,0.3)",
+                                      color: "rgba(253,224,71,0.85)", display: "flex", alignItems: "center", gap: "0.4rem",
+                                    }}>
+                                      ⚠ Changing provider or model will clear the current chat
+                                    </div>
+                                  )}
+
+                                  {/* Provider selector */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>Provider</label>
+                                    <div style={{ display: "flex", gap: "0.4rem", flexWrap: "wrap" }}>
+                                      {(["groq", "openai", "anthropic", "gemini"] as LLMProvider[]).map(p => (
+                                        <button key={p}
+                                          onClick={() => setLLMDraft(d => ({
+                                            ...d,
+                                            provider: p,
+                                            model: PROVIDER_DEFAULTS[p].model,
+                                          }))}
+                                          style={{
+                                            fontSize: "0.75rem", padding: "0.3rem 0.7rem", borderRadius: "6px", cursor: "pointer",
+                                            background: llmDraft.provider === p ? "rgba(99,102,241,0.8)" : "rgba(39,39,42,0.8)",
+                                            border: llmDraft.provider === p ? "1px solid rgba(99,102,241,0.6)" : "1px solid rgba(63,63,70,0.5)",
+                                            color: llmDraft.provider === p ? "#fff" : "rgba(255,255,255,0.6)",
+                                            fontWeight: llmDraft.provider === p ? 600 : 400,
+                                          }}
+                                        >
+                                          {PROVIDER_DEFAULTS[p].label}
+                                        </button>
+                                      ))}
+                                    </div>
+                                  </div>
+
+                                  {/* Model selector */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>Model</label>
+                                    <select
+                                      value={PROVIDER_DEFAULTS[llmDraft.provider].models.some(m => m.id === llmDraft.model) ? llmDraft.model : "__custom__"}
+                                      onChange={e => {
+                                        if (e.target.value !== "__custom__") {
+                                          setLLMDraft(d => ({ ...d, model: e.target.value }))
+                                        }
+                                      }}
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                        borderRadius: "6px", padding: "0.45rem 0.6rem",
+                                        color: "#fff", fontSize: "0.8rem", fontFamily: "monospace",
+                                        cursor: "pointer",
+                                      }}
+                                    >
+                                      {PROVIDER_DEFAULTS[llmDraft.provider].models.map(m => (
+                                        <option key={m.id} value={m.id}>{m.label}</option>
+                                      ))}
+                                      <option value="__custom__" disabled style={{ color: "rgba(255,255,255,0.4)" }}>
+                                        ── custom (type below) ──
+                                      </option>
+                                    </select>
+                                    {/* Custom model input — shown when selection isn't in the list */}
+                                    <input
+                                      value={llmDraft.model}
+                                      onChange={e => setLLMDraft(d => ({ ...d, model: e.target.value }))}
+                                      placeholder="or type a custom model ID"
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.4)",
+                                        borderRadius: "6px", padding: "0.4rem 0.6rem",
+                                        color: "rgba(255,255,255,0.7)", fontSize: "0.75rem", fontFamily: "monospace",
+                                      }}
+                                    />
+                                  </div>
+
+                                  {/* API key input */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>
+                                      API Key
+                                      {llmDraft.provider === "groq" && (
+                                        <span style={{ marginLeft: "0.4rem", color: "rgba(134,239,172,0.7)" }}>(free key at console.groq.com)</span>
+                                      )}
+                                    </label>
+                                    <input
+                                      type="password"
+                                      value={llmDraft.apiKeys[llmDraft.provider] ?? ""}
+                                      onChange={e => setLLMDraft(d => ({
+                                        ...d,
+                                        apiKeys: { ...d.apiKeys, [d.provider]: e.target.value }
+                                      }))}
+                                      placeholder={llmDraft.provider === "groq" ? "gsk_... (leave blank for env var)" : "Paste your API key"}
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                        borderRadius: "6px", padding: "0.45rem 0.6rem",
+                                        color: "#fff", fontSize: "0.8rem", fontFamily: "monospace",
+                                      }}
+                                    />
+                                    <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)" }}>
+                                      Stored in localStorage · never sent to FluidMCP servers
+                                    </span>
+                                  </div>
+
+                                  <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                                    <button
+                                      onClick={() => setLLMSelectorOpen(false)}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "transparent", border: "1px solid rgba(63,63,70,0.5)", color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                                    >
+                                      Cancel
+                                    </button>
+                                    <button
+                                      onClick={() => { saveLLMSettings(llmDraft); setLLMSelectorOpen(false); }}
                                       style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
                                     >
                                       Save


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `Groq · llama-3.1-8b-instant` badge with a clickable multi-provider LLM selector
- Supports **Groq** (default, free), **OpenAI**, **Anthropic**, and **Gemini** — users bring their own API keys
- Clean error UX: auth failures and quota errors show a red bubble with a "Fix LLM settings" button instead of a stuck thinking state

## What changed

**Backend**
- `inspector_agent.py` — multi-provider routing: OpenAI-compatible client for Groq/OpenAI/Gemini, Anthropic SDK for Anthropic; Gemini uses `default_query` for required `?key=` param; clean user-facing error messages (no env var names or raw provider dicts exposed)
- `inspector.py` — `ChatRequest` now accepts `provider`, `model`, `api_key`, `system_prompt` fields

**Frontend**
- `MCPInspector.tsx` — clickable model badge opens settings dialog with provider pills, per-provider model dropdown (presets + custom text input), API key password field; settings persist in localStorage; warning shown when provider/model change will clear chat history; thinking state clears correctly on all error paths; red error bubble + Fix LLM settings button on failures

## Test plan
- [ ] Groq (no key) — works out of the box
- [ ] OpenAI — valid key routes correctly; invalid key shows red error + Fix button
- [ ] Anthropic — valid key routes correctly
- [ ] Gemini — valid key routes correctly (uses `?key=` query param per Google docs)
- [ ] No key provided — shows "No API key provided for X" with Fix button (no env var names leaked)
- [ ] Quota exceeded — shows "Quota exceeded: ..." message
- [ ] Switch provider with active chat — yellow warning appears in dialog; chat clears on save
- [ ] Switch provider with empty chat — no warning shown
