### PR TITLE
MCP-498: Add JSON upload to auto-fill Add Server form + duplicate ID guard

### DIFF
--- a/fluidmcp/frontend/src/components/ServerForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerForm.tsx
@@ -1,13 +1,14 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 interface ServerFormProps {
   mode: 'create' | 'edit';
   initialData?: any;
+  existingIds?: string[];
   onSubmit: (data: any) => Promise<boolean>;
   onCancel: () => void;
 }
 
-export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSubmit, onCancel }) => {
+export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, existingIds = [], onSubmit, onCancel }) => {
   const [formData, setFormData] = useState({
     id: initialData?.id || '',
     name: initialData?.name || '',
@@ -19,6 +20,57 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
   });
 
   const [submitting, setSubmitting] = useState(false);
+  const [jsonError, setJsonError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const idConflict = mode === 'create' && formData.id.length > 0 && existingIds.includes(formData.id);
+
+  const handleJsonUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setJsonError('');
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string);
+
+        // Support two formats:
+        // 1. { "mcpServers": { "server-id": { command, args, env, ... } } }
+        // 2. Direct config: { command, args, env, id, name, description, ... }
+        let serverId = '';
+        let serverConfig: any = parsed;
+
+        if (parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+          const entries = Object.entries(parsed.mcpServers);
+          if (entries.length === 0) {
+            setJsonError('No servers found in mcpServers object.');
+            return;
+          }
+          [serverId, serverConfig] = entries[0] as [string, any];
+        }
+
+        const envEntries = Object.entries(serverConfig?.env || {})
+          .map(([k, v]) => `${k}=${v}`)
+          .join('\n');
+
+        setFormData(prev => ({
+          ...prev,
+          id: (serverId || serverConfig?.id || prev.id).toLowerCase().replace(/[^a-z0-9-]/g, '-'),
+          name: serverConfig?.name || prev.name,
+          description: serverConfig?.description || prev.description,
+          command: serverConfig?.command || prev.command,
+          args: Array.isArray(serverConfig?.args) ? serverConfig.args.join(' ') : (serverConfig?.args || prev.args),
+          env: envEntries,
+        }));
+      } catch {
+        setJsonError('Invalid JSON file. Please check the file and try again.');
+      }
+    };
+    reader.readAsText(file);
+    // Reset input so the same file can be re-uploaded if needed
+    e.target.value = '';
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,6 +126,35 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* JSON Upload — create mode only */}
+      {mode === 'create' && (
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleJsonUpload}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full flex items-center justify-center space-x-2 px-4 py-3 border-2 border-dashed border-zinc-600 rounded-lg text-zinc-400 hover:border-blue-500 hover:text-blue-400 transition-colors"
+          >
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+            </svg>
+            <span className="text-sm font-medium">Upload JSON config to auto-fill</span>
+          </button>
+          {jsonError && (
+            <p className="mt-1 text-xs text-red-400">{jsonError}</p>
+          )}
+          <p className="mt-1 text-xs text-zinc-500">
+            Accepts MCP config format: <code className="font-mono">{"{ mcpServers: { id: { command, args, env } } }"}</code>
+          </p>
+        </div>
+      )}
+
       {/* Server ID */}
       <div>
         <label className="block text-sm font-medium text-zinc-200 mb-2">
@@ -84,13 +165,23 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
           value={formData.id}
           onChange={(e) => setFormData({ ...formData, id: e.target.value.toLowerCase() })}
           disabled={mode === 'edit'}
-          className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 text-white placeholder-zinc-400 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-zinc-900/50 disabled:cursor-not-allowed disabled:text-zinc-500"
+          className={`w-full px-3 py-2 bg-zinc-800/50 border text-white placeholder-zinc-400 rounded-lg focus:ring-2 disabled:bg-zinc-900/50 disabled:cursor-not-allowed disabled:text-zinc-500 ${
+            idConflict
+              ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
+              : 'border-zinc-700 focus:ring-blue-500 focus:border-blue-500'
+          }`}
           placeholder="my-server-id"
           required
         />
-        <p className="mt-1 text-xs text-zinc-400">
-          Lowercase letters, numbers, hyphens only. Cannot be changed after creation.
-        </p>
+        {idConflict ? (
+          <p className="mt-1 text-xs text-red-400">
+            A server with this ID already exists. Choose a different ID.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-zinc-400">
+            Lowercase letters, numbers, hyphens only. Cannot be changed after creation.
+          </p>
+        )}
       </div>
 
       {/* Server Name */}
@@ -203,7 +294,7 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
         <button
           type="submit"
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          disabled={submitting}
+          disabled={submitting || idConflict}
         >
           {submitting ? 'Saving...' : mode === 'create' ? 'Create Server' : 'Save Changes'}
         </button>

--- a/fluidmcp/frontend/src/pages/ManageServers.tsx
+++ b/fluidmcp/frontend/src/pages/ManageServers.tsx
@@ -232,6 +232,7 @@ export default function ManageServers() {
                     <ServerForm
                       mode="create"
                       initialData={null}
+                      existingIds={servers.map(s => s.id)}
                       onSubmit={handleFormSubmit}
                       onCancel={() => setShowForm(false)}
                     />


### PR DESCRIPTION
### Additions
- Upload button in create mode parses a JSON file (MCP config format or direct flat config) and pre-fills command, args, env, id, name, description
- Real-time duplicate ID detection: red border + inline error + disabled submit when typed/uploaded ID matches an existing server
- No changes to submission or persistence logic
