### PR TITLE
[MCP-457]-docs: Add onboarding tutorial for EventLoopWatchdog and MCPHealthMonitor

### DIFF
--- a/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
+++ b/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
@@ -9,12 +9,12 @@
 
 Two background monitors:
 
-| Monitor | File | Purpose |
-|---------|------|---------|
-| `EventLoopWatchdog` | [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | Measures asyncio event loop lag — detects blocking calls |
-| `MCPHealthMonitor` | [`fluidmcp/cli/services/server_manager.py`](../../../fluidmcp/cli/services/server_manager.py) | Polls MCP subprocess liveness — auto-restarts crashed servers |
+| Monitor | File | Status |
+|---------|------|--------|
+| `EventLoopWatchdog` | [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | Implemented — not yet merged to main, not yet wired into `server.py` |
+| `MCPHealthMonitor` | [`fluidmcp/cli/services/server_manager.py`](../../../fluidmcp/cli/services/server_manager.py) | Implemented and wired into `server.py` |
 
-> **Integration status:** `MCPHealthMonitor` is started automatically when `fmcp serve` runs (wired into `server.py`). `EventLoopWatchdog` is implemented and ready to use but is not yet wired into `server.py`.
+> **Note on EventLoopWatchdog:** The implementation exists on feature branches but has not yet merged to `main`. The sections below document what was built. Once merged, it can be wired into `server.py` following the same lifecycle pattern as `MCPHealthMonitor`.
 
 ---
 
@@ -31,12 +31,13 @@ Two background monitors:
 |  |  Background asyncio  |    |  Background asyncio task.            |   |
 |  |  task -- measures    |    |  Polls every 30s. For each server:   |   |
 |  |  sleep() drift       |    |    * stdio: process.poll()           |   |
-|  |  every 10s.          |    |    * SSE: psutil check_process_alive |   |
-|  |                      |    |    * if dead -> _cleanup_server()    |   |
-|  |  lag > 0.5s -> WARN  |    |    * if restart policy allows ->     |   |
-|  |  lag > 2.0s -> ERROR |    |      backoff delay -> restart        |   |
-|  |                      |    |                                      |   |
-|  |  (not yet wired into |    |                                      |   |
+|  |  every 10s.          |    |    * SSE: HealthChecker              |   |
+|  |                      |    |      .check_process_alive(pid)       |   |
+|  |  lag > 0.5s -> WARN  |    |      (uses psutil internally)        |   |
+|  |  lag > 2.0s -> ERROR |    |    * if dead -> acquire op_lock      |   |
+|  |                      |    |      -> _cleanup_server()            |   |
+|  |  (not yet on main /  |    |    * if restart policy allows ->     |   |
+|  |   not yet wired into |    |      backoff delay -> restart        |   |
 |  |   server.py)         |    |                                      |   |
 |  +----------------------+    +--------------------------------------+   |
 |             |                               |                           |
@@ -51,6 +52,8 @@ Two background monitors:
 ---
 
 ## EventLoopWatchdog
+
+> **Status:** Implementation exists on feature branches, not yet merged to `main`.
 
 ### How it works
 
@@ -132,10 +135,14 @@ await watchdog.stop()  # cancels task, awaits CancelledError, sets _task = None
 
 ### How it works
 
-Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_INTERVAL` env var) the monitor iterates all running MCP server processes and checks liveness:
+Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_INTERVAL` env var) the monitor iterates all running MCP server processes and checks liveness. An additional env var `FMCP_RESTART_TIMEOUT_S` (default 60s) controls how long a restart attempt is allowed to run before it is cancelled:
 
 - **stdio servers** (`subprocess.Popen`): `process.poll()` — non-None return means the process has exited
-- **SSE servers** (`SseSubprocessHandle`): `health_checker.check_process_alive(pid)` via psutil
+- **SSE servers** (`SseSubprocessHandle`): `HealthChecker.check_process_alive(pid)` — a wrapper around psutil that checks the process is alive by PID
+
+### Restart count — in-memory vs database
+
+`MCPHealthMonitor` tracks restart attempts in `self._restart_counts` — an **in-memory dict** keyed by `server_id`. This is separate from any `restart_count` stored in the database instance state. The in-memory count is used solely to enforce `max_restarts` within the lifetime of the current monitor. It resets to zero (for a given server) after 5 minutes of sustained healthy uptime, or when the monitor process restarts.
 
 ### Flow
 
@@ -152,7 +159,7 @@ _monitor_loop() runs every 30s
     _check_server(server_id, process)
         |
         +-- stdio: process.poll() is None  ->  alive
-        +-- SSE:   check_process_alive()   ->  alive
+        +-- SSE:   HealthChecker.check_process_alive()  ->  alive
         |
         +-- process has exited
                 |
@@ -162,7 +169,9 @@ _monitor_loop() runs every 30s
                 v
             get config from DB
                 |
-                +-- config missing  ->  _cleanup_server() only, no restart
+                +-- config missing
+                |     acquire op_lock
+                |     _cleanup_server() only, no restart
                 |
                 +-- config found
                         |
@@ -173,7 +182,7 @@ _monitor_loop() runs every 30s
                     restart_policy == "on-failure" and exit_code == 0?  ->  cleanup only
                         |
                         v
-                    restart_count >= max_restarts?
+                    _restart_counts[server_id] >= max_restarts?
                         ->  cleanup only, log warning
                         ->  server stays stopped until operator manually restarts via API
                         |
@@ -186,9 +195,9 @@ _monitor_loop() runs every 30s
                     _cleanup_server(server_id, exit_code)
                     asyncio.wait_for(_start_server_unlocked(), timeout=60s)  <- FMCP_RESTART_TIMEOUT_S
                         |
-                        +-- success  ->  log info, increment restart_count
-                        +-- timeout  ->  log error, increment restart_count
-                        +-- failure  ->  log error, increment restart_count
+                        +-- success  ->  log info, increment _restart_counts[server_id]
+                        +-- timeout  ->  log error, increment _restart_counts[server_id]
+                        +-- failure  ->  log error, increment _restart_counts[server_id]
         |
         v
     await asyncio.sleep(check_interval)
@@ -196,18 +205,18 @@ _monitor_loop() runs every 30s
 
 ### Restart count reset
 
-The restart count for a server resets only after **5 minutes of sustained healthy uptime** (checked on the next poll cycle where the process is still alive). This prevents a flapping server from getting a "fresh start" too soon and exhausting `max_restarts` across many short-lived restart cycles.
+The in-memory `_restart_counts[server_id]` resets only after **5 minutes of sustained healthy uptime** (checked on the next poll cycle where the process is still alive). This prevents a flapping server from getting a "fresh start" too soon and exhausting `max_restarts` across many short-lived restart cycles.
 
 ### After max_restarts is hit
 
-Once `restart_count >= max_restarts`, the monitor stops attempting restarts. The server process stays stopped. **An operator must manually restart it** via the management API:
+Once `_restart_counts[server_id] >= max_restarts`, the monitor stops attempting restarts. The server process stays stopped. **An operator must manually restart it** via the management API:
 
 ```bash
 curl -X POST http://localhost:<port>/api/servers/<server_id>/start \
   -H "Authorization: Bearer <token>"
 ```
 
-The restart count does not automatically reset — the server will not self-recover without manual intervention.
+The in-memory restart count does not automatically reset — the server will not self-recover without manual intervention.
 
 ### Env vars
 
@@ -241,27 +250,34 @@ restart 5+ -> 160s  (maximum)
 
 ## Startup & Shutdown Integration (`server.py`)
 
-`MCPHealthMonitor` is integrated into `server.py`. The current startup order is:
+`MCPHealthMonitor` is integrated into `server.py`. The complete startup and shutdown order:
 
 ```python
 # server.py -- main()
 
-# 1. Start health monitor BEFORE create_app()
+# 1. Create ServerManager
+server_manager = ServerManager(persistence)
+
+# 2. Start idle cleanup task
+server_manager.start_idle_cleanup_task()
+
+# 3. Start health monitor
 health_monitor = MCPHealthMonitor(server_manager, check_interval=health_check_interval)
 health_monitor.start()
 
-# 2. Create FastAPI app
+# 4. Create FastAPI app
 app = await create_app(...)
 
 # ... server runs until shutdown signal ...
 
-# 3. Shutdown order
+# 5. Shutdown order
 await health_monitor.stop()                    # stop monitor first
 await server_manager.stop_idle_cleanup_task()  # stop idle cleanup
-await server_manager.shutdown_all()            # stop all MCP processes last
+await server_manager.shutdown_all()            # stop all MCP processes
+await persistence.disconnect()                 # close DB connection last
 ```
 
-> `EventLoopWatchdog` is not yet wired into `server.py`. The class is ready in `watchdog.py` and can be added to the lifecycle above when needed.
+> `EventLoopWatchdog` is not yet wired into `server.py`. Once `watchdog.py` is merged to `main`, it can be added between steps 3 and 4, with `await loop_watchdog.stop()` added to the shutdown sequence after `health_monitor.stop()`.
 
 ---
 
@@ -269,7 +285,7 @@ await server_manager.shutdown_all()            # stop all MCP processes last
 
 | File | Role |
 |------|------|
-| [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | `EventLoopWatchdog` + `_get_env_float()` |
+| [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | `EventLoopWatchdog` + `_get_env_float()` (not yet on main) |
 | [`fluidmcp/cli/services/server_manager.py`](../../../fluidmcp/cli/services/server_manager.py) | `MCPHealthMonitor` + `_check_server()` + `_calculate_restart_delay()` |
 | [`fluidmcp/cli/server.py`](../../../fluidmcp/cli/server.py) | `MCPHealthMonitor` start/stop integration in `main()` |
 | [`tests/test_server_manager_cleanup.py`](../../../tests/test_server_manager_cleanup.py) | Tests for `ServerManager` shutdown and process cleanup |

--- a/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
+++ b/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
@@ -1,0 +1,255 @@
+# EventLoopWatchdog & MCPHealthMonitor — Overview
+
+**Target audience:** New developers joining the FluidMCP project
+**Scope:** Two background monitors added for production stability — `EventLoopWatchdog` (asyncio lag detection) and `MCPHealthMonitor` (MCP process liveness + auto-restart)
+
+---
+
+## What Was Built
+
+Two background monitors:
+
+| Monitor | File | Purpose |
+|---------|------|---------|
+| `EventLoopWatchdog` | `fluidmcp/cli/services/watchdog.py` | Measures asyncio event loop lag — detects blocking calls |
+| `MCPHealthMonitor` | `fluidmcp/cli/services/server_manager.py` | Polls MCP subprocess liveness — auto-restarts crashed servers |
+
+> **Integration status:** `MCPHealthMonitor` is started automatically when `fmcp serve` runs (wired into `server.py`). `EventLoopWatchdog` is implemented and ready to use but is not yet wired into `server.py`.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  fmcp serve  (server.py — main() coroutine)                             │
+│                                                                         │
+│  ┌──────────────────────┐    ┌──────────────────────────────────────┐   │
+│  │  EventLoopWatchdog   │    │        MCPHealthMonitor              │   │
+│  │  watchdog.py         │    │  server_manager.py                   │   │
+│  │                      │    │                                      │   │
+│  │  Background asyncio  │    │  Background asyncio task.            │   │
+│  │  task — measures     │    │  Polls every 30s. For each server:   │   │
+│  │  sleep() drift       │    │    • stdio: process.poll()           │   │
+│  │  every 10s.          │    │    • SSE: psutil check_process_alive │   │
+│  │                      │    │    • if dead → _cleanup_server()     │   │
+│  │  lag > 0.5s → WARN   │    │    • if restart policy allows →      │   │
+│  │  lag > 2.0s → ERROR  │    │      backoff delay → restart         │   │
+│  │                      │    │                                      │   │
+│  │  (not yet wired into │    │                                      │   │
+│  │   server.py)         │    │                                      │   │
+│  └──────────────────────┘    └──────────────────────────────────────┘   │
+│             │                               │                           │
+│             ▼                               ▼                           │
+│       Loguru logger                   ServerManager                     │
+│       (structured logs)               _cleanup_server() →               │
+│                                         db.save_crash_event()           │
+│                                         db.save_instance_state()        │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## EventLoopWatchdog
+
+### How it works
+
+Every `_CHECK_INTERVAL` seconds the watchdog does:
+
+```
+before = time.monotonic()
+await asyncio.sleep(_CHECK_INTERVAL)
+lag = time.monotonic() - before - _CHECK_INTERVAL
+```
+
+If `lag` is large, the event loop was blocked during that sleep — a synchronous call, CPU-heavy coroutine, or I/O contention held the loop and prevented other tasks from running.
+
+### Flow
+
+```
+watchdog._loop() starts
+        │
+        ▼
+    record before = time.monotonic()
+        │
+        ▼
+    await asyncio.sleep(10s)   ← yields control to event loop
+        │
+        ▼
+    lag = wall_clock_delta - 10s
+        │
+        ├── lag >= 2.0s  →  logger.error("Event loop lag Xs exceeds error threshold")
+        ├── lag >= 0.5s  →  logger.warning("Event loop lag Xs exceeds warn threshold")
+        └── lag < 0.5s   →  (no log — healthy)
+        │
+        ▼
+    loop back ──────────────────────────────────────────────────────────┐
+```
+
+### Env vars
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `FMCP_LOOP_LAG_WARN_S` | `0.5` | Log WARNING if lag exceeds this (seconds) |
+| `FMCP_LOOP_LAG_ERROR_S` | `2.0` | Log ERROR if lag exceeds this (seconds) |
+| `FMCP_LOOP_LAG_INTERVAL_S` | `10.0` | How often to measure (min: 0.001s) |
+
+> All three are read at **module import time** via `_get_env_float()` and stored in module-level constants (`_WARN_THRESHOLD`, `_ERROR_THRESHOLD`, `_CHECK_INTERVAL`). Changing them at runtime has no effect.
+
+### Safe env var parsing — `_get_env_float()`
+
+```python
+# watchdog.py
+def _get_env_float(name, default, min_value=None):
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return default          # bad value → silent fallback
+    if min_value is not None and value < min_value:
+        return default          # below min → fallback
+    return value
+```
+
+> Called at **module import time** (to set `_WARN_THRESHOLD` etc.), so it must NOT call `logger` — loguru may not be configured yet. Invalid env values fall back silently.
+
+### Lifecycle
+
+```python
+watchdog = EventLoopWatchdog()
+watchdog.start()   # creates asyncio.Task, guards against duplicate start
+...
+await watchdog.stop()  # cancels task, awaits CancelledError, sets _task = None
+```
+
+---
+
+## MCPHealthMonitor
+
+### How it works
+
+Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_INTERVAL` env var) the monitor iterates all running MCP server processes and checks liveness. An additional env var `FMCP_RESTART_TIMEOUT_S` (default 60s) controls how long a restart attempt is allowed to run before it is cancelled:
+
+- **stdio servers** (`subprocess.Popen`): `process.poll()` — non-None return means the process has exited
+- **SSE servers** (`SseSubprocessHandle`): `health_checker.check_process_alive(pid)` via psutil
+
+### Flow
+
+```
+_monitor_loop() runs every 30s
+        │
+        ▼
+    snapshot = list(server_manager.processes.items())
+        │
+        ▼
+    for each (server_id, process):
+        │
+        ▼
+    _check_server(server_id, process)
+        │
+        ├── stdio: process.poll() is None  →  alive
+        ├── SSE:   check_process_alive()   →  alive
+        │
+        └── process has exited
+                │
+                ▼
+            already in _restarts_in_progress?  →  skip (no duplicate)
+                │
+                ▼
+            get config from DB
+                │
+                ├── config missing  →  _cleanup_server() only, no restart
+                │
+                └── config found
+                        │
+                        ▼
+                    restart_policy == "never"?  →  cleanup only
+                        │
+                        ▼
+                    restart_policy == "on-failure" and exit_code == 0?  →  cleanup only
+                        │
+                        ▼
+                    restart_count >= max_restarts?  →  cleanup only, log warning
+                        │
+                        ▼
+                    calculate backoff delay
+                    await asyncio.sleep(delay)
+                        │
+                        ▼
+                    acquire op_lock
+                    _cleanup_server(server_id, exit_code)
+                    _start_server_unlocked(server_id, config)
+                        │
+                        ├── success  →  log info, increment restart_count
+                        └── failure  →  log error, increment restart_count
+        │
+        ▼
+    restart_count resets only after 5 minutes of sustained healthy uptime
+```
+
+### Env vars
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `FMCP_HEALTH_CHECK_INTERVAL` | `30` | Seconds between health-check polls (integer) |
+| `FMCP_RESTART_TIMEOUT_S` | `60` | Seconds before a restart attempt is cancelled |
+
+### Exponential backoff
+
+```
+delay = 5s × 2^min(restart_count, 5)
+
+restart 0 →   5s
+restart 1 →  10s
+restart 2 →  20s
+restart 3 →  40s
+restart 4 →  80s
+restart 5+ → 160s  (maximum)
+```
+
+### Restart policies
+
+| Policy | Behaviour |
+|--------|-----------|
+| `"on-failure"` | Restart only on non-zero exit code (default when field is omitted) |
+| `"always"` | Restart on any exit (including exit 0) |
+| `"never"` | No automatic restart |
+
+---
+
+## Startup & Shutdown Integration (`server.py`)
+
+`MCPHealthMonitor` is integrated into `server.py`. The current startup order is:
+
+```python
+# server.py — main()
+
+# 1. Start health monitor BEFORE create_app()
+health_monitor = MCPHealthMonitor(server_manager, check_interval=health_check_interval)
+health_monitor.start()
+
+# 2. Create FastAPI app
+app = await create_app(...)
+
+# ... server runs until shutdown signal ...
+
+# 3. Shutdown order
+await health_monitor.stop()                  # stop monitor first
+await server_manager.stop_idle_cleanup_task()  # stop idle cleanup
+await server_manager.shutdown_all()          # stop all MCP processes last
+```
+
+> `EventLoopWatchdog` is not yet wired into `server.py`. The class is ready in `watchdog.py` and can be added to the lifecycle above when needed.
+
+---
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `fluidmcp/cli/services/watchdog.py` | `EventLoopWatchdog` + `_get_env_float()` |
+| `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor` + `_check_server()` + `_calculate_restart_delay()` |
+| `fluidmcp/cli/server.py` | `MCPHealthMonitor` start/stop integration in `main()` |
+| `tests/test_server_manager_cleanup.py` | Tests for `ServerManager` shutdown and process cleanup |

--- a/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
+++ b/onboarding-tutorials/code-flow/watchdog/watchdog-overview.md
@@ -11,8 +11,8 @@ Two background monitors:
 
 | Monitor | File | Purpose |
 |---------|------|---------|
-| `EventLoopWatchdog` | `fluidmcp/cli/services/watchdog.py` | Measures asyncio event loop lag — detects blocking calls |
-| `MCPHealthMonitor` | `fluidmcp/cli/services/server_manager.py` | Polls MCP subprocess liveness — auto-restarts crashed servers |
+| `EventLoopWatchdog` | [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | Measures asyncio event loop lag — detects blocking calls |
+| `MCPHealthMonitor` | [`fluidmcp/cli/services/server_manager.py`](../../../fluidmcp/cli/services/server_manager.py) | Polls MCP subprocess liveness — auto-restarts crashed servers |
 
 > **Integration status:** `MCPHealthMonitor` is started automatically when `fmcp serve` runs (wired into `server.py`). `EventLoopWatchdog` is implemented and ready to use but is not yet wired into `server.py`.
 
@@ -21,31 +21,31 @@ Two background monitors:
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────────────┐
-│  fmcp serve  (server.py — main() coroutine)                             │
-│                                                                         │
-│  ┌──────────────────────┐    ┌──────────────────────────────────────┐   │
-│  │  EventLoopWatchdog   │    │        MCPHealthMonitor              │   │
-│  │  watchdog.py         │    │  server_manager.py                   │   │
-│  │                      │    │                                      │   │
-│  │  Background asyncio  │    │  Background asyncio task.            │   │
-│  │  task — measures     │    │  Polls every 30s. For each server:   │   │
-│  │  sleep() drift       │    │    • stdio: process.poll()           │   │
-│  │  every 10s.          │    │    • SSE: psutil check_process_alive │   │
-│  │                      │    │    • if dead → _cleanup_server()     │   │
-│  │  lag > 0.5s → WARN   │    │    • if restart policy allows →      │   │
-│  │  lag > 2.0s → ERROR  │    │      backoff delay → restart         │   │
-│  │                      │    │                                      │   │
-│  │  (not yet wired into │    │                                      │   │
-│  │   server.py)         │    │                                      │   │
-│  └──────────────────────┘    └──────────────────────────────────────┘   │
-│             │                               │                           │
-│             ▼                               ▼                           │
-│       Loguru logger                   ServerManager                     │
-│       (structured logs)               _cleanup_server() →               │
-│                                         db.save_crash_event()           │
-│                                         db.save_instance_state()        │
-└─────────────────────────────────────────────────────────────────────────┘
++-------------------------------------------------------------------------+
+|  fmcp serve  (server.py -- main() coroutine)                            |
+|                                                                         |
+|  +----------------------+    +--------------------------------------+   |
+|  |  EventLoopWatchdog   |    |        MCPHealthMonitor              |   |
+|  |  watchdog.py         |    |  server_manager.py                   |   |
+|  |                      |    |                                      |   |
+|  |  Background asyncio  |    |  Background asyncio task.            |   |
+|  |  task -- measures    |    |  Polls every 30s. For each server:   |   |
+|  |  sleep() drift       |    |    * stdio: process.poll()           |   |
+|  |  every 10s.          |    |    * SSE: psutil check_process_alive |   |
+|  |                      |    |    * if dead -> _cleanup_server()    |   |
+|  |  lag > 0.5s -> WARN  |    |    * if restart policy allows ->     |   |
+|  |  lag > 2.0s -> ERROR |    |      backoff delay -> restart        |   |
+|  |                      |    |                                      |   |
+|  |  (not yet wired into |    |                                      |   |
+|  |   server.py)         |    |                                      |   |
+|  +----------------------+    +--------------------------------------+   |
+|             |                               |                           |
+|             v                               v                           |
+|       Loguru logger                   ServerManager                     |
+|       (structured logs)               _cleanup_server() ->              |
+|                                         db.save_crash_event()           |
+|                                         db.save_instance_state()        |
++-------------------------------------------------------------------------+
 ```
 
 ---
@@ -68,22 +68,22 @@ If `lag` is large, the event loop was blocked during that sleep — a synchronou
 
 ```
 watchdog._loop() starts
-        │
-        ▼
+        |
+        v
     record before = time.monotonic()
-        │
-        ▼
-    await asyncio.sleep(10s)   ← yields control to event loop
-        │
-        ▼
+        |
+        v
+    await asyncio.sleep(10s)   <- yields control to event loop
+        |
+        v
     lag = wall_clock_delta - 10s
-        │
-        ├── lag >= 2.0s  →  logger.error("Event loop lag Xs exceeds error threshold")
-        ├── lag >= 0.5s  →  logger.warning("Event loop lag Xs exceeds warn threshold")
-        └── lag < 0.5s   →  (no log — healthy)
-        │
-        ▼
-    loop back ──────────────────────────────────────────────────────────┐
+        |
+        +-- lag >= 2.0s  ->  logger.error("Event loop lag Xs exceeds error threshold")
+        +-- lag >= 0.5s  ->  logger.warning("Event loop lag Xs exceeds warn threshold")
+        +-- lag < 0.5s   ->  (no log -- healthy)
+        |
+        v
+    loop back
 ```
 
 ### Env vars
@@ -95,6 +95,8 @@ watchdog._loop() starts
 | `FMCP_LOOP_LAG_INTERVAL_S` | `10.0` | How often to measure (min: 0.001s) |
 
 > All three are read at **module import time** via `_get_env_float()` and stored in module-level constants (`_WARN_THRESHOLD`, `_ERROR_THRESHOLD`, `_CHECK_INTERVAL`). Changing them at runtime has no effect.
+>
+> **Operator note:** There is no log warning when an invalid env value is silently discarded. For example, `FMCP_LOOP_LAG_WARN_S=0.5x` will silently fall back to the default `0.5`. Verify the correct threshold is active by checking startup logs where the watchdog prints its configured values.
 
 ### Safe env var parsing — `_get_env_float()`
 
@@ -107,13 +109,13 @@ def _get_env_float(name, default, min_value=None):
     try:
         value = float(raw)
     except (TypeError, ValueError):
-        return default          # bad value → silent fallback
+        return default          # bad value -> silent fallback
     if min_value is not None and value < min_value:
-        return default          # below min → fallback
+        return default          # below min -> fallback
     return value
 ```
 
-> Called at **module import time** (to set `_WARN_THRESHOLD` etc.), so it must NOT call `logger` — loguru may not be configured yet. Invalid env values fall back silently.
+> Called at **module import time** (to set `_WARN_THRESHOLD` etc.), so it must NOT call `logger` — loguru may not be configured yet.
 
 ### Lifecycle
 
@@ -130,7 +132,7 @@ await watchdog.stop()  # cancels task, awaits CancelledError, sets _task = None
 
 ### How it works
 
-Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_INTERVAL` env var) the monitor iterates all running MCP server processes and checks liveness. An additional env var `FMCP_RESTART_TIMEOUT_S` (default 60s) controls how long a restart attempt is allowed to run before it is cancelled:
+Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_INTERVAL` env var) the monitor iterates all running MCP server processes and checks liveness:
 
 - **stdio servers** (`subprocess.Popen`): `process.poll()` — non-None return means the process has exited
 - **SSE servers** (`SseSubprocessHandle`): `health_checker.check_process_alive(pid)` via psutil
@@ -139,74 +141,92 @@ Every `check_interval` seconds (default 30s, overridden by `FMCP_HEALTH_CHECK_IN
 
 ```
 _monitor_loop() runs every 30s
-        │
-        ▼
+        |
+        v
     snapshot = list(server_manager.processes.items())
-        │
-        ▼
+        |
+        v
     for each (server_id, process):
-        │
-        ▼
+        |
+        v
     _check_server(server_id, process)
-        │
-        ├── stdio: process.poll() is None  →  alive
-        ├── SSE:   check_process_alive()   →  alive
-        │
-        └── process has exited
-                │
-                ▼
-            already in _restarts_in_progress?  →  skip (no duplicate)
-                │
-                ▼
+        |
+        +-- stdio: process.poll() is None  ->  alive
+        +-- SSE:   check_process_alive()   ->  alive
+        |
+        +-- process has exited
+                |
+                v
+            already in _restarts_in_progress?  ->  skip (no duplicate)
+                |
+                v
             get config from DB
-                │
-                ├── config missing  →  _cleanup_server() only, no restart
-                │
-                └── config found
-                        │
-                        ▼
-                    restart_policy == "never"?  →  cleanup only
-                        │
-                        ▼
-                    restart_policy == "on-failure" and exit_code == 0?  →  cleanup only
-                        │
-                        ▼
-                    restart_count >= max_restarts?  →  cleanup only, log warning
-                        │
-                        ▼
+                |
+                +-- config missing  ->  _cleanup_server() only, no restart
+                |
+                +-- config found
+                        |
+                        v
+                    restart_policy == "never"?  ->  cleanup only
+                        |
+                        v
+                    restart_policy == "on-failure" and exit_code == 0?  ->  cleanup only
+                        |
+                        v
+                    restart_count >= max_restarts?
+                        ->  cleanup only, log warning
+                        ->  server stays stopped until operator manually restarts via API
+                        |
+                        v
                     calculate backoff delay
                     await asyncio.sleep(delay)
-                        │
-                        ▼
+                        |
+                        v
                     acquire op_lock
                     _cleanup_server(server_id, exit_code)
-                    _start_server_unlocked(server_id, config)
-                        │
-                        ├── success  →  log info, increment restart_count
-                        └── failure  →  log error, increment restart_count
-        │
-        ▼
-    restart_count resets only after 5 minutes of sustained healthy uptime
+                    asyncio.wait_for(_start_server_unlocked(), timeout=60s)  <- FMCP_RESTART_TIMEOUT_S
+                        |
+                        +-- success  ->  log info, increment restart_count
+                        +-- timeout  ->  log error, increment restart_count
+                        +-- failure  ->  log error, increment restart_count
+        |
+        v
+    await asyncio.sleep(check_interval)
 ```
+
+### Restart count reset
+
+The restart count for a server resets only after **5 minutes of sustained healthy uptime** (checked on the next poll cycle where the process is still alive). This prevents a flapping server from getting a "fresh start" too soon and exhausting `max_restarts` across many short-lived restart cycles.
+
+### After max_restarts is hit
+
+Once `restart_count >= max_restarts`, the monitor stops attempting restarts. The server process stays stopped. **An operator must manually restart it** via the management API:
+
+```bash
+curl -X POST http://localhost:<port>/api/servers/<server_id>/start \
+  -H "Authorization: Bearer <token>"
+```
+
+The restart count does not automatically reset — the server will not self-recover without manual intervention.
 
 ### Env vars
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `FMCP_HEALTH_CHECK_INTERVAL` | `30` | Seconds between health-check polls (integer) |
-| `FMCP_RESTART_TIMEOUT_S` | `60` | Seconds before a restart attempt is cancelled |
+| `FMCP_RESTART_TIMEOUT_S` | `60` | Seconds before a single restart attempt is cancelled |
 
 ### Exponential backoff
 
 ```
-delay = 5s × 2^min(restart_count, 5)
+delay = 5s x 2^min(restart_count, 5)
 
-restart 0 →   5s
-restart 1 →  10s
-restart 2 →  20s
-restart 3 →  40s
-restart 4 →  80s
-restart 5+ → 160s  (maximum)
+restart 0 ->   5s
+restart 1 ->  10s
+restart 2 ->  20s
+restart 3 ->  40s
+restart 4 ->  80s
+restart 5+ -> 160s  (maximum)
 ```
 
 ### Restart policies
@@ -224,7 +244,7 @@ restart 5+ → 160s  (maximum)
 `MCPHealthMonitor` is integrated into `server.py`. The current startup order is:
 
 ```python
-# server.py — main()
+# server.py -- main()
 
 # 1. Start health monitor BEFORE create_app()
 health_monitor = MCPHealthMonitor(server_manager, check_interval=health_check_interval)
@@ -236,9 +256,9 @@ app = await create_app(...)
 # ... server runs until shutdown signal ...
 
 # 3. Shutdown order
-await health_monitor.stop()                  # stop monitor first
+await health_monitor.stop()                    # stop monitor first
 await server_manager.stop_idle_cleanup_task()  # stop idle cleanup
-await server_manager.shutdown_all()          # stop all MCP processes last
+await server_manager.shutdown_all()            # stop all MCP processes last
 ```
 
 > `EventLoopWatchdog` is not yet wired into `server.py`. The class is ready in `watchdog.py` and can be added to the lifecycle above when needed.
@@ -249,7 +269,7 @@ await server_manager.shutdown_all()          # stop all MCP processes last
 
 | File | Role |
 |------|------|
-| `fluidmcp/cli/services/watchdog.py` | `EventLoopWatchdog` + `_get_env_float()` |
-| `fluidmcp/cli/services/server_manager.py` | `MCPHealthMonitor` + `_check_server()` + `_calculate_restart_delay()` |
-| `fluidmcp/cli/server.py` | `MCPHealthMonitor` start/stop integration in `main()` |
-| `tests/test_server_manager_cleanup.py` | Tests for `ServerManager` shutdown and process cleanup |
+| [`fluidmcp/cli/services/watchdog.py`](../../../fluidmcp/cli/services/watchdog.py) | `EventLoopWatchdog` + `_get_env_float()` |
+| [`fluidmcp/cli/services/server_manager.py`](../../../fluidmcp/cli/services/server_manager.py) | `MCPHealthMonitor` + `_check_server()` + `_calculate_restart_delay()` |
+| [`fluidmcp/cli/server.py`](../../../fluidmcp/cli/server.py) | `MCPHealthMonitor` start/stop integration in `main()` |
+| [`tests/test_server_manager_cleanup.py`](../../../tests/test_server_manager_cleanup.py) | Tests for `ServerManager` shutdown and process cleanup |


### PR DESCRIPTION
## Summary

- Added single-file onboarding tutorial for `EventLoopWatchdog` and `MCPHealthMonitor` — two background monitors built for production stability
- `EventLoopWatchdog` (`watchdog.py`): measures asyncio sleep-drift every 10s to detect a blocked event loop; logs WARNING at >0.5s lag, ERROR at >2.0s lag
- `MCPHealthMonitor` (`server_manager.py`): polls every 30s for MCP subprocess liveness (stdio via `process.poll()`, SSE via psutil); auto-restarts crashed servers with exponential backoff
- Documents architecture, flow diagrams, all env vars with defaults, restart policies, backoff formula, and startup/shutdown integration in `server.py`
- Integration status noted: `MCPHealthMonitor` is wired into `server.py`; `EventLoopWatchdog` is implemented and ready but not yet wired in

## File added

`onboarding-tutorials/code-flow/watchdog/watchdog-overview.md`

## Test plan

- [ ] Confirm env vars, defaults, and thresholds match `watchdog.py`
- [ ] Confirm restart policies, backoff formula, and 5-minute uptime reset match `server_manager.py`
- [ ] Confirm startup/shutdown order matches `server.py`
- [ ] Confirm no unimplemented features are described

