### PR TITLE
MCP Inspector 5K (Phase A): OAuth 2.0 PKCE backend

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -501,7 +501,10 @@ async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None
                     "client_id": entry["client_id"],
                     "code_verifier": entry["verifier"],
                 },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
+                },
             )
             resp.raise_for_status()
             token_data = resp.json()

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -3,9 +3,14 @@ import asyncio
 import time
 import json
 import ipaddress
+import hashlib
+import base64
+import os
+import secrets
 from typing import Dict, Any, Optional, AsyncGenerator
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 
+import httpx
 from fastapi import APIRouter, HTTPException, Body, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -22,12 +27,35 @@ sessions: Dict[str, InspectorSession] = {}
 SESSION_TTL = 1800   # 30 minutes in seconds
 CLEANUP_INTERVAL = 300  # Run cleanup every 5 minutes
 
+# Pending OAuth exchanges: state -> { verifier, token_url, client_id, redirect_uri, result? }
+# Entries expire after OAUTH_STATE_TTL seconds.
+oauth_pending: Dict[str, Dict[str, Any]] = {}
+OAUTH_STATE_TTL = 600  # 10 minutes
+
 
 # ─── Request Models ────────────────────────────────────────────────────────────
 
 class AuthConfig(BaseModel):
-    type: str = "none"        # "none" | "bearer"
+    type: str = "none"        # "none" | "bearer" | "header" | "oauth"
     token: Optional[str] = None
+    # OAuth fields (only used when type == "oauth")
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    expires_at: Optional[float] = None   # Unix timestamp
+    token_url: Optional[str] = None      # token endpoint for refresh
+    client_id: Optional[str] = None
+
+
+class OAuthAuthorizeRequest(BaseModel):
+    authorization_url: str
+    token_url: str
+    client_id: str
+    redirect_uri: str
+    scopes: Optional[str] = ""   # space-separated
+
+
+class OAuthRefreshRequest(BaseModel):
+    pass  # uses credentials stored in the session
 
 
 class ConnectRequest(BaseModel):
@@ -365,6 +393,201 @@ async def export_server(session_id: str):
         "resources": resources,
         "prompts": prompts,
     }
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE (code_verifier, code_challenge) pair using S256 method."""
+    verifier = base64.urlsafe_b64encode(os.urandom(40)).rstrip(b"=").decode()
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _validate_oauth_url(url: str, field: str) -> None:
+    """Ensure an OAuth endpoint URL is a valid public https URL."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise HTTPException(400, f"Invalid {field}")
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, f"{field} must be http/https")
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(400, f"{field} must include a host")
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise HTTPException(400, f"{field} must not point to a private/internal address")
+    except ValueError:
+        pass  # hostname — fine
+
+
+@router.post("/inspector/oauth/authorize")
+async def oauth_authorize(body: OAuthAuthorizeRequest):
+    """
+    Start an OAuth 2.0 PKCE flow.
+
+    Generates a PKCE verifier/challenge pair and a random state token,
+    stores them in oauth_pending, and returns the full authorization URL
+    the frontend should open in a popup.
+    """
+    _validate_oauth_url(body.authorization_url, "authorization_url")
+    _validate_oauth_url(body.token_url, "token_url")
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    oauth_pending[state] = {
+        "verifier": verifier,
+        "token_url": body.token_url,
+        "client_id": body.client_id,
+        "redirect_uri": body.redirect_uri,
+        "created_at": time.time(),
+        "result": None,
+    }
+
+    params = {
+        "response_type": "code",
+        "client_id": body.client_id,
+        "redirect_uri": body.redirect_uri,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    if body.scopes:
+        params["scope"] = body.scopes
+
+    redirect_url = f"{body.authorization_url}?{urlencode(params)}"
+    return {"redirect_url": redirect_url, "state": state}
+
+
+@router.get("/inspector/oauth/callback")
+async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None, error: Optional[str] = None):
+    """
+    OAuth 2.0 redirect callback.
+
+    The authorization server redirects here after the user approves or denies
+    access.  This endpoint exchanges the authorization code for tokens and
+    stores them in oauth_pending so the frontend can poll for the result.
+
+    On success the browser is redirected to /ui/oauth-callback so the popup
+    page can read the result via window.opener.postMessage and close itself.
+    """
+    from fastapi.responses import HTMLResponse
+
+    if error:
+        return HTMLResponse(_oauth_popup_html(None, error))
+
+    if not state or not code:
+        return HTMLResponse(_oauth_popup_html(None, "missing_code_or_state"))
+
+    entry = oauth_pending.get(state)
+    if not entry:
+        return HTMLResponse(_oauth_popup_html(None, "invalid_or_expired_state"))
+
+    # Expire stale entries
+    if time.time() - entry["created_at"] > OAUTH_STATE_TTL:
+        oauth_pending.pop(state, None)
+        return HTMLResponse(_oauth_popup_html(None, "state_expired"))
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                entry["token_url"],
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": entry["redirect_uri"],
+                    "client_id": entry["client_id"],
+                    "code_verifier": entry["verifier"],
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            resp.raise_for_status()
+            token_data = resp.json()
+    except Exception as e:
+        logger.warning(f"OAuth callback: token exchange failed — {e}")
+        oauth_pending.pop(state, None)
+        return HTMLResponse(_oauth_popup_html(None, f"token_exchange_failed: {e}"))
+
+    result = {
+        "access_token": token_data.get("access_token"),
+        "refresh_token": token_data.get("refresh_token"),
+        "expires_at": time.time() + token_data.get("expires_in", 3600),
+        "token_url": entry["token_url"],
+        "client_id": entry["client_id"],
+    }
+    entry["result"] = result
+    logger.info(f"OAuth callback: token exchange succeeded for state={state[:8]}…")
+    return HTMLResponse(_oauth_popup_html(result, None))
+
+
+@router.get("/inspector/oauth/result/{state}")
+async def oauth_result(state: str):
+    """
+    Poll for an OAuth token result after the popup has completed.
+
+    The frontend opens the authorization URL in a popup.  While the popup is
+    open the frontend polls this endpoint until a result appears (max
+    OAUTH_STATE_TTL seconds).  Once consumed the entry is removed.
+    """
+    entry = oauth_pending.get(state)
+    if not entry:
+        raise HTTPException(404, "OAuth state not found or already consumed")
+    if time.time() - entry["created_at"] > OAUTH_STATE_TTL:
+        oauth_pending.pop(state, None)
+        raise HTTPException(410, "OAuth state expired")
+    if entry["result"] is None:
+        return {"status": "pending"}
+    result = entry.pop("result")
+    oauth_pending.pop(state, None)
+    return {"status": "complete", "token": result}
+
+
+@router.post("/inspector/{session_id}/oauth/refresh")
+async def oauth_refresh(session_id: str):
+    """
+    Manually trigger an OAuth token refresh for an active session.
+    Useful when the frontend detects imminent expiry and wants to refresh
+    before the next tool call.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    if session.auth.get("type") != "oauth":
+        raise HTTPException(400, "Session does not use OAuth auth")
+    try:
+        await session._auto_refresh()
+    except Exception as e:
+        raise HTTPException(502, f"Token refresh failed: {e}")
+    return {
+        "access_token": session.auth.get("access_token"),
+        "expires_at": session.auth.get("expires_at"),
+    }
+
+
+def _oauth_popup_html(token: Optional[dict], error: Optional[str]) -> str:
+    """
+    Minimal HTML page returned to the OAuth popup after the callback.
+    Posts a message to the opener window then closes the popup.
+    """
+    if error:
+        payload = json.dumps({"error": error})
+    else:
+        payload = json.dumps({"token": token})
+    return f"""<!DOCTYPE html>
+<html>
+<head><title>OAuth Callback</title></head>
+<body>
+<script>
+  try {{
+    window.opener.postMessage({payload}, window.location.origin);
+  }} catch(e) {{}}
+  window.close();
+</script>
+<p>Authentication complete. You may close this window.</p>
+</body>
+</html>"""
 
 
 @router.post("/inspector/{session_id}/chat/stream")

--- a/fluidmcp/cli/services/frontend_utils.py
+++ b/fluidmcp/cli/services/frontend_utils.py
@@ -10,7 +10,8 @@ This module provides functionality to:
 from pathlib import Path
 from typing import Optional
 from loguru import logger
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 
@@ -135,6 +136,15 @@ def setup_frontend_routes(
         return False
 
     try:
+        # Starlette's StaticFiles issues a 301 to "/ui/" when "/ui" is requested,
+        # building the Location from the raw Host header. In proxied environments
+        # (GitHub Codespaces, ngrok, Railway) that header is often "localhost",
+        # so the browser gets redirected to localhost instead of the tunnel URL.
+        # Fix: intercept GET /ui before the mount and redirect with a relative path.
+        @app.get("/ui")
+        async def _ui_root_redirect(_req: Request):
+            return RedirectResponse(url="/ui/", status_code=301)
+
         # Mount StaticFiles for serving built assets (JS, CSS, images)
         # The html=True parameter enables SPA mode:
         # - Serves static files normally (app.js, styles.css, etc.)

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -72,6 +72,9 @@ class InspectorSession:
         # Auto-incrementing request ID (avoids hardcoded 1/2/3 collisions)
         self._req_id = 0
 
+        # FastMCP streamable-HTTP session ID (returned in mcp-session-id header)
+        self._mcp_session_id: Optional[str] = None
+
         # SSE state
         self._sse_post_url: Optional[str] = None
         self._sse_ready = asyncio.Event()      # set once endpoint URL is known
@@ -99,12 +102,14 @@ class InspectorSession:
         return self._client
 
     def _build_headers(self) -> Dict[str, str]:
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
         auth_type = self.auth.get("type")
         if auth_type == "bearer" and self.auth.get("token"):
             headers["Authorization"] = f"Bearer {self.auth['token']}"
         elif auth_type == "oauth" and self.auth.get("access_token"):
             headers["Authorization"] = f"Bearer {self.auth['access_token']}"
+        if self._mcp_session_id:
+            headers["mcp-session-id"] = self._mcp_session_id
         headers.update(self.extra_headers)
         return headers
 
@@ -464,6 +469,23 @@ class InspectorSession:
             except Exception as e:
                 logger.warning(f"Inspector: OAuth 401 retry failed — {e}")
         response.raise_for_status()
+
+        # Capture FastMCP streamable-HTTP session ID on first response
+        session_id_header = response.headers.get("mcp-session-id")
+        if session_id_header and not self._mcp_session_id:
+            self._mcp_session_id = session_id_header
+            logger.debug(f"Inspector: captured mcp-session-id={session_id_header}")
+
+        content_type = response.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            # FastMCP streamable-HTTP returns SSE. Extract the first data: line.
+            for line in response.text.splitlines():
+                if line.startswith("data:"):
+                    payload = line[len("data:"):].strip()
+                    if payload:
+                        return json.loads(payload)
+            raise Exception("No data event found in SSE response")
+
         return response.json()
 
     # ── Public API ────────────────────────────────────────────────────────────

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -100,10 +100,50 @@ class InspectorSession:
 
     def _build_headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        if self.auth.get("type") == "bearer" and self.auth.get("token"):
+        auth_type = self.auth.get("type")
+        if auth_type == "bearer" and self.auth.get("token"):
             headers["Authorization"] = f"Bearer {self.auth['token']}"
+        elif auth_type == "oauth" and self.auth.get("access_token"):
+            headers["Authorization"] = f"Bearer {self.auth['access_token']}"
         headers.update(self.extra_headers)
         return headers
+
+    async def _auto_refresh(self) -> None:
+        """Exchange the refresh token for a new access token."""
+        refresh_token = self.auth.get("refresh_token")
+        token_url = self.auth.get("token_url")
+        client_id = self.auth.get("client_id")
+        if not (refresh_token and token_url and client_id):
+            return
+        client = self._get_client()
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self.auth["access_token"] = data["access_token"]
+        if "refresh_token" in data:
+            self.auth["refresh_token"] = data["refresh_token"]
+        if "expires_in" in data:
+            self.auth["expires_at"] = time.time() + data["expires_in"]
+        self.add_log("connect", "OAuth token refreshed")
+
+    async def _ensure_fresh_token(self) -> None:
+        """Proactively refresh the OAuth access token if it expires within 60 seconds."""
+        if self.auth.get("type") != "oauth":
+            return
+        expires_at = self.auth.get("expires_at")
+        if expires_at is not None and time.time() >= expires_at - 60:
+            try:
+                await self._auto_refresh()
+            except Exception as e:
+                logger.warning(f"Inspector: proactive OAuth refresh failed — {e}")
 
     MAX_LOGS = 250
 
@@ -414,8 +454,15 @@ class InspectorSession:
         if self.transport == "sse":
             return await self._sse_request(request)
 
+        await self._ensure_fresh_token()
         client = self._get_client()
         response = await client.post(self.url, json=request, headers=self._build_headers())
+        if response.status_code == 401 and self.auth.get("type") == "oauth":
+            try:
+                await self._auto_refresh()
+                response = await client.post(self.url, json=request, headers=self._build_headers())
+            except Exception as e:
+                logger.warning(f"Inspector: OAuth 401 retry failed — {e}")
         response.raise_for_status()
         return response.json()
 

--- a/fluidmcp/frontend/src/App.tsx
+++ b/fluidmcp/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import LLMModelDetails from "./pages/LLMModelDetails";
 import LLMPlayground from "./pages/LLMPlayground";
 import ManageServers from "./pages/ManageServers";
 import MCPInspector from "./pages/MCPInspector";
+import OAuthCallback from "./pages/OAuthCallback";
 
 function App() {
   return (
@@ -30,6 +31,7 @@ function App() {
         <Route path="/documentation" element={<Documentation />} />
         <Route path="/servers/:serverId" element={<ServerDetails />} />
         <Route path="/inspector" element={<MCPInspector />} />
+        <Route path="/oauth-callback" element={<OAuthCallback />} />
         <Route path="/servers/:serverId/tools/:toolName" element={<ToolRunner />} />
         <Route path="/llm/models" element={<LLMModels />} />
         <Route path="/llm/models/:modelId" element={<LLMModelDetails />} />

--- a/fluidmcp/frontend/src/components/inspector/AddServerModal.tsx
+++ b/fluidmcp/frontend/src/components/inspector/AddServerModal.tsx
@@ -1,4 +1,13 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
+import apiClient, { BASE_URL } from "@/services/api";
+
+export interface OAuthToken {
+  access_token: string;
+  refresh_token?: string;
+  expires_at?: number;
+  token_url: string;
+  client_id: string;
+}
 
 interface AddServerModalProps {
   connecting: boolean;
@@ -8,8 +17,8 @@ interface AddServerModalProps {
   setCommand: (v: string) => void;
   transport: string;
   setTransport: (v: string) => void;
-  authType: "none" | "bearer" | "header";
-  setAuthType: (v: "none" | "bearer" | "header") => void;
+  authType: "none" | "bearer" | "header" | "oauth";
+  setAuthType: (v: "none" | "bearer" | "header" | "oauth") => void;
   token: string;
   setToken: (v: string) => void;
   headerKey: string;
@@ -21,6 +30,8 @@ interface AddServerModalProps {
   envVars: { key: string; value: string }[];
   setEnvVars: React.Dispatch<React.SetStateAction<{ key: string; value: string }[]>>;
   recentUrls: string[];
+  oauthToken: OAuthToken | null;
+  setOAuthToken: (t: OAuthToken | null) => void;
   onClose: () => void;
   onConnect: () => void;
 }
@@ -37,9 +48,106 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
   customName, setCustomName,
   envVars, setEnvVars,
   recentUrls,
+  oauthToken, setOAuthToken,
   onClose,
   onConnect,
 }) => {
+  const [oauthAuthUrl, setOauthAuthUrl] = useState("");
+  const [oauthTokenUrl, setOauthTokenUrl] = useState("");
+  const [oauthClientId, setOauthClientId] = useState("");
+  const [oauthScopes, setOauthScopes] = useState("");
+  const [oauthAuthorizing, setOauthAuthorizing] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+
+  const redirectUri = `${BASE_URL}/api/inspector/oauth/callback`;
+
+  const handleAuthorize = useCallback(async () => {
+    if (!oauthAuthUrl || !oauthTokenUrl || !oauthClientId) {
+      setOauthError("Authorization URL, Token URL, and Client ID are required.");
+      return;
+    }
+    setOauthError(null);
+    setOauthAuthorizing(true);
+    setOAuthToken(null);
+
+    try {
+      const { redirect_url, state } = await apiClient.startOAuthFlow({
+        authorization_url: oauthAuthUrl,
+        token_url: oauthTokenUrl,
+        client_id: oauthClientId,
+        redirect_uri: redirectUri,
+        scopes: oauthScopes,
+      });
+
+      const popup = window.open(redirect_url, "oauth_popup", "width=520,height=640,resizable=yes");
+      if (!popup) {
+        setOauthError("Popup blocked. Please allow popups for this site.");
+        setOauthAuthorizing(false);
+        return;
+      }
+
+      // Poll backend for result with exponential backoff (1s → 2s → 4s, cap 5s).
+      // popup.closed must NOT stop polling — the popup closes intentionally
+      // as soon as our callback page runs window.close(). Keep polling until
+      // we get a result or the hard deadline passes.
+      const deadline = Date.now() + 10 * 60 * 1000;
+      let popupClosedAt: number | null = null;
+      let pollInterval = 1000;
+
+      const poll = async () => {
+        // Track when popup first closed so we can give a grace period
+        if (popup.closed && popupClosedAt === null) {
+          popupClosedAt = Date.now();
+        }
+
+        // Hard deadline
+        if (Date.now() > deadline) {
+          setOauthAuthorizing(false);
+          setOauthError("Authorization timed out.");
+          return;
+        }
+
+        // If popup has been closed for >15s with no result, user probably cancelled
+        if (popupClosedAt !== null && Date.now() - popupClosedAt > 15000) {
+          setOauthAuthorizing(false);
+          setOauthError("Authorization cancelled or failed.");
+          return;
+        }
+
+        try {
+          const result = await apiClient.pollOAuthResult(state);
+          if (result.status === "complete" && result.token) {
+            setOAuthToken({
+              access_token: result.token.access_token,
+              refresh_token: result.token.refresh_token,
+              expires_at: result.token.expires_at,
+              token_url: oauthTokenUrl,
+              client_id: oauthClientId,
+            });
+            setOauthAuthorizing(false);
+            popup.close();
+            return;
+          }
+        } catch {
+          // transient error — keep polling
+        }
+        pollInterval = Math.min(pollInterval * 2, 5000);
+        setTimeout(poll, pollInterval);
+      };
+      setTimeout(poll, pollInterval);
+    } catch (e: any) {
+      setOauthError(e?.message ?? "Failed to start OAuth flow.");
+      setOauthAuthorizing(false);
+    }
+  }, [oauthAuthUrl, oauthTokenUrl, oauthClientId, oauthScopes, redirectUri, setOAuthToken]);
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%", padding: "0.5rem", borderRadius: "0.4rem",
+    border: "1px solid rgba(63,63,70,0.6)",
+    background: "#18181b", color: "#fff", boxSizing: "border-box",
+    fontSize: "0.85rem",
+  };
+
   return (
     <div
       onClick={onClose}
@@ -223,7 +331,7 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
                 <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>Auth Type</label>
                 <select
                   value={authType}
-                  onChange={(e) => setAuthType(e.target.value as "none" | "bearer" | "header")}
+                  onChange={(e) => setAuthType(e.target.value as "none" | "bearer" | "header" | "oauth")}
                   style={{
                     width: "100%", marginTop: "0.3rem", padding: "0.5rem",
                     borderRadius: "0.4rem", background: "#18181b", color: "#fff",
@@ -233,8 +341,76 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
                   <option value="none">None</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="header">Header Token</option>
+                  <option value="oauth">OAuth 2.0 (PKCE)</option>
                 </select>
               </div>
+
+              {authType === "oauth" && (
+                <div style={{ marginTop: "0.8rem", display: "flex", flexDirection: "column", gap: "0.6rem" }}>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Authorization URL</label>
+                    <input
+                      value={oauthAuthUrl}
+                      onChange={(e) => setOauthAuthUrl(e.target.value)}
+                      placeholder="https://provider.example.com/oauth/authorize"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Token URL</label>
+                    <input
+                      value={oauthTokenUrl}
+                      onChange={(e) => setOauthTokenUrl(e.target.value)}
+                      placeholder="https://provider.example.com/oauth/token"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Client ID</label>
+                    <input
+                      value={oauthClientId}
+                      onChange={(e) => setOauthClientId(e.target.value)}
+                      placeholder="your-client-id"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>
+                      Scopes <span style={{ color: "rgba(255,255,255,0.3)" }}>(space-separated, optional)</span>
+                    </label>
+                    <input
+                      value={oauthScopes}
+                      onChange={(e) => setOauthScopes(e.target.value)}
+                      placeholder="read write"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleAuthorize}
+                    disabled={oauthAuthorizing}
+                    style={{
+                      padding: "0.5rem 1rem", borderRadius: "0.4rem", fontWeight: 600,
+                      background: oauthToken ? "rgba(16,185,129,0.15)" : "rgba(99,102,241,0.15)",
+                      border: `1px solid ${oauthToken ? "rgba(16,185,129,0.4)" : "rgba(99,102,241,0.4)"}`,
+                      color: oauthToken ? "#10b981" : "rgba(165,180,252,0.9)",
+                      cursor: oauthAuthorizing ? "default" : "pointer",
+                      fontSize: "0.85rem",
+                    }}
+                  >
+                    {oauthAuthorizing ? "Waiting for authorization…" : oauthToken ? "✓ Authorized — re-authorize" : "Authorize"}
+                  </button>
+                  {oauthError && (
+                    <p style={{ margin: 0, fontSize: "0.75rem", color: "#ef4444" }}>{oauthError}</p>
+                  )}
+                  {oauthToken && (
+                    <p style={{ margin: 0, fontSize: "0.72rem", color: "rgba(16,185,129,0.8)" }}>
+                      Token obtained
+                      {oauthToken.expires_at ? ` · expires ${new Date(oauthToken.expires_at * 1000).toLocaleTimeString()}` : ""}
+                    </p>
+                  )}
+                </div>
+              )}
 
               {authType === "bearer" && (
                 <div style={{ marginTop: "0.8rem" }}>

--- a/fluidmcp/frontend/src/components/inspector/ServerListPanel.tsx
+++ b/fluidmcp/frontend/src/components/inspector/ServerListPanel.tsx
@@ -12,6 +12,17 @@ interface MCPServer {
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
   connectedAt?: number;
   error?: string;
+  auth?: { type: string; expires_at?: number };
+}
+
+function oauthBadge(auth: MCPServer["auth"]): { label: string; color: string; bg: string } | null {
+  if (auth?.type !== "oauth") return null;
+  const now = Date.now() / 1000;
+  const expiresAt = auth.expires_at;
+  if (!expiresAt) return { label: "OAuth", color: "#6366f1", bg: "rgba(99,102,241,0.15)" };
+  if (now >= expiresAt) return { label: "Token expired", color: "#ef4444", bg: "rgba(239,68,68,0.12)" };
+  if (now >= expiresAt - 300) return { label: "Expiring soon", color: "#f59e0b", bg: "rgba(245,158,11,0.12)" };
+  return { label: "OAuth ✓", color: "#10b981", bg: "rgba(16,185,129,0.12)" };
 }
 
 function relativeTime(ts: number): string {
@@ -147,16 +158,23 @@ export const ServerListPanel: React.FC<ServerListPanelProps> = ({
                 }}
               >
                 {/* Header row */}
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                  <div style={{ fontWeight: "600", fontSize: "0.9rem" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.4rem" }}>
+                  <div style={{ fontWeight: "600", fontSize: "0.9rem", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {server.name || server.server_info?.name || "MCP Server"}
                   </div>
-                  <span style={{
-                    fontSize: "0.7rem", padding: "0.2rem 0.5rem", borderRadius: "0.3rem",
-                    background: statusInfo.bg, color: statusInfo.color, flexShrink: 0,
-                  }}>
-                    {statusInfo.text}
-                  </span>
+                  <div style={{ display: "flex", gap: "0.3rem", flexShrink: 0, alignItems: "center" }}>
+                    {(() => { const b = oauthBadge(server.auth); return b ? (
+                      <span style={{ fontSize: "0.65rem", padding: "0.15rem 0.45rem", borderRadius: "0.3rem", background: b.bg, color: b.color, fontWeight: 600 }}>
+                        {b.label}
+                      </span>
+                    ) : null; })()}
+                    <span style={{
+                      fontSize: "0.7rem", padding: "0.2rem 0.5rem", borderRadius: "0.3rem",
+                      background: statusInfo.bg, color: statusInfo.color,
+                    }}>
+                      {statusInfo.text}
+                    </span>
+                  </div>
                 </div>
 
                 {/* URL + meta */}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Navbar } from "@/components/Navbar";
 import { apiClient } from "@/services/api";
+import type { OAuthToken } from "@/components/inspector/AddServerModal";
 import { type SavedRequest, loadSavedRequests } from "@/lib/saved-requests";
 import { ServerListPanel } from '../components/inspector/ServerListPanel';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
@@ -26,10 +27,15 @@ interface MCPServer {
   connectedAt?: number; // timestamp (ms) when status became "connected"
   error?: string;
   auth?: {
-    type: "none" | "bearer" | "header"
+    type: "none" | "bearer" | "header" | "oauth"
     token?: string
     headerKey?: string
     headerValue?: string
+    access_token?: string
+    refresh_token?: string
+    expires_at?: number
+    token_url?: string
+    client_id?: string
   };
 }
 
@@ -54,11 +60,12 @@ const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36
 
 export default function MCPInspector() {
 
-  const [authType, setAuthType] = useState<"none" | "bearer" | "header">("none")
+  const [authType, setAuthType] = useState<"none" | "bearer" | "header" | "oauth">("none")
 
   const [token, setToken] = useState("")
   const [headerKey, setHeaderKey] = useState("")
   const [headerValue, setHeaderValue] = useState("")
+  const [oauthToken, setOAuthToken] = useState<OAuthToken | null>(null)
 
   const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -208,6 +215,10 @@ export default function MCPInspector() {
         alert("Please enter header key and value")
         return
       }
+      if (authType === "oauth" && !oauthToken) {
+        alert("Please complete the OAuth authorization flow first")
+        return
+      }
       if (servers.some(s => s.url === url && s.status !== "failed")) {
         alert("Server already added");
         return;
@@ -234,12 +245,21 @@ export default function MCPInspector() {
 
     const serverId = generateServerId();
 
-    const authConfig = {
-      type: authType,
-      token: token,
-      headerKey: headerKey,
-      headerValue: headerValue
-    };
+    const authConfig = authType === "oauth" && oauthToken ? {
+      type: "oauth" as const,
+      access_token: oauthToken.access_token,
+      refresh_token: oauthToken.refresh_token,
+      expires_at: oauthToken.expires_at,
+      token_url: oauthToken.token_url,
+      client_id: oauthToken.client_id,
+    } : authType === "bearer" ? {
+      type: "bearer" as const,
+      token,
+    } : authType === "header" ? {
+      type: "header" as const,
+      headerKey,
+      headerValue,
+    } : { type: "none" as const };
 
     try {
       setConnecting(true);
@@ -271,6 +291,18 @@ export default function MCPInspector() {
       // Header Token (not applicable for stdio)
       if (transport !== "stdio" && authType === "header" && headerKey && headerValue) {
         payload.headers = { [headerKey]: headerValue }
+      }
+
+      // OAuth (not applicable for stdio)
+      if (transport !== "stdio" && authType === "oauth" && oauthToken) {
+        payload.auth = {
+          type: "oauth",
+          access_token: oauthToken.access_token,
+          refresh_token: oauthToken.refresh_token,
+          expires_at: oauthToken.expires_at,
+          token_url: oauthToken.token_url,
+          client_id: oauthToken.client_id,
+        }
       }
 
       const res = await apiClient.connectInspectorServer(payload)
@@ -312,6 +344,7 @@ export default function MCPInspector() {
       setToken("")
       setHeaderKey("")
       setHeaderValue("")
+      setOAuthToken(null)
       setCustomName("")
       setCommand("")
       setEnvVars([])
@@ -404,7 +437,32 @@ export default function MCPInspector() {
           [server.auth.headerKey]: server.auth.headerValue,
         };
       }
-      
+
+      // OAuth (not applicable for stdio) — token stored on server.auth
+      if (server.transport !== "stdio" && server.auth?.type === "oauth" && server.auth.access_token) {
+        let oauthAuth = { ...server.auth };
+
+        // Proactively refresh if token is expired or within 60s of expiry
+        if (server.session_id && oauthAuth.expires_at && Date.now() / 1000 > oauthAuth.expires_at - 60) {
+          try {
+            const refreshed = await apiClient.refreshOAuthToken(server.session_id);
+            oauthAuth = { ...oauthAuth, access_token: refreshed.access_token, expires_at: refreshed.expires_at };
+            setServers(prev => prev.map(s => s.id === serverId ? { ...s, auth: oauthAuth } : s));
+          } catch {
+            // Refresh failed — proceed with stale token, backend 401 will surface the error
+          }
+        }
+
+        payload.auth = {
+          type: "oauth",
+          access_token: oauthAuth.access_token,
+          refresh_token: oauthAuth.refresh_token,
+          expires_at: oauthAuth.expires_at,
+          token_url: oauthAuth.token_url,
+          client_id: oauthAuth.client_id,
+        };
+      }
+
       const res = await apiClient.connectInspectorServer(payload);
       // Reset log offset — reconnect starts a new session with a fresh log stream
       logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
@@ -808,6 +866,7 @@ export default function MCPInspector() {
     setToken("")
     setHeaderKey("")
     setHeaderValue("")
+    setOAuthToken(null)
   }, [authType])
 
   return (
@@ -1256,8 +1315,9 @@ export default function MCPInspector() {
           customName={customName} setCustomName={setCustomName}
           envVars={envVars} setEnvVars={setEnvVars}
           recentUrls={recentUrls}
+          oauthToken={oauthToken} setOAuthToken={setOAuthToken}
           onConnect={handleConnect}
-          onClose={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
+          onClose={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); setOAuthToken(null); }}
         />
       )}
 

--- a/fluidmcp/frontend/src/pages/OAuthCallback.tsx
+++ b/fluidmcp/frontend/src/pages/OAuthCallback.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * Fallback page at /oauth-callback.
+ *
+ * The actual OAuth popup is served by the backend's _oauth_popup_html which
+ * calls window.close() directly. This React page only renders if someone
+ * navigates to /oauth-callback directly in a non-popup context — it's a
+ * graceful dead-end, nothing more.
+ */
+export default function OAuthCallback() {
+  useEffect(() => {
+    window.close();
+  }, []);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b", color: "#fff", fontFamily: "sans-serif" }}>
+      <p style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.9rem" }}>Authentication complete. Closing…</p>
+    </div>
+  );
+}

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -23,7 +23,7 @@ import type {
   ReplicateModelConfig,
 } from '../types/llm';
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL || window.location.origin;
 
 /** Error subclass that preserves the HTTP status code from API responses. */
 export class ApiHttpError extends Error {
@@ -387,6 +387,27 @@ class ApiClient {
 
   async exportInspectorServer(sessionId: string): Promise<any> {
     return this.request(`/api/inspector/${sessionId}/export`);
+  }
+
+  async startOAuthFlow(params: {
+    authorization_url: string;
+    token_url: string;
+    client_id: string;
+    redirect_uri: string;
+    scopes?: string;
+  }): Promise<{ redirect_url: string; state: string }> {
+    return this.request(`/api/inspector/oauth/authorize`, {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+  }
+
+  async pollOAuthResult(state: string): Promise<{ status: "pending" | "complete"; token?: any }> {
+    return this.request(`/api/inspector/oauth/result/${state}`);
+  }
+
+  async refreshOAuthToken(sessionId: string): Promise<{ access_token: string; expires_at: number }> {
+    return this.request(`/api/inspector/${sessionId}/oauth/refresh`, { method: "POST" });
   }
 
   async listInspectorResources(sessionId: string): Promise<any> {


### PR DESCRIPTION
## Summary

- **Phase A (backend):** OAuth 2.0 PKCE flow — `/oauth/authorize`, `/oauth/callback`, `/oauth/result/{state}`, `/{session_id}/oauth/refresh` endpoints; auto-refresh before token expiry; 401 retry with refresh in `inspector_session.py`
- **Phase B (frontend):** OAuth auth type in Add Server modal with popup-based PKCE flow, exponential backoff polling, expiry status badge on server cards, proactive refresh on reconnect
- **Bonus fixes:** FastMCP streamable-HTTP support (SSE response parsing + `mcp-session-id` header); `/ui` redirect fix for Codespace/proxied deployments

## Test plan

- [ ] Open inspector → Add server → Auth Type: OAuth 2.0 (PKCE) → fill Authorization URL, Token URL, Client ID → click Authorize → popup opens and closes → button turns green "✓ Authorized"
- [ ] Click Connect → server connects with green "OAuth ✓" badge
- [ ] Run a tool on the OAuth-protected server → succeeds with Bearer token
- [ ] Disconnect → Reconnect → reconnects without re-authorizing (token reused)
- [ ] Connect without authorizing → alert shown, blocked
- [ ] Chat flow → LLM picks tool on OAuth-protected server → executes correctly
- [ ] `/ui` URL in Codespace/proxied env no longer redirects to `localhost`

🤖 Generated with [Claude Code](https://claude.com/claude-code)