### PR TITLE
Railway Deployment #c0535f fix: remove stdlib backports from deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 annotated-types==0.7.0
 anyio==4.9.0
-asyncio==3.4.3
 boto3==1.38.10
 botocore==1.38.10
 certifi==2025.4.26
@@ -21,7 +20,6 @@ loguru==0.7.3
 mcp==1.7.1
 motor==3.7.1
 openai==1.77.0
-pathlib==1.0.1
 prometheus-client==0.21.0
 psutil==7.0.0
 redis==5.0.0


### PR DESCRIPTION
## Problem

The Docker build fails at `pip install -r requirements.txt` with a `BrokenPipeError` while downloading `asyncio==3.4.3`. Both `asyncio` and `pathlib` are PyPI backport packages from 2014 intended for Python 3.3, and are incompatible with Python 3.10 where both modules are part of the standard library.

## Solution

Removed `asyncio==3.4.3` and `pathlib==1.0.1` from `requirements.txt`. Both modules are built into Python 3.10 and remain available to the application via standard imports — no code changes are needed.

### Changes
- **Modified** `requirements.txt`

### Context
- **Deployment**: [#c0535f](https://railway.com/project/d63c7ce7-0305-49fd-a2a6-54bf2b9f5fbb/environment/445ddad5-3974-4047-b6f6-2d1c94135bf3/deployment/c0535fea-b91c-4090-a457-d23e9c8b12d9)
- **Failed commit**: `b1ed48c`

---
*Generated by [Railway](https://railway.com)*