### PR TITLE
MCP-499: feat: Add Server button on Dashboard with auto-open modal

### DIFF
--- a/fluidmcp/frontend/src/pages/Dashboard.tsx
+++ b/fluidmcp/frontend/src/pages/Dashboard.tsx
@@ -12,7 +12,7 @@ import { Footer } from "@/components/Footer";
 import { Skeleton } from "@/components/ui/skeleton";
 import AOS from 'aos';
 import 'aos/dist/aos.css';
-//dummy comment to change file1
+
 export default function Dashboard() {
   const navigate = useNavigate();
   const { servers, activeServers, loading, error, refetch, startServer } = useServers();
@@ -124,7 +124,10 @@ export default function Dashboard() {
                 <Skeleton className="h-8 w-64 mb-2" />
                 <Skeleton className="h-4 w-48" />
               </div>
-              <Skeleton className="h-10 w-24" />
+              <div style={{ display: 'flex', gap: '0.5rem' }}>
+                <Skeleton className="h-10 w-28" />
+                <Skeleton className="h-10 w-24" />
+              </div>
             </div>
           </header>
           
@@ -183,17 +186,30 @@ export default function Dashboard() {
                 {servers.length} {servers.length === 1 ? 'server' : 'servers'} configured, {activeServers.length} running
               </p>
             </div>
-            <button 
-              onClick={refetch}
-              style={{ background: 'transparent', color: '#d1d5db', border: '1px solid rgba(63, 63, 70, 0.6)', padding: '0.5rem 1rem', borderRadius: '0.375rem', fontSize: '0.875rem', fontWeight: '500', display: 'inline-flex', alignItems: 'center', gap: '0.5rem', transition: 'all 0.2s', margin: 0, cursor: 'pointer' }}
-              onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(39, 39, 42, 0.8)'; e.currentTarget.style.borderColor = 'rgba(82, 82, 91, 0.8)'; }}
-              onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.borderColor = 'rgba(63, 63, 70, 0.6)'; }}
-            >
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-              </svg>
-              Refresh
-            </button>
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <button
+                onClick={() => navigate('/servers/manage', { state: { openAddServer: true } })}
+                style={{ background: '#2563eb', color: '#fff', border: 'none', padding: '0.5rem 1rem', borderRadius: '0.375rem', fontSize: '0.875rem', fontWeight: '500', display: 'inline-flex', alignItems: 'center', gap: '0.5rem', transition: 'all 0.2s', margin: 0, cursor: 'pointer' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = '#1d4ed8'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = '#2563eb'; }}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                </svg>
+                Add Server
+              </button>
+              <button
+                onClick={refetch}
+                style={{ background: 'transparent', color: '#d1d5db', border: '1px solid rgba(63, 63, 70, 0.6)', padding: '0.5rem 1rem', borderRadius: '0.375rem', fontSize: '0.875rem', fontWeight: '500', display: 'inline-flex', alignItems: 'center', gap: '0.5rem', transition: 'all 0.2s', margin: 0, cursor: 'pointer' }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = 'rgba(39, 39, 42, 0.8)'; e.currentTarget.style.borderColor = 'rgba(82, 82, 91, 0.8)'; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.borderColor = 'rgba(63, 63, 70, 0.6)'; }}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                </svg>
+                Refresh
+              </button>
+            </div>
           </div>
         </header>
       </div>
@@ -227,8 +243,23 @@ export default function Dashboard() {
               <div className="empty-state-icon">📦</div>
               <h3 className="empty-state-title">No servers found</h3>
               <p className="empty-state-description">
-                Try adjusting your search, sort, or filter options.
+                {servers.length === 0
+                  ? 'No servers configured yet.'
+                  : 'Try adjusting your search, sort, or filter options.'}
               </p>
+              {servers.length === 0 && (
+                <button
+                  onClick={() => navigate('/servers/manage', { state: { openAddServer: true } })}
+                  style={{ marginTop: '1rem', background: '#2563eb', color: '#fff', border: 'none', padding: '0.5rem 1.25rem', borderRadius: '0.375rem', fontSize: '0.875rem', fontWeight: '500', display: 'inline-flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
+                  onMouseEnter={(e) => { e.currentTarget.style.background = '#1d4ed8'; }}
+                  onMouseLeave={(e) => { e.currentTarget.style.background = '#2563eb'; }}
+                >
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                  </svg>
+                  Add Server
+                </button>
+              )}
             </div>
           ) : (
             <>

--- a/fluidmcp/frontend/src/pages/ManageServers.tsx
+++ b/fluidmcp/frontend/src/pages/ManageServers.tsx
@@ -26,7 +26,7 @@ export default function ManageServers() {
 
   // Auto-open add-server modal when navigated from Dashboard
   useEffect(() => {
-    if ((location.state as any)?.openAddServer) {
+    if ((location.state as { openAddServer?: boolean })?.openAddServer) {
       setEditingServer(null);
       setCreateTab('manual');
       setShowForm(true);

--- a/fluidmcp/frontend/src/pages/ManageServers.tsx
+++ b/fluidmcp/frontend/src/pages/ManageServers.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
 import { ServerForm } from '../components/ServerForm';
 import { CloneFromGithubForm } from '../components/CloneFromGithubForm';
@@ -11,6 +12,7 @@ type FilterMode = 'all' | 'running' | 'stopped' | 'failed';
 type CreateTab = 'manual' | 'github';
 
 export default function ManageServers() {
+  const location = useLocation();
   const [showDeleted, setShowDeleted] = useState(false);
   const { servers, loading, createServer, updateServer, deleteServer, refetch } = useServerManagement(showDeleted);
 
@@ -21,6 +23,15 @@ export default function ManageServers() {
   const [searchQuery, setSearchQuery] = useState('');
   const [filterMode, setFilterMode] = useState<FilterMode>('all');
   const [currentPage, setCurrentPage] = useState(1);
+
+  // Auto-open add-server modal when navigated from Dashboard
+  useEffect(() => {
+    if ((location.state as any)?.openAddServer) {
+      setEditingServer(null);
+      setCreateTab('manual');
+      setShowForm(true);
+    }
+  }, [location.state]);
 
   const SERVERS_PER_PAGE = 10;
 


### PR DESCRIPTION
## Summary
- Adds a primary **Add Server** button in the Dashboard header that navigates to `/servers/manage` and auto-opens the add-server modal
- Adds a secondary **Add Server** CTA in the empty state (shown only when no servers are configured)
- `ManageServers` reads `location.state.openAddServer` on mount to trigger the modal automatically
- Fixed loading skeleton to show two button placeholders matching the updated header layout
- Removed leftover `//dummy comment to change file1` from Dashboard.tsx
- Typed router `location.state` properly instead of `as any` cast (security review fix)

## Test plan
- [x] Click **Add Server** on Dashboard header → lands on Manage page with modal open
- [x] Click **Add Server** in empty state (no servers) → same behaviour
- [x] Navigate to `/servers/manage` directly → modal does NOT auto-open
- [x] Loading skeleton shows two button placeholders in header

🤖 Generated with Claude Code