### PR TITLE
MCP-519: feat: make server names clickable on Manage Screen

### DIFF
--- a/fluidmcp/frontend/src/pages/ManageServers.tsx
+++ b/fluidmcp/frontend/src/pages/ManageServers.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Navbar } from '../components/Navbar';
 import { ServerForm } from '../components/ServerForm';
 import { CloneFromGithubForm } from '../components/CloneFromGithubForm';
@@ -11,6 +12,7 @@ type FilterMode = 'all' | 'running' | 'stopped' | 'failed';
 type CreateTab = 'manual' | 'github';
 
 export default function ManageServers() {
+  const navigate = useNavigate();
   const [showDeleted, setShowDeleted] = useState(false);
   const { servers, loading, createServer, updateServer, deleteServer, refetch } = useServerManagement(showDeleted);
 
@@ -294,7 +296,12 @@ export default function ManageServers() {
                     return (
                       <tr key={server.id} className="hover:bg-zinc-800/50 transition-colors">
                         <td className="px-6 py-4">
-                          <div className="text-sm font-medium text-white">{server.name}</div>
+                          <span
+                            onClick={() => navigate(`/servers/${server.id}`)}
+                            className="text-sm font-medium text-white hover:text-zinc-300 hover:underline transition-colors cursor-pointer"
+                          >
+                            {server.name}
+                          </span>
                           <div className="text-xs text-zinc-400 font-mono">{server.id}</div>
                           {server.description && (
                             <div className="text-xs text-zinc-400 mt-1">{server.description}</div>


### PR DESCRIPTION
## Summary
- Server names on the Manage Screen are now clickable, navigating directly to `/servers/:id`
- Used a `<span>` instead of `<button>` to avoid the global button CSS applying a blue background on hover
- Hover style is a subtle grey-white underline (`text-zinc-300 + underline`) for a clean, readable affordance

## Test plan
- [x] Go to Manage Screen (`/servers/manage`)
- [x] Hover over a server name — should show grey-white underline, no blue background
- [x] Click a server name — should navigate to that server's detail page
- [x] Verify other columns (command, status, actions) are unaffected