### PR TITLE
[MCP-528]: MCP Inspector 5B: Trace export JSON and Markdown (sprint 5O)

### DIFF
--- a/fluidmcp/frontend/src/lib/trace-export.ts
+++ b/fluidmcp/frontend/src/lib/trace-export.ts
@@ -1,0 +1,115 @@
+import type { ExecutionRun } from "../components/inspector/chat-types";
+
+export interface TraceExportOptions {
+  serverName?: string;
+  serverUrl?: string;
+}
+
+function formatTimestamp(ms: number): string {
+  return new Date(ms).toISOString();
+}
+
+function formatDuration(startMs: number, endMs?: number): string {
+  if (!endMs) return "—";
+  return `${endMs - startMs}ms`;
+}
+
+
+export function toJSON(runs: ExecutionRun[], opts: TraceExportOptions = {}): string {
+  const payload = {
+    exported_at: new Date().toISOString(),
+    server_name: opts.serverName ?? null,
+    server_url: opts.serverUrl ?? null,
+    run_count: runs.length,
+    runs: runs.map((run) => ({
+      run_id: run.runId,
+      server_id: run.serverId,
+      started_at: formatTimestamp(run.startTime),
+      ended_at: run.endTime ? formatTimestamp(run.endTime) : null,
+      duration_ms: run.endTime ? run.endTime - run.startTime : null,
+      steps: run.steps.map((s) => ({
+        type: s.type,
+        tool_name: s.toolName ?? null,
+        params: s.params ?? null,
+        result: s.result ?? null,
+        content: s.content ?? null,
+        timestamp: formatTimestamp(s.timestamp),
+      })),
+    })),
+  };
+  return JSON.stringify(payload, null, 2);
+}
+
+export function toMarkdown(runs: ExecutionRun[], opts: TraceExportOptions = {}): string {
+  const lines: string[] = [];
+  const exportedAt = new Date().toLocaleString();
+
+  lines.push(`# MCP Trace Export`);
+  if (opts.serverName) lines.push(`**Server:** ${opts.serverName}`);
+  if (opts.serverUrl) lines.push(`**URL:** ${opts.serverUrl}`);
+  lines.push(`**Exported:** ${exportedAt}`);
+  lines.push(`**Runs:** ${runs.length}`);
+  lines.push("");
+
+  runs.forEach((run, i) => {
+    const toolCallStep = run.steps.find((s) => s.type === "tool_call");
+    const label = toolCallStep?.toolName ?? "chat";
+    const duration = formatDuration(run.startTime, run.endTime);
+
+    lines.push(`---`);
+    lines.push(`## Run ${i + 1} — \`${label}\` (${duration})`);
+    lines.push(`**Started:** ${formatTimestamp(run.startTime)}`);
+    if (run.endTime) lines.push(`**Ended:** ${formatTimestamp(run.endTime)}`);
+    lines.push("");
+
+    run.steps.forEach((step) => {
+      switch (step.type) {
+        case "user":
+          lines.push(`### User`);
+          lines.push(step.content ?? "");
+          lines.push("");
+          break;
+        case "thinking":
+          lines.push(`### Thinking`);
+          lines.push(`> ${(step.content ?? "").replace(/\n/g, "\n> ")}`);
+          lines.push("");
+          break;
+        case "tool_call":
+          lines.push(`### Tool Call — \`${step.toolName}\``);
+          lines.push("```json");
+          lines.push(JSON.stringify(step.params ?? {}, null, 2));
+          lines.push("```");
+          lines.push("");
+          break;
+        case "tool_result":
+          lines.push(`### Tool Result`);
+          lines.push("```json");
+          lines.push(JSON.stringify(step.result ?? {}, null, 2));
+          lines.push("```");
+          lines.push("");
+          break;
+        case "assistant":
+          lines.push(`### Assistant`);
+          lines.push(step.content ?? "");
+          lines.push("");
+          break;
+        case "error":
+          lines.push(`### Error`);
+          lines.push(`> ${step.content ?? ""}`);
+          lines.push("");
+          break;
+      }
+    });
+  });
+
+  return lines.join("\n");
+}
+
+export function downloadFile(content: string, filename: string, mimeType: string): void {
+  const blob = new Blob([content], { type: mimeType });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -12,6 +12,7 @@ import { PromptsPanel } from '../components/inspector/PromptsPanel';
 import { ManualToolPanel } from '../components/inspector/ManualToolPanel';
 import { ChatPanel } from '../components/inspector/ChatPanel';
 import { type ChatMessage, type ExecutionRun } from '../components/inspector/chat-types';
+import { toJSON, toMarkdown, downloadFile } from '../lib/trace-export';
 
 // Type for server object
 interface MCPServer {
@@ -104,6 +105,7 @@ export default function MCPInspector() {
   const [toolSubTab, setToolSubTab] = useState<"tools" | "saved">("tools")
   const [savedRequests, setSavedRequests] = useState<SavedRequest[]>([])
   const [saveDialogOpen, setSaveDialogOpen] = useState(false)
+  const [traceDropdownOpen, setTraceDropdownOpen] = useState(false)
   const [saveTitle, setSaveTitle] = useState("")
   const [formPrefill, setFormPrefill] = useState<Record<string, any> | undefined>(undefined)
   const [renamingId, setRenamingId] = useState<string | null>(null)
@@ -1079,31 +1081,88 @@ export default function MCPInspector() {
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0 }}>
                   <h2 style={{ fontSize: "1.1rem", fontWeight: "600" }}>Tool Execution</h2>
                   {selectedServer?.status === "connected" && selectedServer.session_id && (
-                    <button
-                      onClick={async () => {
-                        try {
-                          const data = await apiClient.exportInspectorServer(selectedServer.session_id!);
-                          // Merge in the display name from local state since backend doesn't store it
-                          data.serverInfo = { ...data.serverInfo, name: selectedServer.name || selectedServer.server_info?.name };
-                          const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
-                          const a = document.createElement("a");
-                          a.href = URL.createObjectURL(blob);
-                          a.download = `${(selectedServer.name || selectedServer.server_info?.name || "mcp-server").replace(/\s+/g, "-").toLowerCase()}-export.json`;
-                          a.click();
-                          URL.revokeObjectURL(a.href);
-                        } catch (e) {
-                          console.error("Export failed", e);
-                        }
-                      }}
-                      title="Export server config + tools as JSON"
-                      style={{
-                        fontSize: "0.72rem", padding: "0.25rem 0.65rem", borderRadius: "6px",
-                        background: "rgba(39,39,42,0.8)", border: "1px solid rgba(63,63,70,0.6)",
-                        color: "rgba(255,255,255,0.6)", cursor: "pointer", display: "flex", alignItems: "center", gap: "0.3rem",
-                      }}
-                    >
-                      ↓ Export
-                    </button>
+                    <div style={{ display: "flex", gap: "0.4rem", alignItems: "center" }}>
+                      <button
+                        onClick={async () => {
+                          try {
+                            const data = await apiClient.exportInspectorServer(selectedServer.session_id!);
+                            // Merge in the display name from local state since backend doesn't store it
+                            data.serverInfo = { ...data.serverInfo, name: selectedServer.name || selectedServer.server_info?.name };
+                            const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+                            const a = document.createElement("a");
+                            a.href = URL.createObjectURL(blob);
+                            a.download = `${(selectedServer.name || selectedServer.server_info?.name || "mcp-server").replace(/\s+/g, "-").toLowerCase()}-export.json`;
+                            a.click();
+                            URL.revokeObjectURL(a.href);
+                          } catch (e) {
+                            console.error("Export failed", e);
+                          }
+                        }}
+                        title="Export server config + tools as JSON"
+                        style={{
+                          fontSize: "0.72rem", padding: "0.25rem 0.65rem", borderRadius: "6px",
+                          background: "rgba(39,39,42,0.8)", border: "1px solid rgba(63,63,70,0.6)",
+                          color: "rgba(255,255,255,0.6)", cursor: "pointer", display: "flex", alignItems: "center", gap: "0.3rem",
+                        }}
+                      >
+                        ↓ Export
+                      </button>
+
+                      {executionHistory.length > 0 && (
+                        <div style={{ position: "relative" }}>
+                          <button
+                            onClick={() => setTraceDropdownOpen(o => !o)}
+                            title="Export execution trace"
+                            style={{
+                              fontSize: "0.72rem", padding: "0.25rem 0.65rem", borderRadius: "6px",
+                              background: "rgba(39,39,42,0.8)", border: "1px solid rgba(63,63,70,0.6)",
+                              color: "rgba(255,255,255,0.6)", cursor: "pointer", display: "flex", alignItems: "center", gap: "0.3rem",
+                            }}
+                          >
+                            ↓ Trace ▾
+                          </button>
+                          {traceDropdownOpen && (
+                            <div
+                              onMouseLeave={() => setTraceDropdownOpen(false)}
+                              style={{
+                                position: "absolute", top: "calc(100% + 4px)", right: 0,
+                                background: "#18181b", border: "1px solid rgba(63,63,70,0.7)",
+                                borderRadius: "6px", overflow: "hidden", zIndex: 50, minWidth: "130px",
+                              }}
+                            >
+                              {[
+                                { label: "JSON", ext: "json", mime: "application/json" },
+                                { label: "Markdown", ext: "md", mime: "text/markdown" },
+                              ].map(({ label, ext, mime }) => (
+                                <button
+                                  key={ext}
+                                  onClick={() => {
+                                    setTraceDropdownOpen(false);
+                                    const serverName = selectedServer.name || selectedServer.server_info?.name || "mcp-server";
+                                    const slug = serverName.replace(/\s+/g, "-").toLowerCase();
+                                    const opts = { serverName, serverUrl: selectedServer.url };
+                                    const content = ext === "json"
+                                      ? toJSON(executionHistory, opts)
+                                      : toMarkdown(executionHistory, opts);
+                                    downloadFile(content, `${slug}-trace.${ext}`, mime);
+                                  }}
+                                  style={{
+                                    display: "block", width: "100%", textAlign: "left",
+                                    padding: "0.45rem 0.75rem", background: "transparent",
+                                    border: "none", color: "rgba(255,255,255,0.7)",
+                                    fontSize: "0.75rem", cursor: "pointer",
+                                  }}
+                                  onMouseEnter={e => (e.currentTarget.style.background = "rgba(99,102,241,0.15)")}
+                                  onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+                                >
+                                  {label}
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary

- `trace-export.ts`: pure utility with `toJSON()` and `toMarkdown()` functions that serialize `ExecutionRun[]` into downloadable files
  - JSON: structured dump with run metadata, timing, params, and results per step
  - Markdown: human-readable report with tool calls, params, results, and assistant messages formatted as code blocks
- `MCPInspector`: `↓ Trace ▾` dropdown button added next to existing Export button in Tool Execution header
  - Shows JSON and Markdown download options
  - Only visible when `executionHistory.length > 0` for the current server

## Test plan

- [x] Run a tool on any connected server
- [x] Click `↓ Trace ▾` → dropdown shows JSON and Markdown options
- [x] Click JSON → `<server>-trace.json` downloads with correct run metadata, timing, params, and result
- [x] Click Markdown → `<server>-trace.md` downloads with human-readable report
- [x] Trace button hidden when no runs exist for current server
- [x] Trace button hidden when server is disconnected
