### PR TITLE
[MCP-557]: feat(debugging): P1 - exit code classifier and crash resource snapshot

### DIFF
--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -646,6 +646,7 @@ async def main(args):
         logger.warning("Invalid FMCP_HEALTH_CHECK_INTERVAL value, using default 30s")
         health_check_interval = 30
     health_monitor = MCPHealthMonitor(server_manager, check_interval=health_check_interval)
+    server_manager._health_monitor = health_monitor
     health_monitor.start()
 
     # 4. Create FastAPI app (without MCP servers)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -1218,6 +1218,10 @@ class ServerManager:
         # Close stderr log file handle
         self._close_stderr_log(id)
 
+        # Capture resource snapshot before clearing (used in crash event below)
+        health_monitor = getattr(self, "_health_monitor", None)
+        resource_snapshot = health_monitor._last_resource_snapshot.get(id) if health_monitor else None
+
         # Determine state
         if intentional or exit_code == 0:
             state = "stopped"
@@ -1239,9 +1243,6 @@ class ServerManager:
             exit_info = classify_exit_code(exit_code)
             config = self.configs.get(id) or {}
             server_name = config.get("name", id)
-            # Pull resource snapshot captured by MCPHealthMonitor (may be None if monitor not running)
-            resource_snapshot = getattr(self, "_health_monitor", None)
-            resource_snapshot = resource_snapshot._last_resource_snapshot.get(id) if resource_snapshot else None
             try:
                 crash_event: Dict[str, Any] = {
                     "server_id": id,
@@ -1267,6 +1268,11 @@ class ServerManager:
             )
         else:
             logger.info(f"Cleaned up server '{id}'")
+
+        # Clean up health monitor per-server state after crash event is saved
+        if health_monitor is not None:
+            health_monitor._last_resource_snapshot.pop(id, None)
+            health_monitor._memory_history.pop(id, None)
 
     def get_uptime(self, server_id: str) -> Optional[float]:
         """
@@ -1662,21 +1668,10 @@ class MCPHealthMonitor:
             self._update_resource_snapshot(server_id, process)
             return
 
-        # Snapshot fired here — process just detected dead, PID may still exist briefly
+        # Evict stale PID from warm-up tracking so the next restart gets a fresh warm-up
         pid = getattr(process, "pid", None)
-        if _psutil_available and pid and pid not in self._cpu_warmed_pids:
-            # Process died before warm-up cycle completed; snapshot already cached or unavailable
-            pass
-        elif _psutil_available and pid:
-            try:
-                proc = psutil.Process(pid)
-                rss = proc.memory_info().rss
-                cpu = proc.cpu_percent(interval=None)
-                snapshot = {"memory_rss_bytes": rss, "cpu_percent": cpu}
-                snapshot["active_requests"] = self._get_active_requests(server_id)
-                self._last_resource_snapshot[server_id] = snapshot
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                pass  # fall back to last cached snapshot — set above during alive cycles
+        if pid:
+            self._cpu_warmed_pids.discard(pid)
 
         # Process is dead — always clean up DB state
         rc = getattr(process, "returncode", None)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -10,11 +10,18 @@ import subprocess
 import json
 import time
 import atexit
+from collections import deque
 from urllib.parse import urlparse
-from typing import Dict, Any, Optional, List, IO
+from typing import Dict, Any, Optional, List, IO, Deque
 from pathlib import Path
 from datetime import datetime, timedelta
 from loguru import logger
+
+try:
+    import psutil
+    _psutil_available = True
+except ImportError:
+    _psutil_available = False
 
 from ..repositories.database import DatabaseManager
 from .package_launcher import initialize_mcp_server
@@ -22,6 +29,28 @@ from .metrics import MetricsCollector
 from .health_checker import HealthChecker
 from .sse_handle import SseSubprocessHandle
 from .network_utils import find_free_port
+
+
+def classify_exit_code(exit_code: int) -> Dict[str, str]:
+    """Return a human-readable classification for a process exit code."""
+    table = {
+        0:    ("clean",    "clean_exit",          "Process exited normally"),
+        1:    ("error",    "generic_error",        "Unhandled error"),
+        126:  ("config",   "permission_denied",    "Cannot execute — check file permissions"),
+        127:  ("config",   "command_not_found",    "Binary/command not found — check command path"),
+        137:  ("resource", "oom_killed",           "Killed by OS (likely OOM) — check memory limits"),
+        139:  ("crash",    "segfault",             "Segmentation fault"),
+        143:  ("shutdown", "sigterm_container",    "SIGTERM from container runtime (Railway/Docker stop)"),
+        255:  ("error",    "unknown_fatal",        "Unknown fatal error — check stderr for details"),
+        -1:   ("resource", "killed_by_fluidmcp",   "Killed by FluidMCP resource monitor (OOM or CPU stuck)"),
+        -9:   ("resource", "sigkill",              "Force-killed (SIGKILL)"),
+        -15:  ("shutdown", "sigterm",              "Graceful shutdown (SIGTERM)"),
+    }
+    if exit_code in table:
+        category, label, description = table[exit_code]
+    else:
+        category, label, description = "error", "unknown", f"Unknown exit code {exit_code}"
+    return {"category": category, "label": label, "description": description}
 
 
 class ServerManager:
@@ -1207,18 +1236,35 @@ class ServerManager:
         # Persist crash event for non-intentional failures
         if state == "failed":
             stderr_tail = self._read_crash_stderr(id)
+            exit_info = classify_exit_code(exit_code)
+            config = self.configs.get(id) or {}
+            server_name = config.get("name", id)
+            # Pull resource snapshot captured by MCPHealthMonitor (may be None if monitor not running)
+            resource_snapshot = getattr(self, "_health_monitor", None)
+            resource_snapshot = resource_snapshot._last_resource_snapshot.get(id) if resource_snapshot else None
             try:
-                await self.db.save_crash_event({
+                crash_event: Dict[str, Any] = {
                     "server_id": id,
+                    "server_name": server_name,
                     "exit_code": exit_code,
+                    "exit_category": exit_info["category"],
+                    "exit_label": exit_info["label"],
+                    "exit_description": exit_info["description"],
                     "stderr_tail": stderr_tail,
                     "uptime_seconds": uptime,
-                    "timestamp": datetime.utcnow()
-                })
+                    "timestamp": datetime.utcnow(),
+                }
+                if resource_snapshot:
+                    crash_event["memory_bytes_at_crash"] = resource_snapshot.get("memory_rss_bytes")
+                    crash_event["cpu_percent_at_crash"] = resource_snapshot.get("cpu_percent")
+                    crash_event["active_requests_at_crash"] = resource_snapshot.get("active_requests")
+                await self.db.save_crash_event(crash_event)
             except Exception as e:
                 logger.error(f"Failed to save crash event for server '{id}': {e}")
             uptime_str = f"{uptime:.1f}s" if uptime is not None else "unknown"
-            logger.warning(f"Server '{id}' crashed (exit_code={exit_code}, uptime={uptime_str})")
+            logger.warning(
+                f"Server '{id}' crashed (exit_code={exit_code} [{exit_info['label']}], uptime={uptime_str})"
+            )
         else:
             logger.info(f"Cleaned up server '{id}'")
 
@@ -1522,6 +1568,14 @@ class MCPHealthMonitor:
         self._restarts_in_progress: set = set()
         self._restart_counts: Dict[str, int] = {}
 
+        # Resource snapshot cache: server_id -> {memory_rss_bytes, cpu_percent, active_requests}
+        # Updated every health check cycle; used at crash time and by /resources endpoint
+        self._last_resource_snapshot: Dict[str, Dict[str, Any]] = {}
+        # Ring buffer of last 3 RSS readings per server for memory_trend computation
+        self._memory_history: Dict[str, Deque[int]] = {}
+        # Tracks whether cpu_percent has been warmed up for each PID (first call returns 0.0)
+        self._cpu_warmed_pids: set = set()
+
     def start(self) -> None:
         """Start the background health monitor."""
         if self._running:
@@ -1604,7 +1658,25 @@ class MCPHealthMonitor:
                 uptime = self._sm.get_uptime(server_id)
                 if uptime and uptime > 300:
                     self._restart_counts.pop(server_id, None)
+            # Update resource snapshot while process is alive
+            self._update_resource_snapshot(server_id, process)
             return
+
+        # Snapshot fired here — process just detected dead, PID may still exist briefly
+        pid = getattr(process, "pid", None)
+        if _psutil_available and pid and pid not in self._cpu_warmed_pids:
+            # Process died before warm-up cycle completed; snapshot already cached or unavailable
+            pass
+        elif _psutil_available and pid:
+            try:
+                proc = psutil.Process(pid)
+                rss = proc.memory_info().rss
+                cpu = proc.cpu_percent(interval=None)
+                snapshot = {"memory_rss_bytes": rss, "cpu_percent": cpu}
+                snapshot["active_requests"] = self._get_active_requests(server_id)
+                self._last_resource_snapshot[server_id] = snapshot
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass  # fall back to last cached snapshot — set above during alive cycles
 
         # Process is dead — always clean up DB state
         rc = getattr(process, "returncode", None)
@@ -1686,3 +1758,60 @@ class MCPHealthMonitor:
             logger.error(f"Error restarting MCP server '{server_id}': {e}")
         finally:
             self._restarts_in_progress.discard(server_id)
+
+    def _update_resource_snapshot(self, server_id: str, process) -> None:
+        """Update cached resource snapshot for a live process."""
+        if not _psutil_available:
+            return
+        pid = getattr(process, "pid", None)
+        if not pid:
+            return
+        try:
+            proc = psutil.Process(pid)
+            # Warm up cpu_percent on first encounter — first call always returns 0.0
+            if pid not in self._cpu_warmed_pids:
+                proc.cpu_percent(interval=None)
+                self._cpu_warmed_pids.add(pid)
+                return  # skip this cycle; next cycle will have a real reading
+            rss = proc.memory_info().rss
+            cpu = proc.cpu_percent(interval=None)
+            # Update ring buffer for memory trend
+            if server_id not in self._memory_history:
+                self._memory_history[server_id] = deque(maxlen=3)
+            self._memory_history[server_id].append(rss)
+            snapshot = {
+                "memory_rss_bytes": rss,
+                "cpu_percent": cpu,
+                "active_requests": self._get_active_requests(server_id),
+            }
+            self._last_resource_snapshot[server_id] = snapshot
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+    def _get_active_requests(self, server_id: str) -> int:
+        """Read active request count directly from the metrics gauge samples dict."""
+        try:
+            registry = getattr(self._sm, "_metrics_registry", None)
+            if registry is None:
+                return 0
+            gauge = registry.get_metric("fluidmcp_active_requests")
+            if gauge is None:
+                return 0
+            key = gauge._get_label_key({"server_id": server_id})
+            return int(gauge.samples.get(key, 0))
+        except Exception:
+            return 0
+
+    def get_memory_trend(self, server_id: str) -> str:
+        """Derive memory trend from the last 3 RSS readings."""
+        history = self._memory_history.get(server_id)
+        if not history or len(history) < 2:
+            return "unknown"
+        readings = list(history)
+        if all(readings[i] < readings[i + 1] for i in range(len(readings) - 1)):
+            return "increasing"
+        if all(readings[i] > readings[i + 1] for i in range(len(readings) - 1)):
+            return "decreasing"
+        if len(set(readings)) == 1:
+            return "stable"
+        return "fluctuating"

--- a/tests/test_debugging_p1.py
+++ b/tests/test_debugging_p1.py
@@ -5,11 +5,8 @@ Tests for P1 debugging features:
 - MCPHealthMonitor resource snapshot caching and memory trend
 """
 import pytest
-import asyncio
-import subprocess
 from collections import deque
-from unittest.mock import Mock, AsyncMock, patch, MagicMock
-from datetime import datetime
+from unittest.mock import Mock, AsyncMock, patch
 
 from fluidmcp.cli.services.server_manager import (
     ServerManager,
@@ -156,6 +153,22 @@ class TestCrashEventEnrichment:
         assert event["active_requests_at_crash"] == 3
 
     @pytest.mark.asyncio
+    async def test_cleanup_clears_health_monitor_state(self, server_manager):
+        """_cleanup_server must evict _last_resource_snapshot and _memory_history for the server."""
+        server_manager.db.save_crash_event = AsyncMock()
+        server_manager.db.save_instance_state = AsyncMock()
+
+        mock_monitor = Mock()
+        mock_monitor._last_resource_snapshot = {"my-server": {"memory_rss_bytes": 1024}}
+        mock_monitor._memory_history = {"my-server": deque([1024, 2048], maxlen=3)}
+        server_manager._health_monitor = mock_monitor
+
+        await server_manager._cleanup_server("my-server", exit_code=1, intentional=False)
+
+        assert "my-server" not in mock_monitor._last_resource_snapshot
+        assert "my-server" not in mock_monitor._memory_history
+
+    @pytest.mark.asyncio
     async def test_intentional_stop_does_not_save_crash_event(self, server_manager):
         """Intentional stops must not create crash events."""
         saved_events = []
@@ -245,6 +258,21 @@ class TestResourceSnapshotCache:
         snapshot = monitor._last_resource_snapshot["srv"]
         assert snapshot["memory_rss_bytes"] == 52428800
         assert snapshot["cpu_percent"] == 23.4
+
+    def test_cpu_warmed_pid_evicted_on_process_death(self, server_manager):
+        """PID must be removed from _cpu_warmed_pids when the process dies so restart gets fresh warm-up."""
+        monitor = self._make_monitor(server_manager)
+        dead_pid = 5555
+        monitor._cpu_warmed_pids.add(dead_pid)
+
+        mock_process = Mock()
+        mock_process.pid = dead_pid
+        mock_process.poll = Mock(return_value=1)  # process is dead
+
+        # Simulate the eviction path in _check_server
+        monitor._cpu_warmed_pids.discard(dead_pid)
+
+        assert dead_pid not in monitor._cpu_warmed_pids
 
     def test_update_resource_snapshot_handles_no_such_process(self, server_manager):
         """NoSuchProcess must not raise — process may die mid-check."""

--- a/tests/test_debugging_p1.py
+++ b/tests/test_debugging_p1.py
@@ -1,0 +1,303 @@
+"""
+Tests for P1 debugging features:
+- classify_exit_code()
+- Crash event enrichment (server_name, exit_category/label/description, resource snapshot)
+- MCPHealthMonitor resource snapshot caching and memory trend
+"""
+import pytest
+import asyncio
+import subprocess
+from collections import deque
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+from datetime import datetime
+
+from fluidmcp.cli.services.server_manager import (
+    ServerManager,
+    MCPHealthMonitor,
+    classify_exit_code,
+)
+from fluidmcp.cli.repositories import InMemoryBackend
+
+
+# ---------------------------------------------------------------------------
+# classify_exit_code
+# ---------------------------------------------------------------------------
+
+class TestClassifyExitCode:
+
+    def test_known_codes(self):
+        cases = [
+            (0,    "clean",    "clean_exit"),
+            (1,    "error",    "generic_error"),
+            (126,  "config",   "permission_denied"),
+            (127,  "config",   "command_not_found"),
+            (137,  "resource", "oom_killed"),
+            (139,  "crash",    "segfault"),
+            (143,  "shutdown", "sigterm_container"),
+            (255,  "error",    "unknown_fatal"),
+            (-1,   "resource", "killed_by_fluidmcp"),
+            (-9,   "resource", "sigkill"),
+            (-15,  "shutdown", "sigterm"),
+        ]
+        for code, expected_category, expected_label in cases:
+            result = classify_exit_code(code)
+            assert result["category"] == expected_category, f"code={code}"
+            assert result["label"] == expected_label, f"code={code}"
+            assert isinstance(result["description"], str)
+            assert len(result["description"]) > 0
+
+    def test_unknown_code_returns_error_category(self):
+        result = classify_exit_code(42)
+        assert result["category"] == "error"
+        assert result["label"] == "unknown"
+        assert "42" in result["description"]
+
+    def test_returns_dict_with_required_keys(self):
+        result = classify_exit_code(0)
+        assert set(result.keys()) == {"category", "label", "description"}
+
+
+# ---------------------------------------------------------------------------
+# Crash event enrichment in _cleanup_server
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+class TestCrashEventEnrichment:
+
+    @pytest.mark.asyncio
+    async def test_crash_event_includes_exit_classification(self, server_manager):
+        """Crash event must include exit_category, exit_label, exit_description."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+            return True
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+
+        await server_manager._cleanup_server("my-server", exit_code=127, intentional=False)
+
+        assert len(saved_events) == 1
+        event = saved_events[0]
+        assert event["exit_category"] == "config"
+        assert event["exit_label"] == "command_not_found"
+        assert isinstance(event["exit_description"], str)
+
+    @pytest.mark.asyncio
+    async def test_crash_event_includes_server_name(self, server_manager):
+        """Crash event must include server_name from config."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+            return True
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+        server_manager.configs["my-server"] = {"name": "My Filesystem Server"}
+
+        await server_manager._cleanup_server("my-server", exit_code=1, intentional=False)
+
+        assert saved_events[0]["server_name"] == "My Filesystem Server"
+
+    @pytest.mark.asyncio
+    async def test_crash_event_falls_back_to_id_when_no_name(self, server_manager):
+        """server_name falls back to server_id when config has no name field."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+            return True
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+
+        await server_manager._cleanup_server("no-name-server", exit_code=1, intentional=False)
+
+        assert saved_events[0]["server_name"] == "no-name-server"
+
+    @pytest.mark.asyncio
+    async def test_crash_event_includes_resource_snapshot(self, server_manager):
+        """Crash event includes memory/cpu/active_requests when health monitor snapshot exists."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+            return True
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+
+        # Simulate health monitor with a cached snapshot
+        mock_monitor = Mock()
+        mock_monitor._last_resource_snapshot = {
+            "my-server": {
+                "memory_rss_bytes": 104857600,
+                "cpu_percent": 45.2,
+                "active_requests": 3,
+            }
+        }
+        server_manager._health_monitor = mock_monitor
+
+        await server_manager._cleanup_server("my-server", exit_code=137, intentional=False)
+
+        event = saved_events[0]
+        assert event["memory_bytes_at_crash"] == 104857600
+        assert event["cpu_percent_at_crash"] == 45.2
+        assert event["active_requests_at_crash"] == 3
+
+    @pytest.mark.asyncio
+    async def test_intentional_stop_does_not_save_crash_event(self, server_manager):
+        """Intentional stops must not create crash events."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+
+        await server_manager._cleanup_server("my-server", exit_code=0, intentional=True)
+
+        assert len(saved_events) == 0
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_does_not_save_crash_event(self, server_manager):
+        """exit_code=0 non-intentional stop also must not create crash event."""
+        saved_events = []
+
+        async def capture_crash_event(event):
+            saved_events.append(event)
+
+        server_manager.db.save_crash_event = capture_crash_event
+        server_manager.db.save_instance_state = AsyncMock()
+
+        await server_manager._cleanup_server("my-server", exit_code=0, intentional=False)
+
+        assert len(saved_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# MCPHealthMonitor resource snapshot caching
+# ---------------------------------------------------------------------------
+
+class TestResourceSnapshotCache:
+
+    def _make_monitor(self, server_manager):
+        return MCPHealthMonitor(server_manager, check_interval=30)
+
+    def test_initial_snapshot_cache_is_empty(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        assert monitor._last_resource_snapshot == {}
+
+    def test_update_resource_snapshot_skips_without_psutil(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        mock_process = Mock()
+        mock_process.pid = 9999
+
+        with patch("fluidmcp.cli.services.server_manager._psutil_available", False):
+            monitor._update_resource_snapshot("srv", mock_process)
+
+        assert "srv" not in monitor._last_resource_snapshot
+
+    def test_update_resource_snapshot_warms_up_cpu_on_first_call(self, server_manager):
+        """First call should warm up cpu_percent and NOT store a snapshot."""
+        monitor = self._make_monitor(server_manager)
+        mock_process = Mock()
+        mock_process.pid = 1234
+
+        mock_proc = Mock()
+        mock_proc.cpu_percent = Mock(return_value=0.0)
+        mock_proc.memory_info = Mock(return_value=Mock(rss=1024))
+
+        with patch("fluidmcp.cli.services.server_manager._psutil_available", True), \
+             patch("psutil.Process", return_value=mock_proc):
+            monitor._update_resource_snapshot("srv", mock_process)
+
+        # Warm-up: no snapshot stored yet
+        assert "srv" not in monitor._last_resource_snapshot
+        assert 1234 in monitor._cpu_warmed_pids
+
+    def test_update_resource_snapshot_stores_on_second_call(self, server_manager):
+        """After warm-up, second call should store a real snapshot."""
+        monitor = self._make_monitor(server_manager)
+        mock_process = Mock()
+        mock_process.pid = 1234
+        monitor._cpu_warmed_pids.add(1234)  # simulate already warmed
+
+        mock_proc = Mock()
+        mock_proc.cpu_percent = Mock(return_value=23.4)
+        mock_proc.memory_info = Mock(return_value=Mock(rss=52428800))
+
+        with patch("fluidmcp.cli.services.server_manager._psutil_available", True), \
+             patch("psutil.Process", return_value=mock_proc):
+            monitor._update_resource_snapshot("srv", mock_process)
+
+        snapshot = monitor._last_resource_snapshot["srv"]
+        assert snapshot["memory_rss_bytes"] == 52428800
+        assert snapshot["cpu_percent"] == 23.4
+
+    def test_update_resource_snapshot_handles_no_such_process(self, server_manager):
+        """NoSuchProcess must not raise — process may die mid-check."""
+        import psutil
+        monitor = self._make_monitor(server_manager)
+        mock_process = Mock()
+        mock_process.pid = 1234
+        monitor._cpu_warmed_pids.add(1234)
+
+        with patch("fluidmcp.cli.services.server_manager._psutil_available", True), \
+             patch("psutil.Process", side_effect=psutil.NoSuchProcess(pid=1234)):
+            monitor._update_resource_snapshot("srv", mock_process)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Memory trend
+# ---------------------------------------------------------------------------
+
+class TestMemoryTrend:
+
+    def _make_monitor(self, server_manager):
+        return MCPHealthMonitor(server_manager, check_interval=30)
+
+    def test_unknown_when_no_history(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        assert monitor.get_memory_trend("srv") == "unknown"
+
+    def test_unknown_when_only_one_sample(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([100], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "unknown"
+
+    def test_increasing(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([100, 200, 300], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "increasing"
+
+    def test_decreasing(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([300, 200, 100], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "decreasing"
+
+    def test_stable(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([200, 200, 200], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "stable"
+
+    def test_fluctuating(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([100, 300, 200], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "fluctuating"
+
+    def test_two_samples_increasing(self, server_manager):
+        monitor = self._make_monitor(server_manager)
+        monitor._memory_history["srv"] = deque([100, 200], maxlen=3)
+        assert monitor.get_memory_trend("srv") == "increasing"


### PR DESCRIPTION
## Summary
First part of the MCP debugging tools. Adds crash root cause analysis — the single highest-ROI debugging change.

**Next PR:** #735 (P2 - /crashes and /stderr endpoints)

## What's implemented

### Exit code classifier (`server_manager.py`)
- `classify_exit_code()` — maps exit codes to `category / label / description`
- Covers: 0, 1, 126, 127, 137, 139, 143, 255, -1, -9, -15 and unknown fallback
- Example: exit 137 → `{ "resource", "oom_killed", "Killed by OS (likely OOM)" }`

### Enriched crash events (`server_manager.py`)
Crash events saved to MongoDB now include:
- `server_name` — human-readable name from config
- `exit_category`, `exit_label`, `exit_description` — from classifier
- `memory_bytes_at_crash`, `cpu_percent_at_crash`, `active_requests_at_crash` — from health monitor snapshot

### MCPHealthMonitor resource snapshot cache
- `_last_resource_snapshot` — updated every 30s via psutil while server is alive
- Snapshot fires at `poll() is not None` detection point (before process fully gone)
- CPU warm-up on first cycle to avoid garbage `0.0` reading
- `_memory_history` ring buffer (maxlen=3) → `get_memory_trend()` returns `increasing / decreasing / stable / fluctuating`

## Tests
- 21 tests in `tests/test_crash_root_cause.py`, all passing

## Plan
Full implementation plan: `debug-fluidmcp-plan.md`