### PR TITLE
[MCP-536]: FluidMCP feat: add copyable MCP URL to server details page

### DIFF
--- a/fluidmcp/cli/services/frontend_utils.py
+++ b/fluidmcp/cli/services/frontend_utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Optional
 from loguru import logger
 from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 
@@ -135,6 +136,14 @@ def setup_frontend_routes(
         return False
 
     try:
+        # StaticFiles redirects /ui → /ui/ using an absolute URL based on the Host header,
+        # which breaks in reverse-proxy environments (e.g. GitHub Codespaces) where the
+        # internal host differs from the public hostname. Adding a relative redirect here
+        # intercepts the bare /ui request before StaticFiles can issue an absolute one.
+        @app.get("/ui", include_in_schema=False)
+        async def _ui_redirect():
+            return RedirectResponse(url="/ui/")
+
         # Mount StaticFiles for serving built assets (JS, CSS, images)
         # The html=True parameter enables SPA mode:
         # - Serves static files normally (app.js, styles.css, etc.)

--- a/fluidmcp/frontend/src/pages/ServerDetails.tsx
+++ b/fluidmcp/frontend/src/pages/ServerDetails.tsx
@@ -1,5 +1,5 @@
 import { useParams, useNavigate } from "react-router-dom";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useServerDetails } from "../hooks/useServerDetails";
 import { useServerEnv } from "../hooks/useServerEnv";
 import { useServerPolling } from "../hooks/useServerPolling";
@@ -17,6 +17,16 @@ export default function ServerDetails() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [envFormExpanded, setEnvFormExpanded] = useState(false);
   const [envSubmitting, setEnvSubmitting] = useState(false);
+  const [urlCopied, setUrlCopied] = useState(false);
+
+  const mcpUrl = `${window.location.origin}/${serverId}/mcp`;
+
+  const handleCopyUrl = useCallback(() => {
+    navigator.clipboard.writeText(mcpUrl).then(() => {
+      setUrlCopied(true);
+      setTimeout(() => setUrlCopied(false), 2000);
+    });
+  }, [mcpUrl]);
 
   const {
     serverDetails,
@@ -217,7 +227,28 @@ export default function ServerDetails() {
           <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
             <div>
               <h1>{serverDetails.name}</h1>
-              <p style={{ margin: '4px 0 8px 0', fontSize: '0.875rem', fontFamily: 'monospace', color: '#a1a1a1' }}>{serverId}</p>
+              <p style={{ margin: '4px 0 6px 0', fontSize: '0.875rem', fontFamily: 'monospace', color: '#a1a1a1' }}>{serverId}</p>
+              {/* Copyable MCP connection URL */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginBottom: '8px', flexWrap: 'wrap' }}>
+                <span style={{ fontSize: '0.75rem', color: '#71717a', whiteSpace: 'nowrap' }}>MCP URL:</span>
+                <code style={{ fontSize: '0.8rem', fontFamily: 'monospace', color: '#a78bfa', background: 'rgba(139, 92, 246, 0.1)', padding: '2px 8px', borderRadius: '4px', border: '1px solid rgba(139, 92, 246, 0.25)', wordBreak: 'break-all' }}>
+                  {mcpUrl}
+                </code>
+                <button
+                  onClick={handleCopyUrl}
+                  title="Copy MCP URL"
+                  style={{ background: urlCopied ? 'rgba(34, 197, 94, 0.15)' : 'rgba(39, 39, 42, 0.8)', border: `1px solid ${urlCopied ? 'rgba(34, 197, 94, 0.4)' : 'rgba(63, 63, 70, 0.6)'}`, color: urlCopied ? '#4ade80' : '#a1a1aa', padding: '3px 10px', borderRadius: '4px', fontSize: '0.75rem', cursor: 'pointer', transition: 'all 0.2s', whiteSpace: 'nowrap' }}
+                >
+                  {urlCopied ? '✓ Copied' : 'Copy'}
+                </button>
+                <div style={{ position: 'relative', display: 'inline-flex' }} className="mcp-url-hint">
+                  <span style={{ width: '16px', height: '16px', borderRadius: '50%', border: '1px solid #52525b', color: '#71717a', fontSize: '0.65rem', fontWeight: '700', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', cursor: 'default', userSelect: 'none', flexShrink: 0 }}>?</span>
+                  <div style={{ position: 'absolute', left: '50%', bottom: 'calc(100% + 8px)', transform: 'translateX(-50%)', width: '260px', background: '#18181b', border: '1px solid rgba(82, 82, 91, 0.6)', borderRadius: '8px', padding: '10px 12px', fontSize: '0.75rem', color: '#d1d5db', lineHeight: '1.5', pointerEvents: 'none', opacity: 0, transition: 'opacity 0.15s', zIndex: 50 }} className="mcp-url-tooltip">
+                    Use this URL to connect with this MCP server from any MCP-compatible client — such as Claude Desktop, ChatGPT, Cursor, or the MCP Inspector.
+                  </div>
+                </div>
+              </div>
+              <style>{`.mcp-url-hint:hover .mcp-url-tooltip { opacity: 1 !important; }`}</style>
               <p className="subtitle">
                 {serverDetails.description || "No description available"}
               </p>


### PR DESCRIPTION
## Summary

- Fixes `/ui` redirect breaking in reverse-proxy environments (GitHub Codespaces, Railway) — intercepts the bare `/ui` route with a relative redirect before Starlette's `StaticFiles` issues an absolute one using the internal `Host` header
- Adds a copyable MCP connection URL on the server details page, displayed beneath the server ID, built from `window.location.origin` so it works across all deployment environments
- Includes a `?` tooltip explaining the URL can be used to connect from Claude Desktop, ChatGPT, Cursor, or the MCP Inspector

## Test plan

- [x] Navigate to `/ui` — should redirect correctly without being sent to `localhost` in Codespaces/Railway
- [x] Open a server details page — MCP URL should display as `<origin>/<server-id>/mcp`
- [x] Click Copy — URL is copied to clipboard and button briefly shows ✓ Copied
- [x] Hover the `?` icon — tooltip appears with connection instructions
- [x] Resize browser window — URL wraps naturally on narrow screens