### PR TITLE
[MCP-532]: MCP Inspector 5B (Part 2/2): OAuth 2.0 PKCE frontend (sprint 5K)

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -557,6 +557,7 @@ async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None
                 },
                 headers={
                     "Content-Type": "application/x-www-form-urlencoded",
+                    "Accept": "application/json",
                     "Host": original_host,
                 },
                 extensions={"sni_hostname": original_host},

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -185,6 +185,11 @@ class InspectorSession:
         # Auto-incrementing request ID (avoids hardcoded 1/2/3 collisions)
         self._req_id = 0
 
+        # Streamable-HTTP session id (RFC draft): captured from the Mcp-Session-Id
+        # response header on the first request and replayed on every subsequent
+        # request. Stateful servers reject requests missing this header with 400.
+        self._mcp_session_id: Optional[str] = None
+
         # SSE state
         self._sse_post_url: Optional[str] = None
         self._sse_ready = asyncio.Event()      # set once endpoint URL is known
@@ -196,11 +201,6 @@ class InspectorSession:
 
         # Shared httpx client for HTTP/POST requests
         self._client: Optional[httpx.AsyncClient] = None
-
-        # Streamable-HTTP session id (RFC draft): captured from the Mcp-Session-Id
-        # response header on the first request and replayed on every subsequent
-        # request. Stateful servers reject requests missing this header with 400.
-        self._mcp_session_id: Optional[str] = None
 
     # ── Helpers ───────────────────────────────────────────────────────────────
 
@@ -217,7 +217,7 @@ class InspectorSession:
         return self._client
 
     def _build_headers(self) -> Dict[str, str]:
-        headers = {"Content-Type": "application/json", "Accept": "application/json"}
+        headers = {"Content-Type": "application/json", "Accept": "application/json, text/event-stream"}
         auth_type = self.auth.get("type")
         if auth_type == "bearer" and self.auth.get("token"):
             headers["Authorization"] = f"Bearer {self.auth['token']}"
@@ -597,10 +597,24 @@ class InspectorSession:
         # Streamable-HTTP: capture the session id so it can be replayed on every
         # subsequent request. Servers only send this on the initialize response,
         # but checking on every response is harmless and self-healing on reconnect.
-        new_session_id = response.headers.get("mcp-session-id")
-        if new_session_id:
-            self._mcp_session_id = new_session_id
+        session_id_header = response.headers.get("mcp-session-id")
+        if session_id_header:
+            self._mcp_session_id = session_id_header
+            logger.debug(f"Inspector: captured mcp-session-id={session_id_header}")
+
         response.raise_for_status()
+
+        content_type = response.headers.get("content-type", "")
+        if "text/event-stream" in content_type:
+            # FastMCP streamable-HTTP can respond to a single POST with an SSE
+            # stream instead of a plain JSON body. Extract the first data: line.
+            for line in response.text.splitlines():
+                if line.startswith("data:"):
+                    payload = line[len("data:"):].strip()
+                    if payload:
+                        return json.loads(payload)
+            raise Exception("No data event found in SSE response")
+
         return response.json()
 
     # ── Public API ────────────────────────────────────────────────────────────

--- a/fluidmcp/frontend/src/App.tsx
+++ b/fluidmcp/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import LLMModelDetails from "./pages/LLMModelDetails";
 import LLMPlayground from "./pages/LLMPlayground";
 import ManageServers from "./pages/ManageServers";
 import MCPInspector from "./pages/MCPInspector";
+import OAuthCallback from "./pages/OAuthCallback";
 
 function App() {
   return (
@@ -30,6 +31,7 @@ function App() {
         <Route path="/documentation" element={<Documentation />} />
         <Route path="/servers/:serverId" element={<ServerDetails />} />
         <Route path="/inspector" element={<MCPInspector />} />
+        <Route path="/oauth-callback" element={<OAuthCallback />} />
         <Route path="/servers/:serverId/tools/:toolName" element={<ToolRunner />} />
         <Route path="/llm/models" element={<LLMModels />} />
         <Route path="/llm/models/:modelId" element={<LLMModelDetails />} />

--- a/fluidmcp/frontend/src/components/inspector/AddServerModal.tsx
+++ b/fluidmcp/frontend/src/components/inspector/AddServerModal.tsx
@@ -1,4 +1,13 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
+import apiClient, { BASE_URL } from "@/services/api";
+
+export interface OAuthToken {
+  access_token: string;
+  refresh_token?: string;
+  expires_at?: number;
+  token_url: string;
+  client_id: string;
+}
 
 interface AddServerModalProps {
   connecting: boolean;
@@ -8,8 +17,8 @@ interface AddServerModalProps {
   setCommand: (v: string) => void;
   transport: string;
   setTransport: (v: string) => void;
-  authType: "none" | "bearer" | "header";
-  setAuthType: (v: "none" | "bearer" | "header") => void;
+  authType: "none" | "bearer" | "header" | "oauth";
+  setAuthType: (v: "none" | "bearer" | "header" | "oauth") => void;
   token: string;
   setToken: (v: string) => void;
   headerKey: string;
@@ -21,6 +30,8 @@ interface AddServerModalProps {
   envVars: { key: string; value: string }[];
   setEnvVars: React.Dispatch<React.SetStateAction<{ key: string; value: string }[]>>;
   recentUrls: string[];
+  oauthToken: OAuthToken | null;
+  setOAuthToken: (t: OAuthToken | null) => void;
   onClose: () => void;
   onConnect: () => void;
 }
@@ -37,9 +48,106 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
   customName, setCustomName,
   envVars, setEnvVars,
   recentUrls,
+  oauthToken, setOAuthToken,
   onClose,
   onConnect,
 }) => {
+  const [oauthAuthUrl, setOauthAuthUrl] = useState("");
+  const [oauthTokenUrl, setOauthTokenUrl] = useState("");
+  const [oauthClientId, setOauthClientId] = useState("");
+  const [oauthScopes, setOauthScopes] = useState("");
+  const [oauthAuthorizing, setOauthAuthorizing] = useState(false);
+  const [oauthError, setOauthError] = useState<string | null>(null);
+
+  const redirectUri = `${BASE_URL}/api/inspector/oauth/callback`;
+
+  const handleAuthorize = useCallback(async () => {
+    if (!oauthAuthUrl || !oauthTokenUrl || !oauthClientId) {
+      setOauthError("Authorization URL, Token URL, and Client ID are required.");
+      return;
+    }
+    setOauthError(null);
+    setOauthAuthorizing(true);
+    setOAuthToken(null);
+
+    try {
+      const { redirect_url, state } = await apiClient.startOAuthFlow({
+        authorization_url: oauthAuthUrl,
+        token_url: oauthTokenUrl,
+        client_id: oauthClientId,
+        redirect_uri: redirectUri,
+        scopes: oauthScopes,
+      });
+
+      const popup = window.open(redirect_url, "oauth_popup", "width=520,height=640,resizable=yes");
+      if (!popup) {
+        setOauthError("Popup blocked. Please allow popups for this site.");
+        setOauthAuthorizing(false);
+        return;
+      }
+
+      // Poll backend for result with exponential backoff (1s → 2s → 4s, cap 5s).
+      // popup.closed must NOT stop polling — the popup closes intentionally
+      // as soon as our callback page runs window.close(). Keep polling until
+      // we get a result or the hard deadline passes.
+      const deadline = Date.now() + 10 * 60 * 1000;
+      let popupClosedAt: number | null = null;
+      let pollInterval = 1000;
+
+      const poll = async () => {
+        // Track when popup first closed so we can give a grace period
+        if (popup.closed && popupClosedAt === null) {
+          popupClosedAt = Date.now();
+        }
+
+        // Hard deadline
+        if (Date.now() > deadline) {
+          setOauthAuthorizing(false);
+          setOauthError("Authorization timed out.");
+          return;
+        }
+
+        // If popup has been closed for >15s with no result, user probably cancelled
+        if (popupClosedAt !== null && Date.now() - popupClosedAt > 15000) {
+          setOauthAuthorizing(false);
+          setOauthError("Authorization cancelled or failed.");
+          return;
+        }
+
+        try {
+          const result = await apiClient.pollOAuthResult(state);
+          if (result.status === "complete" && result.token) {
+            setOAuthToken({
+              access_token: result.token.access_token,
+              refresh_token: result.token.refresh_token,
+              expires_at: result.token.expires_at,
+              token_url: oauthTokenUrl,
+              client_id: oauthClientId,
+            });
+            setOauthAuthorizing(false);
+            popup.close();
+            return;
+          }
+        } catch {
+          // transient error — keep polling
+        }
+        pollInterval = Math.min(pollInterval * 2, 5000);
+        setTimeout(poll, pollInterval);
+      };
+      setTimeout(poll, pollInterval);
+    } catch (e: any) {
+      setOauthError(e?.message ?? "Failed to start OAuth flow.");
+      setOauthAuthorizing(false);
+    }
+  }, [oauthAuthUrl, oauthTokenUrl, oauthClientId, oauthScopes, redirectUri, setOAuthToken]);
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%", padding: "0.5rem", borderRadius: "0.4rem",
+    border: "1px solid rgba(63,63,70,0.6)",
+    background: "#18181b", color: "#fff", boxSizing: "border-box",
+    fontSize: "0.85rem",
+  };
+
   return (
     <div
       onClick={onClose}
@@ -223,7 +331,7 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
                 <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>Auth Type</label>
                 <select
                   value={authType}
-                  onChange={(e) => setAuthType(e.target.value as "none" | "bearer" | "header")}
+                  onChange={(e) => setAuthType(e.target.value as "none" | "bearer" | "header" | "oauth")}
                   style={{
                     width: "100%", marginTop: "0.3rem", padding: "0.5rem",
                     borderRadius: "0.4rem", background: "#18181b", color: "#fff",
@@ -233,8 +341,76 @@ export const AddServerModal: React.FC<AddServerModalProps> = ({
                   <option value="none">None</option>
                   <option value="bearer">Bearer Token</option>
                   <option value="header">Header Token</option>
+                  <option value="oauth">OAuth 2.0 (PKCE)</option>
                 </select>
               </div>
+
+              {authType === "oauth" && (
+                <div style={{ marginTop: "0.8rem", display: "flex", flexDirection: "column", gap: "0.6rem" }}>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Authorization URL</label>
+                    <input
+                      value={oauthAuthUrl}
+                      onChange={(e) => setOauthAuthUrl(e.target.value)}
+                      placeholder="https://provider.example.com/oauth/authorize"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Token URL</label>
+                    <input
+                      value={oauthTokenUrl}
+                      onChange={(e) => setOauthTokenUrl(e.target.value)}
+                      placeholder="https://provider.example.com/oauth/token"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>Client ID</label>
+                    <input
+                      value={oauthClientId}
+                      onChange={(e) => setOauthClientId(e.target.value)}
+                      placeholder="your-client-id"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <div>
+                    <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.6)", display: "block", marginBottom: "0.25rem" }}>
+                      Scopes <span style={{ color: "rgba(255,255,255,0.3)" }}>(space-separated, optional)</span>
+                    </label>
+                    <input
+                      value={oauthScopes}
+                      onChange={(e) => setOauthScopes(e.target.value)}
+                      placeholder="read write"
+                      style={inputStyle}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={handleAuthorize}
+                    disabled={oauthAuthorizing}
+                    style={{
+                      padding: "0.5rem 1rem", borderRadius: "0.4rem", fontWeight: 600,
+                      background: oauthToken ? "rgba(16,185,129,0.15)" : "rgba(99,102,241,0.15)",
+                      border: `1px solid ${oauthToken ? "rgba(16,185,129,0.4)" : "rgba(99,102,241,0.4)"}`,
+                      color: oauthToken ? "#10b981" : "rgba(165,180,252,0.9)",
+                      cursor: oauthAuthorizing ? "default" : "pointer",
+                      fontSize: "0.85rem",
+                    }}
+                  >
+                    {oauthAuthorizing ? "Waiting for authorization…" : oauthToken ? "✓ Authorized — re-authorize" : "Authorize"}
+                  </button>
+                  {oauthError && (
+                    <p style={{ margin: 0, fontSize: "0.75rem", color: "#ef4444" }}>{oauthError}</p>
+                  )}
+                  {oauthToken && (
+                    <p style={{ margin: 0, fontSize: "0.72rem", color: "rgba(16,185,129,0.8)" }}>
+                      Token obtained
+                      {oauthToken.expires_at ? ` · expires ${new Date(oauthToken.expires_at * 1000).toLocaleTimeString()}` : ""}
+                    </p>
+                  )}
+                </div>
+              )}
 
               {authType === "bearer" && (
                 <div style={{ marginTop: "0.8rem" }}>

--- a/fluidmcp/frontend/src/components/inspector/ServerListPanel.tsx
+++ b/fluidmcp/frontend/src/components/inspector/ServerListPanel.tsx
@@ -12,6 +12,17 @@ interface MCPServer {
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
   connectedAt?: number;
   error?: string;
+  auth?: { type: string; expires_at?: number };
+}
+
+function oauthBadge(auth: MCPServer["auth"]): { label: string; color: string; bg: string } | null {
+  if (auth?.type !== "oauth") return null;
+  const now = Date.now() / 1000;
+  const expiresAt = auth.expires_at;
+  if (!expiresAt) return { label: "OAuth", color: "#6366f1", bg: "rgba(99,102,241,0.15)" };
+  if (now >= expiresAt) return { label: "Token expired", color: "#ef4444", bg: "rgba(239,68,68,0.12)" };
+  if (now >= expiresAt - 300) return { label: "Expiring soon", color: "#f59e0b", bg: "rgba(245,158,11,0.12)" };
+  return { label: "OAuth ✓", color: "#10b981", bg: "rgba(16,185,129,0.12)" };
 }
 
 function relativeTime(ts: number): string {
@@ -157,16 +168,23 @@ export const ServerListPanel: React.FC<ServerListPanelProps> = ({
                 }}
               >
                 {/* Header row */}
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-                  <div style={{ fontWeight: "600", fontSize: "0.9rem" }}>
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: "0.4rem" }}>
+                  <div style={{ fontWeight: "600", fontSize: "0.9rem", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                     {server.name || server.server_info?.name || "MCP Server"}
                   </div>
-                  <span style={{
-                    fontSize: "0.7rem", padding: "0.2rem 0.5rem", borderRadius: "0.3rem",
-                    background: statusInfo.bg, color: statusInfo.color, flexShrink: 0,
-                  }}>
-                    {statusInfo.text}
-                  </span>
+                  <div style={{ display: "flex", gap: "0.3rem", flexShrink: 0, alignItems: "center" }}>
+                    {(() => { const b = oauthBadge(server.auth); return b ? (
+                      <span style={{ fontSize: "0.65rem", padding: "0.15rem 0.45rem", borderRadius: "0.3rem", background: b.bg, color: b.color, fontWeight: 600 }}>
+                        {b.label}
+                      </span>
+                    ) : null; })()}
+                    <span style={{
+                      fontSize: "0.7rem", padding: "0.2rem 0.5rem", borderRadius: "0.3rem",
+                      background: statusInfo.bg, color: statusInfo.color,
+                    }}>
+                      {statusInfo.text}
+                    </span>
+                  </div>
                 </div>
 
                 {/* URL + meta */}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Navbar } from "@/components/Navbar";
 import { apiClient } from "@/services/api";
+import type { OAuthToken } from "@/components/inspector/AddServerModal";
 import { type SavedRequest, loadSavedRequests, renameSavedRequest } from "@/lib/saved-requests";
 import { ServerListPanel } from '../components/inspector/ServerListPanel';
 import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
@@ -26,10 +27,15 @@ interface MCPServer {
   connectedAt?: number; // timestamp (ms) when status became "connected"
   error?: string;
   auth?: {
-    type: "none" | "bearer" | "header"
+    type: "none" | "bearer" | "header" | "oauth"
     token?: string
     headerKey?: string
     headerValue?: string
+    access_token?: string
+    refresh_token?: string
+    expires_at?: number
+    token_url?: string
+    client_id?: string
   };
 }
 
@@ -54,11 +60,12 @@ const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36
 
 export default function MCPInspector() {
 
-  const [authType, setAuthType] = useState<"none" | "bearer" | "header">("none")
+  const [authType, setAuthType] = useState<"none" | "bearer" | "header" | "oauth">("none")
 
   const [token, setToken] = useState("")
   const [headerKey, setHeaderKey] = useState("")
   const [headerValue, setHeaderValue] = useState("")
+  const [oauthToken, setOAuthToken] = useState<OAuthToken | null>(null)
 
   const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -210,6 +217,10 @@ export default function MCPInspector() {
         alert("Please enter header key and value")
         return
       }
+      if (authType === "oauth" && !oauthToken) {
+        alert("Please complete the OAuth authorization flow first")
+        return
+      }
       if (servers.some(s => s.url === url && s.status !== "failed")) {
         alert("Server already added");
         return;
@@ -236,12 +247,21 @@ export default function MCPInspector() {
 
     const serverId = generateServerId();
 
-    const authConfig = {
-      type: authType,
-      token: token,
-      headerKey: headerKey,
-      headerValue: headerValue
-    };
+    const authConfig = authType === "oauth" && oauthToken ? {
+      type: "oauth" as const,
+      access_token: oauthToken.access_token,
+      refresh_token: oauthToken.refresh_token,
+      expires_at: oauthToken.expires_at,
+      token_url: oauthToken.token_url,
+      client_id: oauthToken.client_id,
+    } : authType === "bearer" ? {
+      type: "bearer" as const,
+      token,
+    } : authType === "header" ? {
+      type: "header" as const,
+      headerKey,
+      headerValue,
+    } : { type: "none" as const };
 
     try {
       setConnecting(true);
@@ -273,6 +293,18 @@ export default function MCPInspector() {
       // Header Token (not applicable for stdio)
       if (transport !== "stdio" && authType === "header" && headerKey && headerValue) {
         payload.headers = { [headerKey]: headerValue }
+      }
+
+      // OAuth (not applicable for stdio)
+      if (transport !== "stdio" && authType === "oauth" && oauthToken) {
+        payload.auth = {
+          type: "oauth",
+          access_token: oauthToken.access_token,
+          refresh_token: oauthToken.refresh_token,
+          expires_at: oauthToken.expires_at,
+          token_url: oauthToken.token_url,
+          client_id: oauthToken.client_id,
+        }
       }
 
       const res = await apiClient.connectInspectorServer(payload)
@@ -314,6 +346,7 @@ export default function MCPInspector() {
       setToken("")
       setHeaderKey("")
       setHeaderValue("")
+      setOAuthToken(null)
       setCustomName("")
       setCommand("")
       setEnvVars([])
@@ -406,7 +439,32 @@ export default function MCPInspector() {
           [server.auth.headerKey]: server.auth.headerValue,
         };
       }
-      
+
+      // OAuth (not applicable for stdio) — token stored on server.auth
+      if (server.transport !== "stdio" && server.auth?.type === "oauth" && server.auth.access_token) {
+        let oauthAuth = { ...server.auth };
+
+        // Proactively refresh if token is expired or within 60s of expiry
+        if (server.session_id && oauthAuth.expires_at && Date.now() / 1000 > oauthAuth.expires_at - 60) {
+          try {
+            const refreshed = await apiClient.refreshOAuthToken(server.session_id);
+            oauthAuth = { ...oauthAuth, access_token: refreshed.access_token, expires_at: refreshed.expires_at };
+            setServers(prev => prev.map(s => s.id === serverId ? { ...s, auth: oauthAuth } : s));
+          } catch {
+            // Refresh failed — proceed with stale token, backend 401 will surface the error
+          }
+        }
+
+        payload.auth = {
+          type: "oauth",
+          access_token: oauthAuth.access_token,
+          refresh_token: oauthAuth.refresh_token,
+          expires_at: oauthAuth.expires_at,
+          token_url: oauthAuth.token_url,
+          client_id: oauthAuth.client_id,
+        };
+      }
+
       const res = await apiClient.connectInspectorServer(payload);
       // Reset log offset — reconnect starts a new session with a fresh log stream
       logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
@@ -806,6 +864,7 @@ export default function MCPInspector() {
     setToken("")
     setHeaderKey("")
     setHeaderValue("")
+    setOAuthToken(null)
   }, [authType])
 
   return (
@@ -1288,8 +1347,9 @@ export default function MCPInspector() {
           customName={customName} setCustomName={setCustomName}
           envVars={envVars} setEnvVars={setEnvVars}
           recentUrls={recentUrls}
+          oauthToken={oauthToken} setOAuthToken={setOAuthToken}
           onConnect={handleConnect}
-          onClose={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
+          onClose={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); setOAuthToken(null); }}
         />
       )}
 

--- a/fluidmcp/frontend/src/pages/OAuthCallback.tsx
+++ b/fluidmcp/frontend/src/pages/OAuthCallback.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from "react";
+
+/**
+ * Fallback page at /oauth-callback.
+ *
+ * The actual OAuth popup is served by the backend's _oauth_popup_html which
+ * calls window.close() directly. This React page only renders if someone
+ * navigates to /oauth-callback directly in a non-popup context — it's a
+ * graceful dead-end, nothing more.
+ */
+export default function OAuthCallback() {
+  useEffect(() => {
+    window.close();
+  }, []);
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", height: "100vh", background: "#09090b", color: "#fff", fontFamily: "sans-serif" }}>
+      <p style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.9rem" }}>Authentication complete. Closing…</p>
+    </div>
+  );
+}

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -23,7 +23,7 @@ import type {
   ReplicateModelConfig,
 } from '../types/llm';
 
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || window.location.origin;
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL || window.location.origin;
 
 /** Error subclass that preserves the HTTP status code from API responses. */
 export class ApiHttpError extends Error {
@@ -387,6 +387,27 @@ class ApiClient {
 
   async exportInspectorServer(sessionId: string): Promise<any> {
     return this.request(`/api/inspector/${sessionId}/export`);
+  }
+
+  async startOAuthFlow(params: {
+    authorization_url: string;
+    token_url: string;
+    client_id: string;
+    redirect_uri: string;
+    scopes?: string;
+  }): Promise<{ redirect_url: string; state: string }> {
+    return this.request(`/api/inspector/oauth/authorize`, {
+      method: "POST",
+      body: JSON.stringify(params),
+    });
+  }
+
+  async pollOAuthResult(state: string): Promise<{ status: "pending" | "complete"; token?: any }> {
+    return this.request(`/api/inspector/oauth/result/${state}`);
+  }
+
+  async refreshOAuthToken(sessionId: string): Promise<{ access_token: string; expires_at: number }> {
+    return this.request(`/api/inspector/${sessionId}/oauth/refresh`, { method: "POST" });
   }
 
   async listInspectorResources(sessionId: string): Promise<any> {


### PR DESCRIPTION
## Summary

Depends on PR #689 (Phase A backend).

- AddServerModal: OAuth auth type with Authorization URL, Token URL, Client ID, Scopes fields + Authorize button with popup-based PKCE flow; exponential backoff polling (1s→2s→4s→5s cap); `redirectUri` uses `BASE_URL` from `api.ts`
- ServerListPanel: OAuth status badge (green/yellow/red) based on token expiry
- MCPInspector: `oauthToken` state, OAuth payload in `handleConnect`, `authConfig` only stores fields relevant to chosen auth type, proactive expiry check + refresh in `handleReconnect`, full OAuth fields stored on server object
- `api.ts`: `startOAuthFlow`, `pollOAuthResult`, `refreshOAuthToken` methods; export `BASE_URL`
- `OAuthCallback.tsx`: minimal fallback page (actual popup HTML served by backend)
- `App.tsx`: `/oauth-callback` route
- `frontend_utils.py`: explicit `GET /ui` redirect to fix Starlette StaticFiles building `Location` from raw `Host` header in proxied/Codespace environments
- `inspector_session.py`: capture `mcp-session-id` for FastMCP streamable-HTTP; parse SSE responses from HTTP transport

## Test plan

- [x] Add server → Auth Type: OAuth 2.0 (PKCE) → fill fields → Authorize → green "✓ Authorized"
- [x] Connect → server shows green "OAuth ✓" badge
- [x] Run tool on OAuth-protected server → succeeds
- [x] Disconnect → Reconnect → no re-authorize needed
- [x] Connect without authorizing → alert blocks it
- [x] Chat → LLM picks tool on OAuth server → executes correctly
- [ ] `/ui` in Codespace no longer redirects to `localhost`
