### PR TITLE
MCP-502; fix: allow underscores in server ID validation

### DIFF
--- a/fluidmcp/cli/models/api.py
+++ b/fluidmcp/cli/models/api.py
@@ -247,7 +247,7 @@ class AddServerFromGitHubRequest(BaseModel):
         ),
         min_length=1,
         max_length=100,
-        pattern="^[a-z0-9-]+$",
+        pattern="^[a-z0-9_-]+$",
     )
     server_name: Optional[str] = Field(
         None,

--- a/fluidmcp/cli/services/server_builder.py
+++ b/fluidmcp/cli/services/server_builder.py
@@ -26,22 +26,22 @@ class ServerBuilder:
         Examples:
             "My Server"   -> "my-server"
             "API v2.0"    -> "api-v2-0"
-            "file_system" -> "file-system"
+            "file_system" -> "file_system"
 
         Args:
             text: Text to slugify
 
         Returns:
-            Lowercase hyphenated slug
+            Lowercase slug (hyphens and underscores preserved)
         """
         text = text.lower()
-        # Replace spaces and underscores with hyphens
-        text = re.sub(r'[\s_]+', '-', text)
-        # Remove non-alphanumeric characters (except hyphens)
-        text = re.sub(r'[^a-z0-9-]', '', text)
+        # Replace whitespace with hyphens (underscores preserved)
+        text = re.sub(r'\s+', '-', text)
+        # Remove non-alphanumeric characters (except hyphens and underscores)
+        text = re.sub(r'[^a-z0-9_-]', '', text)
         # Collapse consecutive hyphens
         text = re.sub(r'-+', '-', text)
-        return text.strip('-')
+        return text.strip('-_')
 
     @staticmethod
     def generate_server_id(base_id: str, server_name: str, is_multi_server: bool) -> str:

--- a/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
+++ b/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
@@ -9,10 +9,10 @@ import type { CloneFromGithubServerResult } from '../types/server';
 function slugify(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[\s_]+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9_-]/g, '')
     .replace(/-+/g, '-')
-    .replace(/^-+|-+$/g, '');
+    .replace(/^[-_]+|[-_]+$/g, '');
 }
 
 /** Derive a server-id suggestion from a repo path like "awslabs/mcp". */

--- a/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
+++ b/fluidmcp/frontend/src/components/CloneFromGithubForm.tsx
@@ -129,8 +129,8 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
 
     if (!serverId.trim()) {
       errs.serverId = 'Server ID is required';
-    } else if (!/^[a-z0-9-]+$/.test(serverId.trim())) {
-      errs.serverId = 'Only lowercase letters, numbers, and hyphens';
+    } else if (!/^[a-z0-9_-]+$/.test(serverId.trim())) {
+      errs.serverId = 'Only lowercase letters, numbers, hyphens, and underscores';
     }
 
     if (!token.trim()) {
@@ -404,7 +404,7 @@ export function CloneFromGithubForm({ onSuccess, onCancel }: Props) {
           />
           {errors.serverId
             ? <p className="mt-1 text-xs text-red-400">{errors.serverId}</p>
-            : <p className="mt-1 text-xs text-zinc-500">Lowercase, numbers, hyphens only</p>
+            : <p className="mt-1 text-xs text-zinc-500">Lowercase, numbers, hyphens, underscores</p>
           }
         </div>
 

--- a/fluidmcp/frontend/src/components/ServerForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerForm.tsx
@@ -25,9 +25,9 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
 
     // Validate ID format (lowercase alphanumeric + hyphens)
     if (mode === 'create') {
-      const idRegex = /^[a-z0-9-]+$/;
+      const idRegex = /^[a-z0-9_-]+$/;
       if (!idRegex.test(formData.id)) {
-        alert('Server ID must contain only lowercase letters, numbers, and hyphens');
+        alert('Server ID must contain only lowercase letters, numbers, hyphens, and underscores');
         return;
       }
       if (formData.id.startsWith('-') || formData.id.endsWith('-')) {
@@ -85,11 +85,11 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
           onChange={(e) => setFormData({ ...formData, id: e.target.value.toLowerCase() })}
           disabled={mode === 'edit'}
           className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 text-white placeholder-zinc-400 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-zinc-900/50 disabled:cursor-not-allowed disabled:text-zinc-500"
-          placeholder="my-server-id"
+          placeholder="my-server-id or my_server_id"
           required
         />
         <p className="mt-1 text-xs text-zinc-400">
-          Lowercase letters, numbers, hyphens only. Cannot be changed after creation.
+          Lowercase letters, numbers, hyphens, and underscores. Cannot be changed after creation.
         </p>
       </div>
 

--- a/fluidmcp/frontend/src/components/ServerForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerForm.tsx
@@ -30,8 +30,9 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
         alert('Server ID must contain only lowercase letters, numbers, hyphens, and underscores');
         return;
       }
-      if (formData.id.startsWith('-') || formData.id.endsWith('-')) {
-        alert('Server ID cannot start or end with a hyphen');
+      if (formData.id.startsWith('-') || formData.id.endsWith('-') ||
+          formData.id.startsWith('_') || formData.id.endsWith('_')) {
+        alert('Server ID cannot start or end with a hyphen or underscore');
         return;
       }
     }

--- a/tests/test_github_service.py
+++ b/tests/test_github_service.py
@@ -30,11 +30,11 @@ class TestServerBuilderSlugify:
     def test_spaces_become_hyphens(self):
         assert ServerBuilder.slugify("My Server") == "my-server"
 
-    def test_underscores_become_hyphens(self):
-        assert ServerBuilder.slugify("file_system") == "file-system"
+    def test_underscores_preserved(self):
+        assert ServerBuilder.slugify("file_system") == "file_system"
 
     def test_mixed_spaces_and_underscores(self):
-        assert ServerBuilder.slugify("My_File Server") == "my-file-server"
+        assert ServerBuilder.slugify("My_File Server") == "my_file-server"
 
     def test_removes_special_chars(self):
         # dots are removed; no hyphen is inserted in their place

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,6 +5,8 @@ This test suite validates all validation functions to ensure they correctly
 identify valid and invalid inputs across various edge cases.
 """
 
+import re
+
 from fluidmcp.cli.services.validators import (
     validate_package_string,
     validate_port_number,
@@ -670,3 +672,58 @@ class TestEdgeCases:
         # Unicode in env values should be accepted
         env = {"MESSAGE": "Hello 世界"}
         assert validate_env_dict(env) is True
+
+
+# Server ID pattern used in AddServerFromGitHubRequest (api.py)
+SERVER_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+
+class TestServerIdValidation:
+    """Test server ID validation pattern (matches Pydantic field in api.py)."""
+
+    def test_valid_hyphens(self):
+        """Test valid server IDs with hyphens."""
+        assert SERVER_ID_PATTERN.match("my-server") is not None
+        assert SERVER_ID_PATTERN.match("pdf-to-excel") is not None
+
+    def test_valid_underscores(self):
+        """Test valid server IDs with underscores."""
+        assert SERVER_ID_PATTERN.match("pdf_to_excel_lic") is not None
+        assert SERVER_ID_PATTERN.match("my_server") is not None
+
+    def test_valid_mixed_hyphens_and_underscores(self):
+        """Test valid server IDs mixing hyphens and underscores."""
+        assert SERVER_ID_PATTERN.match("my_pdf-server") is not None
+        assert SERVER_ID_PATTERN.match("tool_v2-prod") is not None
+
+    def test_valid_numbers(self):
+        """Test valid server IDs with numbers."""
+        assert SERVER_ID_PATTERN.match("server123") is not None
+        assert SERVER_ID_PATTERN.match("server-2") is not None
+        assert SERVER_ID_PATTERN.match("server_v2") is not None
+
+    def test_valid_simple_lowercase(self):
+        """Test valid simple lowercase server IDs."""
+        assert SERVER_ID_PATTERN.match("filesystem") is not None
+        assert SERVER_ID_PATTERN.match("memory") is not None
+
+    def test_invalid_uppercase(self):
+        """Test that uppercase letters are rejected."""
+        assert SERVER_ID_PATTERN.match("MyServer") is None
+        assert SERVER_ID_PATTERN.match("PDF_to_excel") is None
+
+    def test_invalid_spaces(self):
+        """Test that spaces are rejected."""
+        assert SERVER_ID_PATTERN.match("my server") is None
+        assert SERVER_ID_PATTERN.match(" server") is None
+
+    def test_invalid_special_characters(self):
+        """Test that special characters are rejected."""
+        assert SERVER_ID_PATTERN.match("my@server") is None
+        assert SERVER_ID_PATTERN.match("server.name") is None
+        assert SERVER_ID_PATTERN.match("server/path") is None
+        assert SERVER_ID_PATTERN.match("server:8080") is None
+
+    def test_invalid_empty_string(self):
+        """Test that empty string is rejected."""
+        assert SERVER_ID_PATTERN.match("") is None

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,6 +7,10 @@ identify valid and invalid inputs across various edge cases.
 
 import re
 
+import pytest
+from pydantic import ValidationError
+
+from fluidmcp.cli.models.api import AddServerFromGitHubRequest
 from fluidmcp.cli.services.validators import (
     validate_package_string,
     validate_port_number,
@@ -674,56 +678,56 @@ class TestEdgeCases:
         assert validate_env_dict(env) is True
 
 
-# Server ID pattern used in AddServerFromGitHubRequest (api.py)
-SERVER_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+def _make_github_request(server_id: str) -> AddServerFromGitHubRequest:
+    return AddServerFromGitHubRequest(server_id=server_id, github_repo="owner/repo")
 
 
 class TestServerIdValidation:
-    """Test server ID validation pattern (matches Pydantic field in api.py)."""
+    """Test server ID validation via the live Pydantic model in api.py."""
 
     def test_valid_hyphens(self):
-        """Test valid server IDs with hyphens."""
-        assert SERVER_ID_PATTERN.match("my-server") is not None
-        assert SERVER_ID_PATTERN.match("pdf-to-excel") is not None
+        _make_github_request("my-server")
+        _make_github_request("pdf-to-excel")
 
     def test_valid_underscores(self):
-        """Test valid server IDs with underscores."""
-        assert SERVER_ID_PATTERN.match("pdf_to_excel_lic") is not None
-        assert SERVER_ID_PATTERN.match("my_server") is not None
+        _make_github_request("pdf_to_excel_lic")
+        _make_github_request("my_server")
 
     def test_valid_mixed_hyphens_and_underscores(self):
-        """Test valid server IDs mixing hyphens and underscores."""
-        assert SERVER_ID_PATTERN.match("my_pdf-server") is not None
-        assert SERVER_ID_PATTERN.match("tool_v2-prod") is not None
+        _make_github_request("my_pdf-server")
+        _make_github_request("tool_v2-prod")
 
     def test_valid_numbers(self):
-        """Test valid server IDs with numbers."""
-        assert SERVER_ID_PATTERN.match("server123") is not None
-        assert SERVER_ID_PATTERN.match("server-2") is not None
-        assert SERVER_ID_PATTERN.match("server_v2") is not None
+        _make_github_request("server123")
+        _make_github_request("server-2")
+        _make_github_request("server_v2")
 
     def test_valid_simple_lowercase(self):
-        """Test valid simple lowercase server IDs."""
-        assert SERVER_ID_PATTERN.match("filesystem") is not None
-        assert SERVER_ID_PATTERN.match("memory") is not None
+        _make_github_request("filesystem")
+        _make_github_request("memory")
 
     def test_invalid_uppercase(self):
-        """Test that uppercase letters are rejected."""
-        assert SERVER_ID_PATTERN.match("MyServer") is None
-        assert SERVER_ID_PATTERN.match("PDF_to_excel") is None
+        with pytest.raises(ValidationError):
+            _make_github_request("MyServer")
+        with pytest.raises(ValidationError):
+            _make_github_request("PDF_to_excel")
 
     def test_invalid_spaces(self):
-        """Test that spaces are rejected."""
-        assert SERVER_ID_PATTERN.match("my server") is None
-        assert SERVER_ID_PATTERN.match(" server") is None
+        with pytest.raises(ValidationError):
+            _make_github_request("my server")
+        with pytest.raises(ValidationError):
+            _make_github_request(" server")
 
     def test_invalid_special_characters(self):
-        """Test that special characters are rejected."""
-        assert SERVER_ID_PATTERN.match("my@server") is None
-        assert SERVER_ID_PATTERN.match("server.name") is None
-        assert SERVER_ID_PATTERN.match("server/path") is None
-        assert SERVER_ID_PATTERN.match("server:8080") is None
+        with pytest.raises(ValidationError):
+            _make_github_request("my@server")
+        with pytest.raises(ValidationError):
+            _make_github_request("server.name")
+        with pytest.raises(ValidationError):
+            _make_github_request("server/path")
+        with pytest.raises(ValidationError):
+            _make_github_request("server:8080")
 
     def test_invalid_empty_string(self):
-        """Test that empty string is rejected."""
-        assert SERVER_ID_PATTERN.match("") is None
+        with pytest.raises(ValidationError):
+            _make_github_request("")


### PR DESCRIPTION
Server IDs like `pdf_to_excel_lic` were rejected due to regex
pattern `[a-z0-9-]` not allowing underscores.

Updated pattern to `[a-z0-9_-]` in:
- Backend: Pydantic model in api.py
- Frontend: ServerForm and CloneFromGithubForm validation,
  error messages, help text, and placeholder

Added 9 unit tests covering valid and invalid server ID patterns.