### PR TITLE
MCP-517: MCP Inspector 5B: LLM response streaming (SSE)

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -1,11 +1,13 @@
 import uuid
 import asyncio
 import time
+import json
 import ipaddress
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, AsyncGenerator
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Body, Depends
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from loguru import logger
 
@@ -40,6 +42,10 @@ class ConnectRequest(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
+    provider: Optional[str] = "groq"
+    model: Optional[str] = None
+    api_key: Optional[str] = None
+    system_prompt: Optional[str] = None
 
 class ReadResourceRequest(BaseModel):
     uri: str
@@ -361,6 +367,93 @@ async def export_server(session_id: str):
     }
 
 
+@router.post("/inspector/{session_id}/chat/stream")
+async def chat_stream(session_id: str, body: ChatRequest):
+    """
+    Streaming chat endpoint — returns SSE events as the LLM generates tokens.
+
+    Event types:
+      {"type": "thinking"}                          — LLM is deciding which tool to use
+      {"type": "token", "content": "..."}           — streamed response token
+      {"type": "tool_call", "tool_name": "...", "params": {...}}  — tool selected
+      {"type": "clarification", "message": "..."}   — LLM couldn't pick a tool
+      {"type": "error", "message": "..."}           — unrecoverable error
+      {"type": "done"}                              — stream complete
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    session.last_used = time.time()
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        def sse(data: dict) -> str:
+            return f"data: {json.dumps(data)}\n\n"
+
+        try:
+            from ..services.inspector_agent import stream_tool_selection
+
+            tools = await session.list_tools()
+
+            if not tools:
+                yield sse({"type": "clarification", "message": "No tools available on this server."})
+                yield sse({"type": "done"})
+                return
+
+            yield sse({"type": "thinking"})
+
+            tool_name = None
+            tool_params = {}
+            clarification = None
+
+            async for event in stream_tool_selection(
+                message=body.message,
+                tools=tools,
+                chat_history=body.chat_history or [],
+                provider=body.provider or "groq",
+                model=body.model,
+                api_key=body.api_key,
+                system_prompt=body.system_prompt,
+            ):
+                event_type = event.get("type")
+
+                if event_type == "token":
+                    yield sse(event)
+
+                elif event_type == "tool_call":
+                    tool_name = event.get("tool_name")
+                    tool_params = event.get("params", {})
+                    available_names = {t["name"] for t in tools}
+                    if tool_name and tool_name in available_names:
+                        yield sse(event)
+                    else:
+                        clarification = "Could not determine which tool to run."
+
+                elif event_type == "clarification":
+                    clarification = event.get("message", "Could not determine which tool to run.")
+
+            if clarification:
+                yield sse({"type": "clarification", "message": clarification})
+            elif tool_name:
+                session.add_log("chat", f"User: {body.message} → tool selected: {tool_name}")
+
+            yield sse({"type": "done"})
+
+        except Exception as e:
+            logger.error(f"Inspector chat stream error: {e}")
+            yield sse({"type": "error", "message": "Unable to determine which tool to run."})
+            yield sse({"type": "done"})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.post("/inspector/{session_id}/chat")
 async def chat_with_tools(session_id: str, body: ChatRequest):
     """
@@ -375,7 +468,6 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
     session.last_used = time.time()
 
     try:
-        # Lazy import — avoids server startup failure when GROQ_API_KEY is absent
         from ..services.inspector_agent import choose_tool_with_llm
 
         tools = await session.list_tools()
@@ -386,9 +478,14 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent, passing chat history for multi-turn context
         agent_result = await choose_tool_with_llm(
-            body.message, tools, chat_history=body.chat_history or []
+            body.message,
+            tools,
+            chat_history=body.chat_history or [],
+            provider=body.provider or "groq",
+            model=body.model,
+            api_key=body.api_key,
+            system_prompt=body.system_prompt,
         )
 
         # Validate the response has the expected fields

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -2,11 +2,13 @@ import os
 import uuid
 import asyncio
 import time
+import json
 import ipaddress
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, AsyncGenerator
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, HTTPException, Body, Depends
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from loguru import logger
 
@@ -396,6 +398,93 @@ async def export_server(session_id: str):
     }
 
 
+@router.post("/inspector/{session_id}/chat/stream")
+async def chat_stream(session_id: str, body: ChatRequest):
+    """
+    Streaming chat endpoint — returns SSE events as the LLM generates tokens.
+
+    Event types:
+      {"type": "thinking"}                          — LLM is deciding which tool to use
+      {"type": "token", "content": "..."}           — streamed response token
+      {"type": "tool_call", "tool_name": "...", "params": {...}}  — tool selected
+      {"type": "clarification", "message": "..."}   — LLM couldn't pick a tool
+      {"type": "error", "message": "..."}           — unrecoverable error
+      {"type": "done"}                              — stream complete
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+
+    session.last_used = time.time()
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        def sse(data: dict) -> str:
+            return f"data: {json.dumps(data)}\n\n"
+
+        try:
+            from ..services.inspector_agent import stream_tool_selection
+
+            tools = await session.list_tools()
+
+            if not tools:
+                yield sse({"type": "clarification", "message": "No tools available on this server."})
+                yield sse({"type": "done"})
+                return
+
+            yield sse({"type": "thinking"})
+
+            tool_name = None
+            tool_params = {}
+            clarification = None
+
+            async for event in stream_tool_selection(
+                message=body.message,
+                tools=tools,
+                chat_history=body.chat_history or [],
+                provider=body.provider or "groq",
+                model=body.model,
+                api_key=body.api_key,
+                system_prompt=body.system_prompt,
+            ):
+                event_type = event.get("type")
+
+                if event_type == "token":
+                    yield sse(event)
+
+                elif event_type == "tool_call":
+                    tool_name = event.get("tool_name")
+                    tool_params = event.get("params", {})
+                    available_names = {t["name"] for t in tools}
+                    if tool_name and tool_name in available_names:
+                        yield sse(event)
+                    else:
+                        clarification = "Could not determine which tool to run."
+
+                elif event_type == "clarification":
+                    clarification = event.get("message", "Could not determine which tool to run.")
+
+            if clarification:
+                yield sse({"type": "clarification", "message": clarification})
+            elif tool_name:
+                session.add_log("chat", f"User: {body.message} → tool selected: {tool_name}")
+
+            yield sse({"type": "done"})
+
+        except Exception as e:
+            logger.error(f"Inspector chat stream error: {e}")
+            yield sse({"type": "error", "message": "Unable to determine which tool to run."})
+            yield sse({"type": "done"})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @router.post("/inspector/{session_id}/chat")
 async def chat_with_tools(session_id: str, body: ChatRequest):
     """
@@ -410,7 +499,6 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
     session.last_used = time.time()
 
     try:
-        # Lazy import — avoids server startup failure when GROQ_API_KEY is absent
         from ..services.inspector_agent import choose_tool_with_llm
 
         tools = await session.list_tools()
@@ -421,15 +509,14 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the agent with the requested provider/model/key
         agent_result = await choose_tool_with_llm(
             body.message,
             tools,
             chat_history=body.chat_history or [],
             provider=body.provider or "groq",
-            model=body.model or None,
-            api_key=body.api_key or None,
-            system_prompt=body.system_prompt or None,
+            model=body.model,
+            api_key=body.api_key,
+            system_prompt=body.system_prompt,
         )
 
         # Validate the response has the expected fields

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -1,110 +1,25 @@
 import os
 import json
 import asyncio
+from typing import AsyncGenerator
 from loguru import logger
 
 
-def format_tools_for_prompt(tools):
-    """
-    Convert MCP tools into a readable prompt format.
-    This remains dynamic → supports ANY MCP.
-    """
+PROVIDER_DEFAULTS = {
+    "groq":      {"base_url": "https://api.groq.com/openai/v1",              "model": "llama-3.1-8b-instant"},
+    "openai":    {"base_url": "https://api.openai.com/v1",                   "model": "gpt-4o-mini"},
+    "gemini":    {"base_url": "https://generativelanguage.googleapis.com/v1beta/openai", "model": "gemini-2.0-flash"},
+    "anthropic": {"model": "claude-haiku-4-5-20251001"},
+}
 
-    formatted = []
+ENV_KEY_MAP = {
+    "groq":      "GROQ_API_KEY",
+    "openai":    "OPENAI_API_KEY",
+    "gemini":    "GEMINI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+}
 
-    for tool in tools:
-        name = tool.get("name")
-        description = tool.get("description", "No description")
-
-        schema = tool.get("inputSchema", {})
-        props = schema.get("properties", {})
-
-        params = []
-        for param_name, param_info in props.items():
-            param_type = param_info.get("type", "string")
-            params.append(f"- {param_name} ({param_type})")
-
-        param_text = "\n".join(params) if params else "None"
-
-        formatted.append(
-            f"""
-Tool: {name}
-Description: {description}
-Parameters:
-{param_text}
-"""
-        )
-
-    return "\n".join(formatted)
-
-
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list | None = None):
-    """
-    Universal MCP agent powered by Groq.
-
-    Imports and initialises the Groq client lazily so the server can start
-    even when GROQ_API_KEY is absent — the error surfaces only when the chat
-    endpoint is actually called.
-    """
-
-    if chat_history is None:
-        chat_history = []
-
-    if not tools:
-        raise RuntimeError("No tools available")
-
-    logger.info(f"Inspector chat message: {message}")
-
-    # Lazy imports — avoids startup failure when GROQ_API_KEY is absent
-    from dotenv import load_dotenv
-    from openai import OpenAI
-
-    load_dotenv()
-
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    if not groq_api_key:
-        raise RuntimeError("GROQ_API_KEY not configured")
-
-    # Build client inside the function — no module-level side effects
-    client = OpenAI(
-        api_key=groq_api_key,
-        base_url="https://api.groq.com/openai/v1"
-    )
-
-    tool_description = format_tools_for_prompt(tools)
-
-    prompt = f"""
-Available tools:
-{tool_description}
-
-User request: {message}
-
-Instructions:
-1. Choose the BEST tool to fulfill the request.
-2. Extract parameters from the request.
-3. If parameters are missing, infer reasonable defaults or leave them empty.
-
-Return ONLY JSON.
-"""
-
-    try:
-        # The OpenAI client is synchronous — run in a thread to avoid blocking
-        # the event loop.
-        # Build prior turns from chat_history for multi-turn context
-        history_messages = [
-            {"role": "user" if m.get("type") == "user" else "assistant",
-             "content": str(m.get("content", ""))}
-            for m in chat_history
-            if m.get("type") in ("user", "assistant") and m.get("content")
-        ]
-
-        def _call_llm():
-            return client.chat.completions.create(
-                model="llama-3.1-8b-instant",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": """
+SYSTEM_PROMPT = """
 You are a strict JSON API for MCP tool selection.
 
 You MUST return ONLY valid JSON.
@@ -120,52 +35,243 @@ Rules:
 - No markdown
 - No extra text
 - Always return JSON
+- One tool per response only
 """
-                    },
-                    *history_messages,
-                    {
-                        "role": "user",
-                        "content": prompt
-                    }
-                ],
-                temperature=0,
-                max_tokens=200
-            )
 
-        response = await asyncio.to_thread(_call_llm)
 
-        content = response.choices[0].message.content.strip()
+def format_tools_for_prompt(tools):
+    formatted = []
+    for tool in tools:
+        name = tool.get("name")
+        description = tool.get("description", "No description")
+        schema = tool.get("inputSchema", {})
+        props = schema.get("properties", {})
+        params = [f"- {p} ({i.get('type', 'string')})" for p, i in props.items()]
+        param_text = "\n".join(params) if params else "None"
+        formatted.append(f"\nTool: {name}\nDescription: {description}\nParameters:\n{param_text}\n")
+    return "\n".join(formatted)
 
-        logger.info(f"LLM raw response: {repr(content)}")
 
-        # First attempt: direct parse
-        try:
-            result = json.loads(content)
-            logger.info(f"LLM parsed result (direct): {result}")
-            return result
+def _build_messages(message: str, tools: list, chat_history: list, system_prompt: str | None) -> list:
+    tool_description = format_tools_for_prompt(tools)
+    user_content = f"""Available tools:\n{tool_description}\n\nUser request: {message}\n\nInstructions:\n1. Choose the BEST tool to fulfill the request.\n2. Extract parameters from the request.\n3. If parameters are missing, infer reasonable defaults or leave them empty.\n\nReturn ONLY JSON."""
 
-        except json.JSONDecodeError:
-            logger.warning("Direct JSON parse failed, attempting extraction...")
+    history_messages = [
+        {"role": "user" if m.get("type") == "user" else "assistant",
+         "content": str(m.get("content", ""))}
+        for m in chat_history
+        if m.get("type") in ("user", "assistant") and m.get("content")
+    ]
 
-            # Fallback: extract JSON block
-            start = content.find("{")
-            end = content.rfind("}") + 1
+    sys = system_prompt.strip() if system_prompt and system_prompt.strip() else SYSTEM_PROMPT.strip()
 
-            if start == -1 or end == 0:
-                raise ValueError(f"No JSON found in LLM response: {content}")
+    return [
+        {"role": "system", "content": sys},
+        *history_messages,
+        {"role": "user", "content": user_content},
+    ]
 
-            json_str = content[start:end]
 
-            try:
-                result = json.loads(json_str)
-                logger.info(f"LLM parsed result (extracted): {result}")
-                return result
+def _resolve_api_key(provider: str, api_key: str | None) -> str:
+    from dotenv import load_dotenv
+    load_dotenv()
+    key = api_key or os.getenv(ENV_KEY_MAP.get(provider, ""))
+    if not key and provider != "groq":
+        raise RuntimeError(f"No API key provided for provider '{provider}'")
+    if not key:
+        raise RuntimeError("GROQ_API_KEY not configured")
+    return key
 
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to parse extracted JSON.\nRaw response: {content}\nExtracted: {json_str}"
-                ) from e
+
+def _parse_tool_json(content: str) -> dict:
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        start = content.find("{")
+        end = content.rfind("}") + 1
+        if start == -1 or end == 0:
+            raise ValueError(f"No JSON found in LLM response: {content}")
+        return json.loads(content[start:end])
+
+
+async def stream_tool_selection(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+) -> AsyncGenerator[dict, None]:
+    """
+    Async generator that streams LLM tool selection.
+
+    Yields dicts:
+      {"type": "token", "content": "..."}
+      {"type": "tool_call", "tool_name": "...", "params": {...}}
+      {"type": "clarification", "message": "..."}
+    """
+    if chat_history is None:
+        chat_history = []
+
+    logger.info(f"Inspector stream chat — provider={provider} message={message!r}")
+
+    key = _resolve_api_key(provider, api_key)
+    defaults = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["groq"])
+    resolved_model = model or defaults["model"]
+    messages = _build_messages(message, tools, chat_history, system_prompt)
+
+    if provider == "anthropic":
+        async for event in _stream_anthropic(key, resolved_model, messages):
+            yield event
+    else:
+        async for event in _stream_openai_compatible(key, resolved_model, messages, defaults["base_url"], provider):
+            yield event
+
+
+async def _stream_openai_compatible(
+    api_key: str,
+    model: str,
+    messages: list,
+    base_url: str,
+    provider: str,
+) -> AsyncGenerator[dict, None]:
+    from openai import OpenAI
+
+    extra_kwargs = {}
+    if provider == "gemini":
+        extra_kwargs["default_query"] = {"key": api_key}
+
+    client = OpenAI(api_key=api_key, base_url=base_url, **extra_kwargs)
+
+    def _collect_tokens() -> list[str]:
+        # Runs in a thread — collects all tokens before returning to the event loop.
+        # Fine for short JSON tool-selection responses; for true sub-token latency
+        # a queue-based approach would be needed.
+        stream = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0,
+            max_tokens=500,
+            stream=True,
+        )
+        tokens = []
+        for chunk in stream:
+            delta = chunk.choices[0].delta.content if chunk.choices else None
+            if delta:
+                tokens.append(delta)
+        return tokens
+
+    try:
+        tokens = await asyncio.to_thread(_collect_tokens)
+
+        accumulated = ""
+        for token in tokens:
+            accumulated += token
+            yield {"type": "token", "content": token}
+
+        logger.info(f"OpenAI-compatible stream accumulated: {repr(accumulated)}")
+        result = _parse_tool_json(accumulated)
+        yield {"type": "tool_call", "tool_name": result.get("tool_name"), "params": result.get("params", {})}
 
     except Exception as e:
-        logger.error(f"Groq agent error: {e}")
-        raise
+        import re as _re
+        user_message = str(e)
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+        logger.error(f"OpenAI-compatible stream error ({provider}): {user_message}")
+        yield {"type": "clarification", "message": user_message}
+
+
+async def _stream_anthropic(
+    api_key: str,
+    model: str,
+    messages: list,
+) -> AsyncGenerator[dict, None]:
+    import anthropic
+
+    # Anthropic requires system message separate from messages list
+    system_content = SYSTEM_PROMPT.strip()
+    filtered = [m for m in messages if m["role"] != "system"]
+    for m in messages:
+        if m["role"] == "system":
+            system_content = m["content"]
+            break
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    def _collect_tokens() -> list[str]:
+        tokens = []
+        with client.messages.stream(
+            model=model,
+            max_tokens=500,
+            system=system_content,
+            messages=filtered,
+        ) as stream:
+            for event in stream:
+                if (
+                    hasattr(event, "type")
+                    and event.type == "content_block_delta"
+                    and hasattr(event, "delta")
+                    and hasattr(event.delta, "text")
+                ):
+                    tokens.append(event.delta.text)
+        return tokens
+
+    try:
+        tokens = await asyncio.to_thread(_collect_tokens)
+
+        accumulated = ""
+        for token in tokens:
+            accumulated += token
+            yield {"type": "token", "content": token}
+
+        logger.info(f"Anthropic stream accumulated: {repr(accumulated)}")
+        result = _parse_tool_json(accumulated)
+        yield {"type": "tool_call", "tool_name": result.get("tool_name"), "params": result.get("params", {})}
+
+    except Exception as e:
+        import re as _re
+        user_message = str(e)
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+        logger.error(f"Anthropic stream error: {user_message}")
+        yield {"type": "clarification", "message": user_message}
+
+
+# ─── Non-streaming (kept for fallback) ────────────────────────────────────────
+
+async def choose_tool_with_llm(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+):
+    """Non-streaming fallback — collects the full stream and returns a single result dict."""
+    if not tools:
+        raise RuntimeError("No tools available")
+
+    tool_name = None
+    tool_params = {}
+    clarification = None
+
+    async for event in stream_tool_selection(
+        message=message,
+        tools=tools,
+        chat_history=chat_history,
+        provider=provider,
+        model=model,
+        api_key=api_key,
+        system_prompt=system_prompt,
+    ):
+        if event["type"] == "tool_call":
+            tool_name = event["tool_name"]
+            tool_params = event["params"]
+        elif event["type"] == "clarification":
+            clarification = event["message"]
+
+    if clarification:
+        raise ValueError(clarification)
+
+    return {"tool_name": tool_name, "params": tool_params}

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -1,98 +1,25 @@
 import os
 import json
 import asyncio
+from typing import AsyncGenerator
 from loguru import logger
 
 
-# Default models per provider
 PROVIDER_DEFAULTS = {
-    "groq":      {"label": "Groq",      "model": "llama-3.1-8b-instant", "base_url": "https://api.groq.com/openai/v1"},
-    "openai":    {"label": "OpenAI",    "model": "gpt-4o-mini",           "base_url": "https://api.openai.com/v1"},
-    "gemini":    {"label": "Gemini",    "model": "gemini-2.0-flash",      "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"},
-    "anthropic": {"label": "Anthropic", "model": "claude-haiku-4-5-20251001", "base_url": None},
+    "groq":      {"label": "Groq",      "base_url": "https://api.groq.com/openai/v1",                             "model": "llama-3.1-8b-instant"},
+    "openai":    {"label": "OpenAI",    "base_url": "https://api.openai.com/v1",                                  "model": "gpt-4o-mini"},
+    "gemini":    {"label": "Gemini",    "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/",   "model": "gemini-2.0-flash"},
+    "anthropic": {"label": "Anthropic", "base_url": None,                                                         "model": "claude-haiku-4-5-20251001"},
 }
 
+ENV_KEY_MAP = {
+    "groq":      "GROQ_API_KEY",
+    "openai":    "OPENAI_API_KEY",
+    "gemini":    "GEMINI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+}
 
-def format_tools_for_prompt(tools):
-    """
-    Convert MCP tools into a readable prompt format.
-    This remains dynamic → supports ANY MCP.
-    """
-
-    formatted = []
-
-    for tool in tools:
-        name = tool.get("name")
-        description = tool.get("description", "No description")
-
-        schema = tool.get("inputSchema", {})
-        props = schema.get("properties", {})
-
-        params = []
-        for param_name, param_info in props.items():
-            param_type = param_info.get("type", "string")
-            params.append(f"- {param_name} ({param_type})")
-
-        param_text = "\n".join(params) if params else "None"
-
-        formatted.append(
-            f"""
-Tool: {name}
-Description: {description}
-Parameters:
-{param_text}
-"""
-        )
-
-    return "\n".join(formatted)
-
-
-async def choose_tool_with_llm(
-    message: str,
-    tools: list,
-    chat_history: list | None = None,
-    provider: str = "groq",
-    model: str | None = None,
-    api_key: str | None = None,
-    system_prompt: str | None = None,
-):
-    """
-    Universal MCP agent with multi-provider support.
-
-    Supported providers: groq, openai, anthropic, gemini
-    - groq/openai/gemini: use the openai-compatible client
-    - anthropic: use the anthropic SDK directly
-
-    API keys are passed in from the frontend (stored in localStorage per provider).
-    Falls back to environment variables if no key is provided.
-    """
-
-    if chat_history is None:
-        chat_history = []
-
-    if not tools:
-        raise RuntimeError("No tools available")
-
-    provider = provider.lower()
-    logger.info(f"Inspector chat — provider={provider}, message={message!r}")
-
-    tool_description = format_tools_for_prompt(tools)
-
-    prompt = f"""
-Available tools:
-{tool_description}
-
-User request: {message}
-
-Instructions:
-1. Choose the BEST tool to fulfill the request.
-2. Extract parameters from the request.
-3. If parameters are missing, infer reasonable defaults or leave them empty. DO NOT explain anything.
-
-Return ONLY JSON.
-"""
-
-    sys_content = system_prompt.strip() if system_prompt and system_prompt.strip() else """
+SYSTEM_PROMPT = """
 You are a strict JSON API for MCP tool selection.
 
 You MUST return ONLY valid JSON.
@@ -108,7 +35,26 @@ Rules:
 - No markdown
 - No extra text
 - Always return JSON
+- One tool per response only
 """
+
+
+def format_tools_for_prompt(tools):
+    formatted = []
+    for tool in tools:
+        name = tool.get("name")
+        description = tool.get("description", "No description")
+        schema = tool.get("inputSchema", {})
+        props = schema.get("properties", {})
+        params = [f"- {p} ({i.get('type', 'string')})" for p, i in props.items()]
+        param_text = "\n".join(params) if params else "None"
+        formatted.append(f"\nTool: {name}\nDescription: {description}\nParameters:\n{param_text}\n")
+    return "\n".join(formatted)
+
+
+def _build_messages(message: str, tools: list, chat_history: list, system_prompt: str | None) -> list:
+    tool_description = format_tools_for_prompt(tools)
+    user_content = f"""Available tools:\n{tool_description}\n\nUser request: {message}\n\nInstructions:\n1. Choose the BEST tool to fulfill the request.\n2. Extract parameters from the request.\n3. If parameters are missing, infer reasonable defaults or leave them empty.\n\nReturn ONLY JSON."""
 
     history_messages = [
         {"role": "user" if m.get("type") == "user" else "assistant",
@@ -117,150 +63,215 @@ Rules:
         if m.get("type") in ("user", "assistant") and m.get("content")
     ]
 
-    if provider == "anthropic":
-        return await _call_anthropic(
-            message=prompt,
-            sys_content=sys_content,
-            history_messages=history_messages,
-            model=model,
-            api_key=api_key,
-        )
-    else:
-        return await _call_openai_compatible(
-            message=prompt,
-            sys_content=sys_content,
-            history_messages=history_messages,
-            provider=provider,
-            model=model,
-            api_key=api_key,
-        )
+    sys = system_prompt.strip() if system_prompt and system_prompt.strip() else SYSTEM_PROMPT.strip()
+
+    return [
+        {"role": "system", "content": sys},
+        *history_messages,
+        {"role": "user", "content": user_content},
+    ]
 
 
-async def _call_openai_compatible(
-    message: str,
-    sys_content: str,
-    history_messages: list,
-    provider: str,
-    model: str | None,
-    api_key: str | None,
-):
-    """Call Groq, OpenAI, or Gemini via the OpenAI-compatible client."""
-    from openai import OpenAI
+def _resolve_api_key(provider: str, api_key: str | None) -> str:
     from dotenv import load_dotenv
-
     load_dotenv()
-
-    defaults = PROVIDER_DEFAULTS.get(provider)
-    if not defaults:
-        raise RuntimeError(f"Unknown provider: {provider!r}")
-
-    resolved_model = model or defaults["model"]
-    base_url = defaults["base_url"]
-
-    # Key resolution: explicit > env var
-    env_key_names = {
-        "groq":   "GROQ_API_KEY",
-        "openai": "OPENAI_API_KEY",
-        "gemini": "GEMINI_API_KEY",
-    }
-    resolved_key = api_key or os.getenv(env_key_names.get(provider, ""), "")
-    if not resolved_key:
-        raise RuntimeError(
-            f"No API key provided for {defaults['label']}. "
-            "Please add your API key in the LLM settings."
-        )
-
-    # Gemini's OpenAI-compatible endpoint requires the key as a query param.
-    # Use default_query so the OpenAI client appends ?key=... to every request
-    # without corrupting the path (appending to base_url breaks path construction).
-    if provider == "gemini":
-        client = OpenAI(api_key="not-used", base_url=base_url, default_query={"key": resolved_key})
-    else:
-        client = OpenAI(api_key=resolved_key, base_url=base_url)
-
-    def _call():
-        return client.chat.completions.create(
-            model=resolved_model,
-            messages=[
-                {"role": "system", "content": sys_content},
-                *history_messages,
-                {"role": "user", "content": message},
-            ],
-            temperature=0,
-            max_tokens=200,
-        )
-
-    response = await asyncio.to_thread(_call)
-    content = response.choices[0].message.content.strip()
-    logger.info(f"[{provider}] raw response: {repr(content)}")
-    return _parse_json_response(content)
+    key = api_key or os.getenv(ENV_KEY_MAP.get(provider, ""))
+    if not key and provider != "groq":
+        raise RuntimeError(f"No API key provided for provider '{provider}'")
+    if not key:
+        raise RuntimeError("GROQ_API_KEY not configured")
+    return key
 
 
-async def _call_anthropic(
-    message: str,
-    sys_content: str,
-    history_messages: list,
-    model: str | None,
-    api_key: str | None,
-):
-    """Call Anthropic Claude via the anthropic SDK."""
-    from anthropic import Anthropic
-    from dotenv import load_dotenv
-
-    load_dotenv()
-
-    resolved_model = model or "claude-haiku-4-5-20251001"
-    resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
-    if not resolved_key:
-        raise RuntimeError(
-            "No API key provided for Anthropic. "
-            "Please add your API key in the LLM settings."
-        )
-
-    client = Anthropic(api_key=resolved_key)
-
-    # Anthropic uses system param separately; convert history
-    anthropic_messages = []
-    for m in history_messages:
-        anthropic_messages.append({"role": m["role"], "content": m["content"]})
-    anthropic_messages.append({"role": "user", "content": message})
-
-    def _call():
-        return client.messages.create(
-            model=resolved_model,
-            system=sys_content,
-            messages=anthropic_messages,
-            temperature=0,
-            max_tokens=200,
-        )
-
-    response = await asyncio.to_thread(_call)
-    content = response.content[0].text.strip()
-    logger.info(f"[anthropic] raw response: {repr(content)}")
-    return _parse_json_response(content)
-
-
-def _parse_json_response(content: str) -> dict:
-    """Parse JSON from LLM response, with fallback extraction."""
+def _parse_tool_json(content: str) -> dict:
     try:
-        result = json.loads(content)
-        logger.info(f"LLM parsed result (direct): {result}")
-        return result
+        return json.loads(content)
     except json.JSONDecodeError:
-        logger.warning("Direct JSON parse failed, attempting extraction...")
+        start = content.find("{")
+        end = content.rfind("}") + 1
+        if start == -1 or end == 0:
+            raise ValueError(f"No JSON found in LLM response: {content}")
+        return json.loads(content[start:end])
 
-    start = content.find("{")
-    end = content.rfind("}") + 1
 
-    if start == -1 or end == 0:
-        raise ValueError(f"No JSON found in LLM response: {content}")
+async def stream_tool_selection(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+) -> AsyncGenerator[dict, None]:
+    """
+    Async generator that streams LLM tool selection.
 
-    json_str = content[start:end]
+    Yields dicts:
+      {"type": "token", "content": "..."}
+      {"type": "tool_call", "tool_name": "...", "params": {...}}
+      {"type": "clarification", "message": "..."}
+    """
+    if chat_history is None:
+        chat_history = []
+
+    logger.info(f"Inspector stream chat — provider={provider} message={message!r}")
+
+    key = _resolve_api_key(provider, api_key)
+    defaults = PROVIDER_DEFAULTS.get(provider, PROVIDER_DEFAULTS["groq"])
+    resolved_model = model or defaults["model"]
+    messages = _build_messages(message, tools, chat_history, system_prompt)
+
+    if provider == "anthropic":
+        async for event in _stream_anthropic(key, resolved_model, messages):
+            yield event
+    else:
+        async for event in _stream_openai_compatible(key, resolved_model, messages, defaults["base_url"], provider):
+            yield event
+
+
+async def _stream_openai_compatible(
+    api_key: str,
+    model: str,
+    messages: list,
+    base_url: str,
+    provider: str,
+) -> AsyncGenerator[dict, None]:
+    from openai import OpenAI
+
+    extra_kwargs = {}
+    if provider == "gemini":
+        extra_kwargs["default_query"] = {"key": api_key}
+
+    client = OpenAI(api_key=api_key, base_url=base_url, **extra_kwargs)
+
+    def _collect_tokens() -> list[str]:
+        # Runs in a thread — collects all tokens before returning to the event loop.
+        # Fine for short JSON tool-selection responses; for true sub-token latency
+        # a queue-based approach would be needed.
+        stream = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0,
+            max_tokens=500,
+            stream=True,
+        )
+        tokens = []
+        for chunk in stream:
+            delta = chunk.choices[0].delta.content if chunk.choices else None
+            if delta:
+                tokens.append(delta)
+        return tokens
+
     try:
-        result = json.loads(json_str)
-        logger.info(f"LLM parsed result (extracted): {result}")
-        return result
+        tokens = await asyncio.to_thread(_collect_tokens)
+
+        accumulated = ""
+        for token in tokens:
+            accumulated += token
+            yield {"type": "token", "content": token}
+
+        logger.info(f"OpenAI-compatible stream accumulated: {repr(accumulated)}")
+        result = _parse_tool_json(accumulated)
+        yield {"type": "tool_call", "tool_name": result.get("tool_name"), "params": result.get("params", {})}
+
     except Exception as e:
-        raise ValueError(
-            f"Failed to parse extracted JSON.\nRaw: {content}\nExtracted: {json_str}"
-        ) from e
+        import re as _re
+        user_message = str(e)
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+        logger.error(f"OpenAI-compatible stream error ({provider}): {user_message}")
+        yield {"type": "clarification", "message": user_message}
+
+
+async def _stream_anthropic(
+    api_key: str,
+    model: str,
+    messages: list,
+) -> AsyncGenerator[dict, None]:
+    import anthropic
+
+    # Anthropic requires system message separate from messages list
+    system_content = SYSTEM_PROMPT.strip()
+    filtered = [m for m in messages if m["role"] != "system"]
+    for m in messages:
+        if m["role"] == "system":
+            system_content = m["content"]
+            break
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    def _collect_tokens() -> list[str]:
+        tokens = []
+        with client.messages.stream(
+            model=model,
+            max_tokens=500,
+            system=system_content,
+            messages=filtered,
+        ) as stream:
+            for event in stream:
+                if (
+                    hasattr(event, "type")
+                    and event.type == "content_block_delta"
+                    and hasattr(event, "delta")
+                    and hasattr(event.delta, "text")
+                ):
+                    tokens.append(event.delta.text)
+        return tokens
+
+    try:
+        tokens = await asyncio.to_thread(_collect_tokens)
+
+        accumulated = ""
+        for token in tokens:
+            accumulated += token
+            yield {"type": "token", "content": token}
+
+        logger.info(f"Anthropic stream accumulated: {repr(accumulated)}")
+        result = _parse_tool_json(accumulated)
+        yield {"type": "tool_call", "tool_name": result.get("tool_name"), "params": result.get("params", {})}
+
+    except Exception as e:
+        import re as _re
+        user_message = str(e)
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+        logger.error(f"Anthropic stream error: {user_message}")
+        yield {"type": "clarification", "message": user_message}
+
+
+# ─── Non-streaming (kept for fallback) ────────────────────────────────────────
+
+async def choose_tool_with_llm(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+):
+    """Non-streaming fallback — collects the full stream and returns a single result dict."""
+    if not tools:
+        raise RuntimeError("No tools available")
+
+    tool_name = None
+    tool_params = {}
+    clarification = None
+
+    async for event in stream_tool_selection(
+        message=message,
+        tools=tools,
+        chat_history=chat_history,
+        provider=provider,
+        model=model,
+        api_key=api_key,
+        system_prompt=system_prompt,
+    ):
+        if event["type"] == "tool_call":
+            tool_name = event["tool_name"]
+            tool_params = event["params"]
+        elif event["type"] == "clarification":
+            clarification = event["message"]
+
+    if clarification:
+        raise ValueError(clarification)
+
+    return {"tool_name": tool_name, "params": tool_params}

--- a/fluidmcp/frontend/src/components/inspector/ChatPanel.tsx
+++ b/fluidmcp/frontend/src/components/inspector/ChatPanel.tsx
@@ -22,6 +22,7 @@ function ThinkingDots() {
 function ChatResultBubble({ result, initialView = "formatted", hideTabSwitcher = false }: { result: unknown; initialView?: "formatted" | "raw"; hideTabSwitcher?: boolean }) {
   const [expanded, setExpanded] = useState(true);
   const [viewMode, setViewMode] = useState<"formatted" | "raw">(initialView);
+  const [expandAll, setExpandAll] = useState(false);
   useEffect(() => { setViewMode(initialView); }, [initialView]);
   const isMcp = typeof result === "object" && result !== null &&
     "content" in result && Array.isArray((result as any).content);
@@ -68,6 +69,15 @@ function ChatResultBubble({ result, initialView = "formatted", hideTabSwitcher =
               <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
               <button style={tabStyle(viewMode === "raw")} onClick={() => setViewMode("raw")}>Raw JSON</button>
             </div>
+            {viewMode === "formatted" && !(isMcp || isMcpArray) && (
+              <button
+                onClick={() => setExpandAll(v => !v)}
+                style={{ ...tabStyle(false), border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.25rem" }}
+                title={expandAll ? "Collapse all" : "Expand all"}
+              >
+                {expandAll ? "Collapse All" : "Expand All"}
+              </button>
+            )}
             <button
               onClick={() => navigator.clipboard.writeText(JSON.stringify(result, null, 2))}
               style={{ ...tabStyle(false), border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.25rem" }}
@@ -94,7 +104,7 @@ function ChatResultBubble({ result, initialView = "formatted", hideTabSwitcher =
             : <div style={{ minWidth: 0, width: "100%", overflow: "hidden" }}>
                 {(isMcp || isMcpArray)
                   ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
-                  : <JsonResultView data={result} />
+                  : <JsonResultView data={result} expandAll={expandAll} />
                 }
               </div>
           }

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -192,6 +192,7 @@ export default function MCPInspector() {
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const chatBottomRef = useRef<HTMLDivElement>(null);
+  const chatAbortRef = useRef<AbortController | null>(null);
 
   const handleConnect = async () => {
 
@@ -524,60 +525,100 @@ export default function MCPInspector() {
   // Capture history with userMsg before any state updates — used below to
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
-
   updateChat(prev => [...prev, userMsg])
 
-  // 3A-4: start an ExecutionRun for this agent turn
   const runId = crypto.randomUUID()
   const runStartTime = Date.now()
   const runSteps: ChatMessage[] = []
   const capturedServerId = selectedServerId
 
+  // Streaming message bubble shown while tokens arrive (before tool_call is known)
+  const streamingMsgId = generateId()
+
+  // Cancel any in-flight stream from a previous turn
+  chatAbortRef.current?.abort()
+  const abortController = new AbortController()
+  chatAbortRef.current = abortController
+
+  const thinkingMsg: ChatMessage = {
+    id: generateId(),
+    runId,
+    type: "thinking",
+    content: "Deciding which tool to use...",
+    timestamp: Date.now(),
+    perfMark: performance.now()
+  }
+
   try {
     setChatLoading(true)
-
-    const thinkingMsg: ChatMessage = {
-      id: generateId(),
-      runId,
-      type: "thinking",
-      content: "Deciding which tool to use...",
-      timestamp: Date.now(),
-      perfMark: performance.now()
-    }
-
     updateChat(prev => [...prev, thinkingMsg])
     runSteps.push(thinkingMsg)
 
-    const res = await apiClient.chatWithInspector(
-      selectedServer.session_id,
-      {
-        message,
-        chat_history: nextHistory.slice(-8).map(m => ({
-          type: m.type,
-          content: m.content
-        })),
-        provider: llmSettings.provider,
-        model: llmSettings.model,
-        ...(llmSettings.apiKeys[llmSettings.provider]
-          ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
-          : {}),
-        ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
+    const payload = {
+      message,
+      chat_history: nextHistory.slice(-8).map(m => ({ type: m.type, content: m.content })),
+      provider: llmSettings.provider,
+      model: llmSettings.model,
+      ...(llmSettings.apiKeys[llmSettings.provider]
+        ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
+        : {}),
+      ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
+    }
+
+    let toolName: string | null = null
+    let toolParams: Record<string, unknown> = {}
+    let clarificationText: string | null = null
+    let streamingStarted = false
+
+    for await (const event of apiClient.chatWithInspectorStream(selectedServer.session_id, payload, abortController.signal)) {
+      if (event.type === "thinking") {
+        // already showing thinking bubble — no-op
+      } else if (event.type === "token" && event.content) {
+        if (!streamingStarted) {
+          // Replace thinking bubble with streaming assistant bubble
+          updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+          updateChat(prev => [...prev, {
+            id: streamingMsgId,
+            runId,
+            type: "assistant",
+            content: event.content ?? "",
+            timestamp: Date.now(),
+            perfMark: performance.now()
+          } as ChatMessage])
+          streamingStarted = true
+        } else {
+          // Append token to existing streaming bubble
+          updateChat(prev => prev.map((m: ChatMessage) =>
+            m.id === streamingMsgId
+              ? { ...m, content: (m.content ?? "") + (event.content ?? "") }
+              : m
+          ))
+        }
+      } else if (event.type === "tool_call") {
+        toolName = event.tool_name ?? null
+        toolParams = (event.params as Record<string, unknown>) ?? {}
+      } else if (event.type === "clarification") {
+        clarificationText = event.message ?? "Could not determine which tool to run."
+      } else if (event.type === "error") {
+        clarificationText = event.message ?? "Unable to determine which tool to run."
       }
-    )
+    }
 
+    // Remove thinking bubble if streaming never started
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+    // Remove streaming bubble — it will be replaced by a proper typed message
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== streamingMsgId))
 
-    if (res.clarification_needed) {
+    if (clarificationText || !toolName) {
       const assistantMsg: ChatMessage = {
         id: generateId(),
         runId,
         type: "assistant",
-        content: res.message,
+        content: clarificationText ?? "Could not determine which tool to run.",
         timestamp: Date.now(),
         perfMark: performance.now()
       }
       updateChat(prev => [...prev, assistantMsg])
-      // save run (no tool call — just clarification)
       setExecutionHistoryByServer(prev => ({
         ...prev,
         [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
@@ -589,24 +630,21 @@ export default function MCPInspector() {
       id: generateId(),
       runId,
       type: "tool_call",
-      toolName: res.tool_name,
-      params: res.params,
+      toolName,
+      params: toolParams,
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, toolCallMsg])
     runSteps.push(toolCallMsg)
 
     const result = await apiClient.runInspectorTool(
       selectedServer.session_id,
-      res.tool_name,
-      res.params
+      toolName,
+      toolParams
     )
 
-    // Check for UI widget resource — can be on the tool definition (tools/list)
-    // or on the result itself (FastMCP puts _meta on the result, not the tool def)
-    const toolDef = selectedServer.tools.find((t: any) => t.name === res.tool_name)
+    const toolDef = selectedServer.tools.find((t: any) => t.name === toolName)
     const resourceUri: string | undefined =
       toolDef?._meta?.["ui/resourceUri"] ||
       toolDef?._meta?.ui?.resourceUri ||
@@ -623,17 +661,16 @@ export default function MCPInspector() {
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, resultMsg])
     runSteps.push(resultMsg)
 
-    // save completed run
     setExecutionHistoryByServer(prev => ({
       ...prev,
       [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
     }))
 
   } catch (err: any) {
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id && m.id !== streamingMsgId))
 
     const errorMsg: ChatMessage = {
       id: generateId(),
@@ -643,11 +680,9 @@ export default function MCPInspector() {
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, errorMsg])
     runSteps.push(errorMsg)
 
-    // save failed run
     setExecutionHistoryByServer(prev => ({
       ...prev,
       [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
@@ -671,6 +706,11 @@ export default function MCPInspector() {
     setExecutionTime(null)
     setLastRunParams(null)
   }, [selectedTool])
+
+  // Abort any in-flight chat stream when the selected server changes or on unmount
+  useEffect(() => {
+    return () => { chatAbortRef.current?.abort() }
+  }, [selectedServerId])
 
   useEffect(() => {
     if (selectedServer?.url) {

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -194,6 +194,7 @@ export default function MCPInspector() {
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const chatBottomRef = useRef<HTMLDivElement>(null);
+  const chatAbortRef = useRef<AbortController | null>(null);
 
   const handleConnect = async () => {
 
@@ -526,55 +527,96 @@ export default function MCPInspector() {
   // Capture history with userMsg before any state updates — used below to
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
-
   updateChat(prev => [...prev, userMsg])
 
-  // 3A-4: start an ExecutionRun for this agent turn
   const runId = crypto.randomUUID()
   const runStartTime = Date.now()
   const runSteps: ChatMessage[] = []
   const capturedServerId = selectedServerId
 
+  // Streaming message bubble shown while tokens arrive (before tool_call is known)
+  const streamingMsgId = generateId()
+
+  // Cancel any in-flight stream from a previous turn
+  chatAbortRef.current?.abort()
+  const abortController = new AbortController()
+  chatAbortRef.current = abortController
+
+  const thinkingMsg: ChatMessage = {
+    id: generateId(),
+    runId,
+    type: "thinking",
+    content: "Deciding which tool to use...",
+    timestamp: Date.now(),
+    perfMark: performance.now()
+  }
+
   try {
     setChatLoading(true)
-
-    const thinkingMsg: ChatMessage = {
-      id: generateId(),
-      runId,
-      type: "thinking",
-      content: "Deciding which tool to use...",
-      timestamp: Date.now(),
-      perfMark: performance.now()
-    }
-
     updateChat(prev => [...prev, thinkingMsg])
     runSteps.push(thinkingMsg)
 
-    const res = await apiClient.chatWithInspector(
-      selectedServer.session_id,
-      {
-        message,
-        chat_history: nextHistory.slice(-8).map(m => ({
-          type: m.type,
-          content: m.content
-        })),
-        provider: llmSettings.provider,
-        model: llmSettings.model,
-        ...(llmSettings.apiKeys[llmSettings.provider]
-          ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
-          : {}),
-        ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
+    const payload = {
+      message,
+      chat_history: nextHistory.slice(-8).map(m => ({ type: m.type, content: m.content })),
+      provider: llmSettings.provider,
+      model: llmSettings.model,
+      ...(llmSettings.apiKeys[llmSettings.provider]
+        ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
+        : {}),
+      ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
+    }
+
+    let toolName: string | null = null
+    let toolParams: Record<string, unknown> = {}
+    let clarificationText: string | null = null
+    let streamingStarted = false
+
+    for await (const event of apiClient.chatWithInspectorStream(selectedServer.session_id, payload, abortController.signal)) {
+      if (event.type === "thinking") {
+        // already showing thinking bubble — no-op
+      } else if (event.type === "token" && event.content) {
+        if (!streamingStarted) {
+          // Replace thinking bubble with streaming assistant bubble
+          updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+          updateChat(prev => [...prev, {
+            id: streamingMsgId,
+            runId,
+            type: "assistant",
+            content: event.content ?? "",
+            timestamp: Date.now(),
+            perfMark: performance.now()
+          } as ChatMessage])
+          streamingStarted = true
+        } else {
+          // Append token to existing streaming bubble
+          updateChat(prev => prev.map((m: ChatMessage) =>
+            m.id === streamingMsgId
+              ? { ...m, content: (m.content ?? "") + (event.content ?? "") }
+              : m
+          ))
+        }
+      } else if (event.type === "tool_call") {
+        toolName = event.tool_name ?? null
+        toolParams = (event.params as Record<string, unknown>) ?? {}
+      } else if (event.type === "clarification") {
+        clarificationText = event.message ?? "Could not determine which tool to run."
+      } else if (event.type === "error") {
+        clarificationText = event.message ?? "Unable to determine which tool to run."
       }
-    )
+    }
 
+    // Remove thinking bubble if streaming never started
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
+    // Remove streaming bubble — it will be replaced by a proper typed message
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== streamingMsgId))
 
-    if (res.clarification_needed) {
+    if (clarificationText || !toolName) {
       // No runId — render as standalone assistant bubble, not inside an ExecutionRunBlock
       const assistantMsg: ChatMessage = {
         id: generateId(),
         type: "assistant",
-        content: res.message,
+        content: clarificationText ?? "Could not determine which tool to run.",
         timestamp: Date.now(),
         perfMark: performance.now()
       }
@@ -586,24 +628,21 @@ export default function MCPInspector() {
       id: generateId(),
       runId,
       type: "tool_call",
-      toolName: res.tool_name,
-      params: res.params,
+      toolName,
+      params: toolParams,
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, toolCallMsg])
     runSteps.push(toolCallMsg)
 
     const result = await apiClient.runInspectorTool(
-      selectedServer.session_id,
-      res.tool_name,
-      res.params
+      selectedServer.session_id!,
+      toolName!,
+      toolParams
     )
 
-    // Check for UI widget resource — can be on the tool definition (tools/list)
-    // or on the result itself (FastMCP puts _meta on the result, not the tool def)
-    const toolDef = selectedServer.tools.find((t: any) => t.name === res.tool_name)
+    const toolDef = selectedServer.tools.find((t: any) => t.name === toolName!)
     const resourceUri: string | undefined =
       toolDef?._meta?.["ui/resourceUri"] ||
       toolDef?._meta?.ui?.resourceUri ||
@@ -620,17 +659,16 @@ export default function MCPInspector() {
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, resultMsg])
     runSteps.push(resultMsg)
 
-    // save completed run
     setExecutionHistoryByServer(prev => ({
       ...prev,
       [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
     }))
 
   } catch (err: any) {
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id && m.id !== streamingMsgId))
 
     const errorMsg: ChatMessage = {
       id: generateId(),
@@ -640,11 +678,9 @@ export default function MCPInspector() {
       timestamp: Date.now(),
       perfMark: performance.now()
     }
-
     updateChat(prev => [...prev, errorMsg])
     runSteps.push(errorMsg)
 
-    // save failed run
     setExecutionHistoryByServer(prev => ({
       ...prev,
       [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
@@ -668,6 +704,11 @@ export default function MCPInspector() {
     setExecutionTime(null)
     setLastRunParams(null)
   }, [selectedTool])
+
+  // Abort any in-flight chat stream when the selected server changes or on unmount
+  useEffect(() => {
+    return () => { chatAbortRef.current?.abort() }
+  }, [selectedServerId])
 
   useEffect(() => {
     if (selectedServer?.url) {

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -335,6 +335,56 @@ class ApiClient {
     });
   }
 
+  async *chatWithInspectorStream(
+    sessionId: string,
+    data: any,
+    signal?: AbortSignal,
+  ): AsyncGenerator<{ type: string; content?: string; tool_name?: string; params?: Record<string, unknown>; message?: string }> {
+    const baseUrl = this.baseUrl || "";
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.token) headers["Authorization"] = `Bearer ${this.token}`;
+
+    const response = await fetch(`${baseUrl}/api/inspector/${sessionId}/chat/stream`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(data),
+      signal,
+    });
+
+    if (!response.ok || !response.body) {
+      throw new Error(`Stream request failed: ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            try {
+              const event = JSON.parse(line.slice(6));
+              yield event;
+              if (event.type === "done") return;
+            } catch {
+              // malformed SSE line — skip
+            }
+          }
+        }
+      }
+    } finally {
+      reader.cancel();
+    }
+  }
+
   async exportInspectorServer(sessionId: string): Promise<any> {
     return this.request(`/api/inspector/${sessionId}/export`);
   }


### PR DESCRIPTION
## Summary

- New SSE endpoint `POST /inspector/{session_id}/chat/stream` — yields `thinking`, `token`, `tool_call`, `clarification`, `done` events as the LLM generates
- `inspector_agent.py` rewritten with `stream_tool_selection()` async generator; separate streaming paths for OpenAI-compatible providers (Groq/OpenAI/Gemini) and Anthropic
- `ChatRequest` extended with `provider`, `model`, `api_key`, `system_prompt` — both endpoints now forward all provider settings
- Frontend `chatWithInspectorStream()` reads the SSE stream via `fetch` + `ReadableStream`; live token-by-token assistant bubble gives perceived responsiveness, then is replaced by the structured `tool_call` message
- `AbortController` cancels in-flight stream on server switch or unmount
- Chat result bubble (Formatted view) now has Expand All / Collapse All button, matching Manual tab

## Security
- API key fragments redacted in `logger.error` calls (not just SSE client response) — caught in security review before commit

## Test plan
- [ ] Send a chat message — response should appear token by token before tool runs
- [ ] Switch servers mid-stream — stream should cancel cleanly
- [ ] Invalid API key — error shown in chat, no key fragment in logs
- [ ] Expand All button appears on chat results in Formatted view
- [ ] Non-streaming fallback (`/chat`) still works with provider settings
