### PR TITLE
[MCP-530]: MCP Inspector 5B (Part 1/2): OAuth 2.0 PKCE backend

### DIFF
--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -17,7 +17,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 from loguru import logger
 
-from ..services.inspector_session import InspectorSession
+from ..services.inspector_session import InspectorSession, resolve_pinned_target
 from ..auth import verify_token
 
 router = APIRouter(dependencies=[Depends(verify_token)])
@@ -452,14 +452,16 @@ def _pkce_pair() -> tuple[str, str]:
 
 def _validate_oauth_url(url: str, field: str) -> None:
     """
-    Ensure an OAuth endpoint URL is a valid public https URL.
+    Fast-fail check that an OAuth endpoint URL is a valid public https URL.
 
-    https is required (not just http/https) because these endpoints receive
-    client secrets and refresh tokens — http would put those credentials on
-    the wire in plaintext. Private/internal addresses are blocked, including
-    via DNS: a hostname is resolved and every returned address is checked, so
-    an attacker-controlled domain that resolves to a private/internal address
-    (e.g. cloud metadata IPs) is rejected the same as a literal internal IP.
+    https is required because these endpoints receive client secrets and
+    refresh tokens — http would put those credentials on the wire in
+    plaintext. This is a convenience check only (bad input is rejected
+    immediately instead of failing later mid-flow) — it resolves the
+    hostname the same way resolve_pinned_target does, but does NOT pin the
+    result. The actual token-endpoint POSTs (oauth_callback, _auto_refresh)
+    call resolve_pinned_target again immediately before connecting so there
+    is no DNS-rebinding window between "checked" and "connected".
     """
     try:
         parsed = urlparse(url)
@@ -467,26 +469,7 @@ def _validate_oauth_url(url: str, field: str) -> None:
         raise HTTPException(400, f"Invalid {field}")
     if parsed.scheme != "https":
         raise HTTPException(400, f"{field} must use https")
-    host = parsed.hostname or ""
-    if not host:
-        raise HTTPException(400, f"{field} must include a host")
-
-    try:
-        addr = ipaddress.ip_address(host)
-        addresses = [addr]
-    except ValueError:
-        # Hostname, not a literal IP — resolve it so DNS rebinding to a
-        # private/internal address is caught, not just literal IPs.
-        import socket
-        try:
-            infos = socket.getaddrinfo(host, None)
-        except socket.gaierror:
-            raise HTTPException(400, f"{field} host could not be resolved")
-        addresses = [ipaddress.ip_address(info[4][0]) for info in infos]
-
-    for addr in addresses:
-        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
-            raise HTTPException(400, f"{field} must not point to a private/internal address")
+    resolve_pinned_target(url, field)
 
 
 @router.post("/inspector/oauth/authorize")
@@ -561,9 +544,10 @@ async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None
         return HTMLResponse(_oauth_popup_html(None, "state_expired"))
 
     try:
+        pinned_url, original_host = resolve_pinned_target(entry["token_url"], "token_url")
         async with httpx.AsyncClient(timeout=15.0) as client:
             resp = await client.post(
-                entry["token_url"],
+                pinned_url,
                 data={
                     "grant_type": "authorization_code",
                     "code": code,
@@ -571,7 +555,11 @@ async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None
                     "client_id": entry["client_id"],
                     "code_verifier": entry["verifier"],
                 },
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
+                headers={
+                    "Content-Type": "application/x-www-form-urlencoded",
+                    "Host": original_host,
+                },
+                extensions={"sni_hostname": original_host},
             )
             resp.raise_for_status()
             token_data = resp.json()

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -4,9 +4,14 @@ import asyncio
 import time
 import json
 import ipaddress
+import hashlib
+import base64
+import os
+import secrets
 from typing import Dict, Any, Optional, AsyncGenerator
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlencode
 
+import httpx
 from fastapi import APIRouter, HTTPException, Body, Depends
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
@@ -23,12 +28,35 @@ sessions: Dict[str, InspectorSession] = {}
 SESSION_TTL = 1800   # 30 minutes in seconds
 CLEANUP_INTERVAL = 300  # Run cleanup every 5 minutes
 
+# Pending OAuth exchanges: state -> { verifier, token_url, client_id, redirect_uri, result? }
+# Entries expire after OAUTH_STATE_TTL seconds.
+oauth_pending: Dict[str, Dict[str, Any]] = {}
+OAUTH_STATE_TTL = 600  # 10 minutes
+
 
 # ─── Request Models ────────────────────────────────────────────────────────────
 
 class AuthConfig(BaseModel):
-    type: str = "none"        # "none" | "bearer"
+    type: str = "none"        # "none" | "bearer" | "header" | "oauth"
     token: Optional[str] = None
+    # OAuth fields (only used when type == "oauth")
+    access_token: Optional[str] = None
+    refresh_token: Optional[str] = None
+    expires_at: Optional[float] = None   # Unix timestamp
+    token_url: Optional[str] = None      # token endpoint for refresh
+    client_id: Optional[str] = None
+
+
+class OAuthAuthorizeRequest(BaseModel):
+    authorization_url: str
+    token_url: str
+    client_id: str
+    redirect_uri: str
+    scopes: Optional[str] = ""   # space-separated
+
+
+class OAuthRefreshRequest(BaseModel):
+    pass  # uses credentials stored in the session
 
 
 class ConnectRequest(BaseModel):
@@ -396,6 +424,201 @@ async def export_server(session_id: str):
         "resources": resources,
         "prompts": prompts,
     }
+
+
+def _pkce_pair() -> tuple[str, str]:
+    """Generate a PKCE (code_verifier, code_challenge) pair using S256 method."""
+    verifier = base64.urlsafe_b64encode(os.urandom(40)).rstrip(b"=").decode()
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _validate_oauth_url(url: str, field: str) -> None:
+    """Ensure an OAuth endpoint URL is a valid public https URL."""
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        raise HTTPException(400, f"Invalid {field}")
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(400, f"{field} must be http/https")
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(400, f"{field} must include a host")
+    try:
+        addr = ipaddress.ip_address(host)
+        if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
+            raise HTTPException(400, f"{field} must not point to a private/internal address")
+    except ValueError:
+        pass  # hostname — fine
+
+
+@router.post("/inspector/oauth/authorize")
+async def oauth_authorize(body: OAuthAuthorizeRequest):
+    """
+    Start an OAuth 2.0 PKCE flow.
+
+    Generates a PKCE verifier/challenge pair and a random state token,
+    stores them in oauth_pending, and returns the full authorization URL
+    the frontend should open in a popup.
+    """
+    _validate_oauth_url(body.authorization_url, "authorization_url")
+    _validate_oauth_url(body.token_url, "token_url")
+
+    verifier, challenge = _pkce_pair()
+    state = secrets.token_urlsafe(24)
+
+    oauth_pending[state] = {
+        "verifier": verifier,
+        "token_url": body.token_url,
+        "client_id": body.client_id,
+        "redirect_uri": body.redirect_uri,
+        "created_at": time.time(),
+        "result": None,
+    }
+
+    params = {
+        "response_type": "code",
+        "client_id": body.client_id,
+        "redirect_uri": body.redirect_uri,
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    if body.scopes:
+        params["scope"] = body.scopes
+
+    redirect_url = f"{body.authorization_url}?{urlencode(params)}"
+    return {"redirect_url": redirect_url, "state": state}
+
+
+@router.get("/inspector/oauth/callback")
+async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None, error: Optional[str] = None):
+    """
+    OAuth 2.0 redirect callback.
+
+    The authorization server redirects here after the user approves or denies
+    access.  This endpoint exchanges the authorization code for tokens and
+    stores them in oauth_pending so the frontend can poll for the result.
+
+    On success the browser is redirected to /ui/oauth-callback so the popup
+    page can read the result via window.opener.postMessage and close itself.
+    """
+    from fastapi.responses import HTMLResponse
+
+    if error:
+        return HTMLResponse(_oauth_popup_html(None, error))
+
+    if not state or not code:
+        return HTMLResponse(_oauth_popup_html(None, "missing_code_or_state"))
+
+    entry = oauth_pending.get(state)
+    if not entry:
+        return HTMLResponse(_oauth_popup_html(None, "invalid_or_expired_state"))
+
+    # Expire stale entries
+    if time.time() - entry["created_at"] > OAUTH_STATE_TTL:
+        oauth_pending.pop(state, None)
+        return HTMLResponse(_oauth_popup_html(None, "state_expired"))
+
+    try:
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.post(
+                entry["token_url"],
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": entry["redirect_uri"],
+                    "client_id": entry["client_id"],
+                    "code_verifier": entry["verifier"],
+                },
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            resp.raise_for_status()
+            token_data = resp.json()
+    except Exception as e:
+        logger.warning(f"OAuth callback: token exchange failed — {e}")
+        oauth_pending.pop(state, None)
+        return HTMLResponse(_oauth_popup_html(None, f"token_exchange_failed: {e}"))
+
+    result = {
+        "access_token": token_data.get("access_token"),
+        "refresh_token": token_data.get("refresh_token"),
+        "expires_at": time.time() + token_data.get("expires_in", 3600),
+        "token_url": entry["token_url"],
+        "client_id": entry["client_id"],
+    }
+    entry["result"] = result
+    logger.info(f"OAuth callback: token exchange succeeded for state={state[:8]}…")
+    return HTMLResponse(_oauth_popup_html(result, None))
+
+
+@router.get("/inspector/oauth/result/{state}")
+async def oauth_result(state: str):
+    """
+    Poll for an OAuth token result after the popup has completed.
+
+    The frontend opens the authorization URL in a popup.  While the popup is
+    open the frontend polls this endpoint until a result appears (max
+    OAUTH_STATE_TTL seconds).  Once consumed the entry is removed.
+    """
+    entry = oauth_pending.get(state)
+    if not entry:
+        raise HTTPException(404, "OAuth state not found or already consumed")
+    if time.time() - entry["created_at"] > OAUTH_STATE_TTL:
+        oauth_pending.pop(state, None)
+        raise HTTPException(410, "OAuth state expired")
+    if entry["result"] is None:
+        return {"status": "pending"}
+    result = entry.pop("result")
+    oauth_pending.pop(state, None)
+    return {"status": "complete", "token": result}
+
+
+@router.post("/inspector/{session_id}/oauth/refresh")
+async def oauth_refresh(session_id: str):
+    """
+    Manually trigger an OAuth token refresh for an active session.
+    Useful when the frontend detects imminent expiry and wants to refresh
+    before the next tool call.
+    """
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    if session.auth.get("type") != "oauth":
+        raise HTTPException(400, "Session does not use OAuth auth")
+    try:
+        await session._auto_refresh()
+    except Exception as e:
+        raise HTTPException(502, f"Token refresh failed: {e}")
+    return {
+        "access_token": session.auth.get("access_token"),
+        "expires_at": session.auth.get("expires_at"),
+    }
+
+
+def _oauth_popup_html(token: Optional[dict], error: Optional[str]) -> str:
+    """
+    Minimal HTML page returned to the OAuth popup after the callback.
+    Posts a message to the opener window then closes the popup.
+    """
+    if error:
+        payload = json.dumps({"error": error})
+    else:
+        payload = json.dumps({"token": token})
+    return f"""<!DOCTYPE html>
+<html>
+<head><title>OAuth Callback</title></head>
+<body>
+<script>
+  try {{
+    window.opener.postMessage({payload}, window.location.origin);
+  }} catch(e) {{}}
+  window.close();
+</script>
+<p>Authentication complete. You may close this window.</p>
+</body>
+</html>"""
 
 
 @router.post("/inspector/{session_id}/chat/stream")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -603,7 +603,8 @@ def _oauth_popup_html(token: Optional[dict], error: Optional[str]) -> str:
     Posts a message to the opener window then closes the popup.
     """
     if error:
-        payload = json.dumps({"error": error})
+        import html as _html
+        payload = json.dumps({"error": _html.escape(str(error))})
     else:
         payload = json.dumps({"token": token})
     return f"""<!DOCTYPE html>

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -448,8 +448,10 @@ def _validate_oauth_url(url: str, field: str) -> None:
 
     https is required (not just http/https) because these endpoints receive
     client secrets and refresh tokens — http would put those credentials on
-    the wire in plaintext. Private/internal addresses are blocked to prevent
-    SSRF via an attacker-supplied token_url (e.g. cloud metadata endpoints).
+    the wire in plaintext. Private/internal addresses are blocked, including
+    via DNS: a hostname is resolved and every returned address is checked, so
+    an attacker-controlled domain that resolves to a private/internal address
+    (e.g. cloud metadata IPs) is rejected the same as a literal internal IP.
     """
     try:
         parsed = urlparse(url)
@@ -460,12 +462,23 @@ def _validate_oauth_url(url: str, field: str) -> None:
     host = parsed.hostname or ""
     if not host:
         raise HTTPException(400, f"{field} must include a host")
+
     try:
         addr = ipaddress.ip_address(host)
+        addresses = [addr]
+    except ValueError:
+        # Hostname, not a literal IP — resolve it so DNS rebinding to a
+        # private/internal address is caught, not just literal IPs.
+        import socket
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            raise HTTPException(400, f"{field} host could not be resolved")
+        addresses = [ipaddress.ip_address(info[4][0]) for info in infos]
+
+    for addr in addresses:
         if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
             raise HTTPException(400, f"{field} must not point to a private/internal address")
-    except ValueError:
-        pass  # hostname — fine
 
 
 @router.post("/inspector/oauth/authorize")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -156,6 +156,14 @@ async def connect_server(body: ConnectRequest):
 
     auth_dict = body.auth.model_dump() if body.auth else {}
 
+    # OAuth sessions can be created directly with an existing refresh token
+    # (e.g. resumed from a prior authorize/callback flow), bypassing the
+    # oauth_authorize validation entirely. Validate token_url here too, or a
+    # malicious/compromised frontend could point token refresh at an internal
+    # address (SSRF) or a plaintext http endpoint (credential leak).
+    if auth_dict.get("type") == "oauth" and auth_dict.get("token_url"):
+        _validate_oauth_url(auth_dict["token_url"], "auth.token_url")
+
     session = InspectorSession(
         url=body.url or "stdio://local",
         command=body.command,
@@ -435,13 +443,20 @@ def _pkce_pair() -> tuple[str, str]:
 
 
 def _validate_oauth_url(url: str, field: str) -> None:
-    """Ensure an OAuth endpoint URL is a valid public https URL."""
+    """
+    Ensure an OAuth endpoint URL is a valid public https URL.
+
+    https is required (not just http/https) because these endpoints receive
+    client secrets and refresh tokens — http would put those credentials on
+    the wire in plaintext. Private/internal addresses are blocked to prevent
+    SSRF via an attacker-supplied token_url (e.g. cloud metadata endpoints).
+    """
     try:
         parsed = urlparse(url)
     except Exception:
         raise HTTPException(400, f"Invalid {field}")
-    if parsed.scheme not in ("http", "https"):
-        raise HTTPException(400, f"{field} must be http/https")
+    if parsed.scheme != "https":
+        raise HTTPException(400, f"{field} must use https")
     host = parsed.hostname or ""
     if not host:
         raise HTTPException(400, f"{field} must include a host")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -22,6 +22,14 @@ from ..auth import verify_token
 
 router = APIRouter(dependencies=[Depends(verify_token)])
 
+# The OAuth authorization server redirects the user's browser here directly —
+# there is no way for that redirect to carry our bearer token, so this one
+# endpoint cannot sit behind verify_token or OAuth would 401 in secure mode.
+# It only exchanges a one-time authorization code (bound to a server-side PKCE
+# verifier keyed by a random state) for tokens; it exposes no other inspector
+# functionality, so it's safe to leave unauthenticated.
+public_router = APIRouter()
+
 # In-memory session store: session_id -> InspectorSession
 sessions: Dict[str, InspectorSession] = {}
 
@@ -520,7 +528,7 @@ async def oauth_authorize(body: OAuthAuthorizeRequest):
     return {"redirect_url": redirect_url, "state": state}
 
 
-@router.get("/inspector/oauth/callback")
+@public_router.get("/inspector/oauth/callback")
 async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None, error: Optional[str] = None):
     """
     OAuth 2.0 redirect callback.
@@ -529,8 +537,11 @@ async def oauth_callback(code: Optional[str] = None, state: Optional[str] = None
     access.  This endpoint exchanges the authorization code for tokens and
     stores them in oauth_pending so the frontend can poll for the result.
 
-    On success the browser is redirected to /ui/oauth-callback so the popup
-    page can read the result via window.opener.postMessage and close itself.
+    The response is a small inline HTML page (see _oauth_popup_html) that
+    posts the result to window.opener via postMessage and closes itself —
+    this endpoint is unauthenticated (public_router) since the browser lands
+    here straight from the authorization server's redirect, with no bearer
+    token attached.
     """
     from fastapi.responses import HTMLResponse
 
@@ -631,10 +642,18 @@ def _oauth_popup_html(token: Optional[dict], error: Optional[str]) -> str:
     Posts a message to the opener window then closes the popup.
     """
     if error:
-        import html as _html
-        payload = json.dumps({"error": _html.escape(str(error))})
+        payload = json.dumps({"error": str(error)})
     else:
         payload = json.dumps({"token": token})
+
+    # token/error values ultimately come from the OAuth token endpoint's
+    # response, which is untrusted (that endpoint is user-supplied and could
+    # be malicious or compromised). A literal "</script>" in any string value
+    # would close this script block early regardless of JSON escaping, since
+    # the HTML parser tokenizes it before any JS parsing happens. Escaping
+    # the slash prevents that without corrupting the JSON for JS to parse.
+    payload = payload.replace("</", "<\\/")
+
     return f"""<!DOCTYPE html>
 <html>
 <head><title>OAuth Callback</title></head>

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -22,7 +22,7 @@ from .api.management import router as mgmt_router
 from .services.package_launcher import create_dynamic_router
 from .services.metrics import get_registry
 from .services.frontend_utils import setup_frontend_routes
-from .api.inspector import router as inspector_router, cleanup_sessions
+from .api.inspector import router as inspector_router, public_router as inspector_public_router, cleanup_sessions
 from .auth import verify_token
 
 
@@ -260,6 +260,9 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
 
     # Include Inspector API
     app.include_router(inspector_router, prefix="/api", tags=["inspector"])
+    # OAuth callback is hit directly by the authorization server's redirect and
+    # cannot carry our bearer token, so it's mounted unauthenticated separately.
+    app.include_router(inspector_public_router, prefix="/api", tags=["inspector"])
     logger.info("Inspector API mounted at /api")
 
     # Include Dynamic MCP Router

--- a/fluidmcp/cli/services/frontend_utils.py
+++ b/fluidmcp/cli/services/frontend_utils.py
@@ -138,7 +138,7 @@ def setup_frontend_routes(
     # Known SPA routes that should redirect /route → /ui/route when hit bare
     _SPA_ROUTES = {
         "status", "servers", "documentation", "inspector",
-        "llm",
+        "llm", "oauth-callback",
     }
 
     try:

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -153,6 +153,11 @@ class InspectorSession:
         # Shared httpx client for HTTP/POST requests
         self._client: Optional[httpx.AsyncClient] = None
 
+        # Streamable-HTTP session id (RFC draft): captured from the Mcp-Session-Id
+        # response header on the first request and replayed on every subsequent
+        # request. Stateful servers reject requests missing this header with 400.
+        self._mcp_session_id: Optional[str] = None
+
     # ── Helpers ───────────────────────────────────────────────────────────────
 
     def _next_id(self) -> int:
@@ -174,6 +179,8 @@ class InspectorSession:
             headers["Authorization"] = f"Bearer {self.auth['token']}"
         elif auth_type == "oauth" and self.auth.get("access_token"):
             headers["Authorization"] = f"Bearer {self.auth['access_token']}"
+        if self._mcp_session_id:
+            headers["Mcp-Session-Id"] = self._mcp_session_id
         headers.update(self.extra_headers)
         return headers
 
@@ -538,6 +545,12 @@ class InspectorSession:
                 response = await client.post(self.url, json=request, headers=self._build_headers())
             except Exception as e:
                 logger.warning(f"Inspector: OAuth 401 retry failed — {e}")
+        # Streamable-HTTP: capture the session id so it can be replayed on every
+        # subsequent request. Servers only send this on the initialize response,
+        # but checking on every response is harmless and self-healing on reconnect.
+        new_session_id = response.headers.get("mcp-session-id")
+        if new_session_id:
+            self._mcp_session_id = new_session_id
         response.raise_for_status()
         return response.json()
 

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -169,10 +169,50 @@ class InspectorSession:
 
     def _build_headers(self) -> Dict[str, str]:
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
-        if self.auth.get("type") == "bearer" and self.auth.get("token"):
+        auth_type = self.auth.get("type")
+        if auth_type == "bearer" and self.auth.get("token"):
             headers["Authorization"] = f"Bearer {self.auth['token']}"
+        elif auth_type == "oauth" and self.auth.get("access_token"):
+            headers["Authorization"] = f"Bearer {self.auth['access_token']}"
         headers.update(self.extra_headers)
         return headers
+
+    async def _auto_refresh(self) -> None:
+        """Exchange the refresh token for a new access token."""
+        refresh_token = self.auth.get("refresh_token")
+        token_url = self.auth.get("token_url")
+        client_id = self.auth.get("client_id")
+        if not (refresh_token and token_url and client_id):
+            return
+        client = self._get_client()
+        resp = await client.post(
+            token_url,
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": client_id,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        self.auth["access_token"] = data["access_token"]
+        if "refresh_token" in data:
+            self.auth["refresh_token"] = data["refresh_token"]
+        if "expires_in" in data:
+            self.auth["expires_at"] = time.time() + data["expires_in"]
+        self.add_log("connect", "OAuth token refreshed")
+
+    async def _ensure_fresh_token(self) -> None:
+        """Proactively refresh the OAuth access token if it expires within 60 seconds."""
+        if self.auth.get("type") != "oauth":
+            return
+        expires_at = self.auth.get("expires_at")
+        if expires_at is not None and time.time() >= expires_at - 60:
+            try:
+                await self._auto_refresh()
+            except Exception as e:
+                logger.warning(f"Inspector: proactive OAuth refresh failed — {e}")
 
     MAX_LOGS = 250
 
@@ -489,8 +529,15 @@ class InspectorSession:
         if self.transport == "sse":
             return await self._sse_request(request)
 
+        await self._ensure_fresh_token()
         client = self._get_client()
         response = await client.post(self.url, json=request, headers=self._build_headers())
+        if response.status_code == 401 and self.auth.get("type") == "oauth":
+            try:
+                await self._auto_refresh()
+                response = await client.post(self.url, json=request, headers=self._build_headers())
+            except Exception as e:
+                logger.warning(f"Inspector: OAuth 401 retry failed — {e}")
         response.raise_for_status()
         return response.json()
 

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -3,12 +3,13 @@ import re
 import time
 import json
 import shlex
+import socket
 import asyncio
 import ipaddress
 from pathlib import Path
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any, List
-from urllib.parse import urlparse
+from typing import Optional, Dict, Any, List, Tuple
+from urllib.parse import urlparse, urlunparse
 import httpx
 from loguru import logger
 from fastapi import HTTPException
@@ -35,6 +36,49 @@ def _validate_url(url: str) -> None:
 
     if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
         raise ValueError("Connections to private/internal addresses are not allowed")
+
+
+def resolve_pinned_target(url: str, field: str = "URL") -> Tuple[str, str]:
+    """
+    Resolve url's hostname exactly once, reject it if any resolved address is
+    private/internal, and return (pinned_url, original_host) where pinned_url
+    has the hostname replaced by one validated IP literal.
+
+    Validating a hostname string once and then letting httpx independently
+    re-resolve it at request time leaves a DNS-rebinding window open: an
+    attacker-controlled domain can resolve to a public address for the check
+    and to a private/metadata address moments later for the real connection.
+    Resolving once here, immediately before connecting, and pointing the
+    actual request straight at that address closes the window. Callers must
+    still send `original_host` as the Host header and as the "sni_hostname"
+    request extension so virtual hosting and TLS certificate validation keep
+    working against an IP-literal URL.
+    """
+    parsed = urlparse(url)
+    host = parsed.hostname or ""
+    if not host:
+        raise HTTPException(400, f"{field} must include a host")
+
+    try:
+        addr = ipaddress.ip_address(host)
+        addresses = [addr]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, None)
+        except socket.gaierror:
+            raise HTTPException(400, f"{field} host could not be resolved")
+        addresses = [ipaddress.ip_address(info[4][0]) for info in infos]
+
+    for a in addresses:
+        if a.is_private or a.is_loopback or a.is_link_local or a.is_reserved:
+            raise HTTPException(400, f"{field} must not point to a private/internal address")
+
+    pinned_ip = addresses[0]
+    netloc = f"[{pinned_ip}]" if pinned_ip.version == 6 else str(pinned_ip)
+    if parsed.port:
+        netloc += f":{parsed.port}"
+    pinned_url = urlunparse(parsed._replace(netloc=netloc))
+    return pinned_url, host
 
 
 # ── Per-binary argument schemas ───────────────────────────────────────────────
@@ -192,14 +236,19 @@ class InspectorSession:
         if not (refresh_token and token_url and client_id):
             return
         client = self._get_client()
+        pinned_url, original_host = resolve_pinned_target(token_url, "token_url")
         resp = await client.post(
-            token_url,
+            pinned_url,
             data={
                 "grant_type": "refresh_token",
                 "refresh_token": refresh_token,
                 "client_id": client_id,
             },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Host": original_host,
+            },
+            extensions={"sni_hostname": original_host},
         )
         resp.raise_for_status()
         data = resp.json()


### PR DESCRIPTION
## Summary

- **Part 1 (backend only):** OAuth 2.0 PKCE flow — `/oauth/authorize`, `/oauth/callback`, `/oauth/result/{state}`, `/{session_id}/oauth/refresh` endpoints
- `inspector_session.py`: extend `_build_headers` for OAuth auth type, `_auto_refresh` (refresh_token grant), `_ensure_fresh_token` (proactive refresh 60s before expiry), 401-retry in `_send`, capture `mcp-session-id` for FastMCP streamable-HTTP, SSE response parsing
- `inspector.py`: extend `AuthConfig` with OAuth fields, `oauth_pending` store, four new OAuth endpoints, PKCE pair generation
- `frontend_utils.py`: explicit `GET /ui` redirect to fix Starlette StaticFiles building Location from raw Host header in proxied envs (Codespace/Railway)

## Test plan

- [x] POST `/api/inspector/oauth/authorize` returns `redirect_url` and `state`
- [x] GET `/api/inspector/oauth/result/{state}` returns pending → tokens after callback
- [x] GET `/api/inspector/oauth/callback?code=...&state=...` exchanges code for tokens and returns popup HTML
- [x] POST `/{session_id}/oauth/refresh` refreshes access token
- [x] FastMCP streamable-HTTP: initialize returns `mcp-session-id`, subsequent calls include it; SSE responses parsed correctly
- [x] `/ui` URL in Codespace/proxied env redirects correctly (no `localhost` in Location)

