### PR TITLE
MCP-505: feat: bulk JSON import for environment variables in server config form

### DIFF
--- a/fluidmcp/frontend/src/components/ServerEnvForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerEnvForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import type { ServerEnvMetadataResponse } from '../types/server';
 import './ServerEnvForm.css';
 
@@ -21,6 +21,12 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
   const [formValues, setFormValues] = useState<Record<string, string>>({});
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showJsonModal, setShowJsonModal] = useState(false);
+  const [jsonInput, setJsonInput] = useState('');
+  const [jsonError, setJsonError] = useState('');
+  const [jsonImportSummary, setJsonImportSummary] = useState<{ matched: number; skipped: number } | null>(null);
+  const jsonTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Initialize form with empty values (never pre-populate for security)
   useEffect(() => {
@@ -104,6 +110,90 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
   };
 
 
+  const extractEnvFromParsed = (parsed: any): Record<string, string> | null => {
+    // Format 1: { mcpServers: { id: { env: {...} } } }
+    if (parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+      const first = Object.values(parsed.mcpServers)[0] as any;
+      return first?.env && typeof first.env === 'object' ? first.env : {};
+    }
+    // Format 2: { env: { KEY: VALUE } }
+    if (parsed.env && typeof parsed.env === 'object' && !Array.isArray(parsed.env)) {
+      return parsed.env;
+    }
+    // Format 3: flat { KEY: VALUE }
+    if (typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return null;
+  };
+
+  const applyEnvObject = (envObj: Record<string, string>) => {
+    let matched = 0;
+    let skipped = 0;
+    const updates: Record<string, string> = {};
+    Object.entries(envObj).forEach(([k, v]) => {
+      if (k in formValues) {
+        updates[k] = String(v);
+        matched++;
+      } else {
+        skipped++;
+      }
+    });
+    setFormValues(prev => ({ ...prev, ...updates }));
+    setJsonImportSummary({ matched, skipped });
+    if (matched > 0) {
+      setTimeout(() => {
+        setShowJsonModal(false);
+        setJsonInput('');
+        setJsonImportSummary(null);
+      }, 1500);
+    }
+  };
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setJsonError('');
+    setJsonImportSummary(null);
+    if (file.size > 1_000_000) {
+      setJsonError('File too large. Max 1MB.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string);
+        const envObj = extractEnvFromParsed(parsed);
+        if (!envObj) {
+          setJsonError('Could not extract environment variables from this file.');
+          return;
+        }
+        // Show parsed content in textarea so user can review before applying
+        setJsonInput(JSON.stringify(envObj, null, 2));
+      } catch {
+        setJsonError('Invalid JSON file. Please check the file and try again.');
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  const handleJsonImport = () => {
+    setJsonError('');
+    setJsonImportSummary(null);
+    try {
+      const parsed = JSON.parse(jsonInput);
+      const envObj = extractEnvFromParsed(parsed);
+      if (!envObj) {
+        setJsonError('JSON must be an object of key-value pairs.');
+        return;
+      }
+      applyEnvObject(envObj);
+    } catch {
+      setJsonError('Invalid JSON. Please check the format and try again.');
+    }
+  };
+
   const isSensitiveField = (key: string): boolean => {
     const lowerKey = key.toLowerCase();
     const sensitivePatterns = [
@@ -131,7 +221,99 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
 
   return (
     <div className="server-env-form">
+      {/* JSON Import Modal */}
+      {showJsonModal && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="relative bg-gradient-to-br from-zinc-900 to-zinc-800 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-lg p-6">
+            <button
+              type="button"
+              onClick={() => { setShowJsonModal(false); setJsonInput(''); setJsonError(''); setJsonImportSummary(null); }}
+              className="absolute top-4 right-4 text-zinc-400 hover:text-white transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+
+            <h3 className="text-lg font-semibold text-white mb-1">Import from JSON</h3>
+            <p className="text-xs text-zinc-400 mb-3">
+              Paste or upload a JSON file. Supports flat <code className="font-mono">{"{ KEY: VALUE }"}</code>, <code className="font-mono">{"{ env: {...} }"}</code>, or full MCP config format. Only keys matching this server's config are applied.
+            </p>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileUpload}
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 mb-3 border-2 border-dashed border-zinc-600 rounded-lg text-zinc-400 hover:border-blue-500 hover:text-blue-400 transition-colors text-sm"
+            >
+              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+              </svg>
+              Upload JSON file
+            </button>
+
+            <p className="text-xs text-zinc-500 mb-2">— or paste JSON below —</p>
+
+            <textarea
+              ref={jsonTextareaRef}
+              value={jsonInput}
+              onChange={e => { setJsonInput(e.target.value); setJsonError(''); setJsonImportSummary(null); }}
+              placeholder={'{\n  "API_KEY": "sk_...",\n  "DB_URL": "postgresql://..."\n}'}
+              rows={10}
+              className="w-full px-3 py-2 bg-zinc-950 border border-zinc-700 text-zinc-200 placeholder-zinc-600 rounded-lg font-mono text-sm focus:outline-none focus:border-blue-500 resize-none"
+            />
+
+            {jsonError && (
+              <p className="mt-2 text-xs text-red-400">{jsonError}</p>
+            )}
+            {jsonImportSummary && (
+              <p className="mt-2 text-xs text-green-400">
+                ✓ {jsonImportSummary.matched} field{jsonImportSummary.matched !== 1 ? 's' : ''} populated
+                {jsonImportSummary.skipped > 0 && `, ${jsonImportSummary.skipped} unknown key${jsonImportSummary.skipped !== 1 ? 's' : ''} skipped`}
+              </p>
+            )}
+
+            <div className="flex gap-3 mt-4">
+              <button
+                type="button"
+                onClick={handleJsonImport}
+                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Apply
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowJsonModal(false); setJsonInput(''); setJsonError(''); setJsonImportSummary(null); }}
+                className="px-4 py-2 bg-zinc-700 text-zinc-300 text-sm font-medium rounded-lg hover:bg-zinc-600 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit}>
+        {/* JSON Import Button */}
+        <div className="flex justify-end mb-4">
+          <button
+            type="button"
+            onClick={() => { setShowJsonModal(true); setJsonError(''); setJsonImportSummary(null); setTimeout(() => jsonTextareaRef.current?.focus(), 50); }}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-300 bg-zinc-800 border border-zinc-700 rounded-lg hover:bg-zinc-700 hover:text-white transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+            </svg>
+            Import from JSON
+          </button>
+        </div>
+
         <div className="env-fields">
           {envKeys.map((key) => {
             const metadata = envMetadata[key];


### PR DESCRIPTION
## Summary
- Adds **Import from JSON** button to the server env config form on the server details page
- Supports three JSON formats: flat \`{ KEY: VALUE }\`, \`{ env: {...} }\`, or full MCP config \`{ mcpServers: { id: { env: {...} } } }\`
- Two input methods: upload a JSON file (env block auto-extracted) or paste JSON directly into textarea
- File upload populates the textarea for review before applying — user sees extracted env before committing
- On Apply, only keys matching the server's configured env vars are populated; unknown keys are skipped with a count shown
- 1MB file size guard to prevent memory issues on large uploads
- Success summary shows matched/skipped count, modal auto-closes after 1.5s

## Test plan
- [x] Open a server details page with env vars configured
- [x] Click **Import from JSON** button
- [x] Upload a flat JSON file — verify env block populates in textarea
- [x] Upload a full MCP config JSON — verify only the \`env\` block is extracted
- [x] Paste JSON manually and click Apply — verify matching fields populated
- [x] Paste JSON with unknown keys — verify skipped count shown, no error
- [x] Paste malformed JSON — verify error message shown
- [ ] Upload file > 1MB — verify size error shown
- [x] Modal auto-closes 1.5s after successful apply