### PR TITLE
MCP-510: fix: env save polling stops on failed state, skips poll when server stopped

### DIFF
--- a/fluidmcp/frontend/src/components/ServerEnvForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerEnvForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import type { ServerEnvMetadataResponse } from '../types/server';
 import './ServerEnvForm.css';
 
@@ -21,6 +21,12 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
   const [formValues, setFormValues] = useState<Record<string, string>>({});
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showJsonModal, setShowJsonModal] = useState(false);
+  const [jsonInput, setJsonInput] = useState('');
+  const [jsonError, setJsonError] = useState('');
+  const [jsonImportSummary, setJsonImportSummary] = useState<{ matched: number; skipped: number } | null>(null);
+  const jsonTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Initialize form with empty values (never pre-populate for security)
   useEffect(() => {
@@ -104,6 +110,90 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
   };
 
 
+  const extractEnvFromParsed = (parsed: any): Record<string, string> | null => {
+    // Format 1: { mcpServers: { id: { env: {...} } } }
+    if (parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+      const first = Object.values(parsed.mcpServers)[0] as any;
+      return first?.env && typeof first.env === 'object' ? first.env : {};
+    }
+    // Format 2: { env: { KEY: VALUE } }
+    if (parsed.env && typeof parsed.env === 'object' && !Array.isArray(parsed.env)) {
+      return parsed.env;
+    }
+    // Format 3: flat { KEY: VALUE }
+    if (typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed;
+    }
+    return null;
+  };
+
+  const applyEnvObject = (envObj: Record<string, string>) => {
+    let matched = 0;
+    let skipped = 0;
+    const updates: Record<string, string> = {};
+    Object.entries(envObj).forEach(([k, v]) => {
+      if (k in formValues) {
+        updates[k] = String(v);
+        matched++;
+      } else {
+        skipped++;
+      }
+    });
+    setFormValues(prev => ({ ...prev, ...updates }));
+    setJsonImportSummary({ matched, skipped });
+    if (matched > 0) {
+      setTimeout(() => {
+        setShowJsonModal(false);
+        setJsonInput('');
+        setJsonImportSummary(null);
+      }, 1500);
+    }
+  };
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setJsonError('');
+    setJsonImportSummary(null);
+    if (file.size > 1_000_000) {
+      setJsonError('File too large. Max 1MB.');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string);
+        const envObj = extractEnvFromParsed(parsed);
+        if (!envObj) {
+          setJsonError('Could not extract environment variables from this file.');
+          return;
+        }
+        // Show parsed content in textarea so user can review before applying
+        setJsonInput(JSON.stringify(envObj, null, 2));
+      } catch {
+        setJsonError('Invalid JSON file. Please check the file and try again.');
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  };
+
+  const handleJsonImport = () => {
+    setJsonError('');
+    setJsonImportSummary(null);
+    try {
+      const parsed = JSON.parse(jsonInput);
+      const envObj = extractEnvFromParsed(parsed);
+      if (!envObj) {
+        setJsonError('JSON must be an object of key-value pairs.');
+        return;
+      }
+      applyEnvObject(envObj);
+    } catch {
+      setJsonError('Invalid JSON. Please check the format and try again.');
+    }
+  };
+
   const isSensitiveField = (key: string): boolean => {
     const lowerKey = key.toLowerCase();
     const sensitivePatterns = [
@@ -131,7 +221,99 @@ export const ServerEnvForm: React.FC<ServerEnvFormProps> = ({
 
   return (
     <div className="server-env-form">
+      {/* JSON Import Modal */}
+      {showJsonModal && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="relative bg-gradient-to-br from-zinc-900 to-zinc-800 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-lg p-6">
+            <button
+              type="button"
+              onClick={() => { setShowJsonModal(false); setJsonInput(''); setJsonError(''); setJsonImportSummary(null); }}
+              className="absolute top-4 right-4 text-zinc-400 hover:text-white transition-colors"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+
+            <h3 className="text-lg font-semibold text-white mb-1">Import from JSON</h3>
+            <p className="text-xs text-zinc-400 mb-3">
+              Paste or upload a JSON file. Supports flat <code className="font-mono">{"{ KEY: VALUE }"}</code>, <code className="font-mono">{"{ env: {...} }"}</code>, or full MCP config format. Only keys matching this server's config are applied.
+            </p>
+
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,application/json"
+              onChange={handleFileUpload}
+              className="hidden"
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 mb-3 border-2 border-dashed border-zinc-600 rounded-lg text-zinc-400 hover:border-blue-500 hover:text-blue-400 transition-colors text-sm"
+            >
+              <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+              </svg>
+              Upload JSON file
+            </button>
+
+            <p className="text-xs text-zinc-500 mb-2">— or paste JSON below —</p>
+
+            <textarea
+              ref={jsonTextareaRef}
+              value={jsonInput}
+              onChange={e => { setJsonInput(e.target.value); setJsonError(''); setJsonImportSummary(null); }}
+              placeholder={'{\n  "API_KEY": "sk_...",\n  "DB_URL": "postgresql://..."\n}'}
+              rows={10}
+              className="w-full px-3 py-2 bg-zinc-950 border border-zinc-700 text-zinc-200 placeholder-zinc-600 rounded-lg font-mono text-sm focus:outline-none focus:border-blue-500 resize-none"
+            />
+
+            {jsonError && (
+              <p className="mt-2 text-xs text-red-400">{jsonError}</p>
+            )}
+            {jsonImportSummary && (
+              <p className="mt-2 text-xs text-green-400">
+                ✓ {jsonImportSummary.matched} field{jsonImportSummary.matched !== 1 ? 's' : ''} populated
+                {jsonImportSummary.skipped > 0 && `, ${jsonImportSummary.skipped} unknown key${jsonImportSummary.skipped !== 1 ? 's' : ''} skipped`}
+              </p>
+            )}
+
+            <div className="flex gap-3 mt-4">
+              <button
+                type="button"
+                onClick={handleJsonImport}
+                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors"
+              >
+                Apply
+              </button>
+              <button
+                type="button"
+                onClick={() => { setShowJsonModal(false); setJsonInput(''); setJsonError(''); setJsonImportSummary(null); }}
+                className="px-4 py-2 bg-zinc-700 text-zinc-300 text-sm font-medium rounded-lg hover:bg-zinc-600 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <form onSubmit={handleSubmit}>
+        {/* JSON Import Button */}
+        <div className="flex justify-end mb-4">
+          <button
+            type="button"
+            onClick={() => { setShowJsonModal(true); setJsonError(''); setJsonImportSummary(null); setTimeout(() => jsonTextareaRef.current?.focus(), 50); }}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-xs font-medium text-zinc-300 bg-zinc-800 border border-zinc-700 rounded-lg hover:bg-zinc-700 hover:text-white transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+            </svg>
+            Import from JSON
+          </button>
+        </div>
+
         <div className="env-fields">
           {envKeys.map((key) => {
             const metadata = envMetadata[key];

--- a/fluidmcp/frontend/src/components/ServerForm.tsx
+++ b/fluidmcp/frontend/src/components/ServerForm.tsx
@@ -1,13 +1,14 @@
-import { useState } from 'react';
+import { useState, useRef } from 'react';
 
 interface ServerFormProps {
   mode: 'create' | 'edit';
   initialData?: any;
+  existingIds?: string[];
   onSubmit: (data: any) => Promise<boolean>;
   onCancel: () => void;
 }
 
-export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSubmit, onCancel }) => {
+export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, existingIds = [], onSubmit, onCancel }) => {
   const [formData, setFormData] = useState({
     id: initialData?.id || '',
     name: initialData?.name || '',
@@ -19,6 +20,57 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
   });
 
   const [submitting, setSubmitting] = useState(false);
+  const [jsonError, setJsonError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const idConflict = mode === 'create' && formData.id.length > 0 && existingIds.includes(formData.id);
+
+  const handleJsonUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setJsonError('');
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string);
+
+        // Support two formats:
+        // 1. { "mcpServers": { "server-id": { command, args, env, ... } } }
+        // 2. Direct config: { command, args, env, id, name, description, ... }
+        let serverId = '';
+        let serverConfig: any = parsed;
+
+        if (parsed.mcpServers && typeof parsed.mcpServers === 'object') {
+          const entries = Object.entries(parsed.mcpServers);
+          if (entries.length === 0) {
+            setJsonError('No servers found in mcpServers object.');
+            return;
+          }
+          [serverId, serverConfig] = entries[0] as [string, any];
+        }
+
+        const envEntries = Object.entries(serverConfig?.env || {})
+          .map(([k, v]) => `${k}=${v}`)
+          .join('\n');
+
+        setFormData(prev => ({
+          ...prev,
+          id: (serverId || serverConfig?.id || prev.id).toLowerCase().replace(/[^a-z0-9-]/g, '-'),
+          name: serverConfig?.name || prev.name,
+          description: serverConfig?.description || prev.description,
+          command: serverConfig?.command || prev.command,
+          args: Array.isArray(serverConfig?.args) ? serverConfig.args.join(' ') : (serverConfig?.args || prev.args),
+          env: envEntries,
+        }));
+      } catch {
+        setJsonError('Invalid JSON file. Please check the file and try again.');
+      }
+    };
+    reader.readAsText(file);
+    // Reset input so the same file can be re-uploaded if needed
+    e.target.value = '';
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -74,6 +126,35 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
+      {/* JSON Upload — create mode only */}
+      {mode === 'create' && (
+        <div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleJsonUpload}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            className="w-full flex items-center justify-center space-x-2 px-4 py-3 border-2 border-dashed border-zinc-600 rounded-lg text-zinc-400 hover:border-blue-500 hover:text-blue-400 transition-colors"
+          >
+            <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12" />
+            </svg>
+            <span className="text-sm font-medium">Upload JSON config to auto-fill</span>
+          </button>
+          {jsonError && (
+            <p className="mt-1 text-xs text-red-400">{jsonError}</p>
+          )}
+          <p className="mt-1 text-xs text-zinc-500">
+            Accepts MCP config format: <code className="font-mono">{"{ mcpServers: { id: { command, args, env } } }"}</code>
+          </p>
+        </div>
+      )}
+
       {/* Server ID */}
       <div>
         <label className="block text-sm font-medium text-zinc-200 mb-2">
@@ -84,13 +165,23 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
           value={formData.id}
           onChange={(e) => setFormData({ ...formData, id: e.target.value.toLowerCase() })}
           disabled={mode === 'edit'}
-          className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700 text-white placeholder-zinc-400 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 disabled:bg-zinc-900/50 disabled:cursor-not-allowed disabled:text-zinc-500"
+          className={`w-full px-3 py-2 bg-zinc-800/50 border text-white placeholder-zinc-400 rounded-lg focus:ring-2 disabled:bg-zinc-900/50 disabled:cursor-not-allowed disabled:text-zinc-500 ${
+            idConflict
+              ? 'border-red-500 focus:ring-red-500 focus:border-red-500'
+              : 'border-zinc-700 focus:ring-blue-500 focus:border-blue-500'
+          }`}
           placeholder="my-server-id"
           required
         />
-        <p className="mt-1 text-xs text-zinc-400">
-          Lowercase letters, numbers, hyphens only. Cannot be changed after creation.
-        </p>
+        {idConflict ? (
+          <p className="mt-1 text-xs text-red-400">
+            A server with this ID already exists. Choose a different ID.
+          </p>
+        ) : (
+          <p className="mt-1 text-xs text-zinc-400">
+            Lowercase letters, numbers, hyphens only. Cannot be changed after creation.
+          </p>
+        )}
       </div>
 
       {/* Server Name */}
@@ -203,7 +294,7 @@ export const ServerForm: React.FC<ServerFormProps> = ({ mode, initialData, onSub
         <button
           type="submit"
           className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          disabled={submitting}
+          disabled={submitting || idConflict}
         >
           {submitting ? 'Saving...' : mode === 'create' ? 'Create Server' : 'Save Changes'}
         </button>

--- a/fluidmcp/frontend/src/hooks/useServerPolling.ts
+++ b/fluidmcp/frontend/src/hooks/useServerPolling.ts
@@ -23,6 +23,10 @@ export function useServerPolling(serverId: string) {
 
           // Check state if specified
           if (expectedState && server.status?.state !== expectedState) {
+            // Server failed — no point waiting out the full timeout
+            if (server.status?.state === 'failed') {
+              throw new Error('Server failed to start. Check server logs for details.');
+            }
             return false;
           }
 

--- a/fluidmcp/frontend/src/pages/ManageServers.tsx
+++ b/fluidmcp/frontend/src/pages/ManageServers.tsx
@@ -232,6 +232,7 @@ export default function ManageServers() {
                     <ServerForm
                       mode="create"
                       initialData={null}
+                      existingIds={servers.map(s => s.id)}
                       onSubmit={handleFormSubmit}
                       onCancel={() => setShowForm(false)}
                     />

--- a/fluidmcp/frontend/src/pages/ServerDetails.tsx
+++ b/fluidmcp/frontend/src/pages/ServerDetails.tsx
@@ -109,34 +109,42 @@ export default function ServerDetails() {
     if (!serverId) return;
 
     const toastId = `env-${serverId}`;
+    const wasRunning = serverDetails?.status?.state === 'running';
 
     setEnvSubmitting(true);
-    showLoading('Saving environment variables and restarting server...', toastId);
+    showLoading(
+      wasRunning ? 'Saving environment variables and restarting server...' : 'Saving environment variables...',
+      toastId
+    );
 
     try {
       await updateEnv(env);
 
-      // Poll for server restart and tools availability
-      const success = await pollForServerState({
-        expectedState: 'running',
-        checkTools: true,
-        onSuccess: () => {
-          // Collapse form after successful restart
-          setEnvFormExpanded(false);
-          showSuccess('Environment variables saved and server restarted successfully', toastId);
-        },
-        onTimeout: () => {
-          showError('Server restart timed out. Please check server status manually.', toastId);
-        },
-      });
+      if (wasRunning) {
+        // Server was running — backend will restart it, poll until running again
+        const success = await pollForServerState({
+          expectedState: 'running',
+          onSuccess: () => {
+            setEnvFormExpanded(false);
+            showSuccess('Environment variables saved and server restarted successfully', toastId);
+          },
+          onTimeout: () => {
+            showError('Server restart timed out. Please check server status manually.', toastId);
+          },
+        });
 
-      // Refetch server details and env metadata after polling completes
-      if (success) {
+        if (success) {
+          await Promise.all([refetch(), refetchEnv()]);
+        }
+      } else {
+        // Server was stopped/failed — env saved, no restart triggered by backend
+        setEnvFormExpanded(false);
+        showSuccess('Environment variables saved. Start the server to apply them.', toastId);
         await Promise.all([refetch(), refetchEnv()]);
       }
     } catch (err) {
       showError(err instanceof Error ? err.message : 'Failed to update environment variables', toastId);
-      throw err; // Re-throw so form knows it failed
+      throw err;
     } finally {
       setEnvSubmitting(false);
     }


### PR DESCRIPTION
## Summary
- Polling now throws immediately when server enters `failed` state instead of waiting the full 30s timeout
- `handleEnvSubmit` checks `wasRunning` before the save — if server was stopped/failed, skips polling entirely and shows "Environment variables saved. Start the server to apply them." toast
- Removed `checkTools: true` from the env-save poll — a server with 0 tools was causing the poll to never resolve even after a successful restart

## Root Cause
The poll condition required both `state === running` AND `tools.length > 0`. Servers with no tools would restart successfully but the poll would keep hammering for the full 30s timeout before showing a timeout error.

## Test plan
- [x] Save env on a **stopped** server → instant success toast, no polling, form collapses
- [x] Save env on a **running** server → restart triggers, poll resolves on `running` state, success toast
- [x] Save env on a running server with **0 tools** → same as above, resolves immediately on restart
- [ ] Start a server that fails → polling stops immediately with error toast, no 30s wait
- [x] Verify behaviour identical in `--secure` mode (auth token flows unchanged)