### PR TITLE
[MCP-554]: chore: merge Inspector Phase 3C → 5A chain into development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,12 @@
 # FMCP_BEARER_TOKEN=your-secure-token-here
 # FMCP_SECURE_MODE=true
 
+# MCP Inspector stdio transport (OPTIONAL)
+# Allows the inspector to spawn local MCP server subprocesses via stdin/stdout.
+# DISABLED by default — only enable on trusted single-user or local deployments.
+# On shared/hosted instances leave this unset to block arbitrary code execution.
+# FMCP_INSPECTOR_ALLOW_STDIO=false
+
 # MongoDB Timeouts (OPTIONAL - only tune if having connection issues)
 # FMCP_MONGODB_SERVER_TIMEOUT=30000
 # FMCP_MONGODB_CONNECT_TIMEOUT=10000

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -29,8 +29,9 @@ class AuthConfig(BaseModel):
 
 
 class ConnectRequest(BaseModel):
-    url: str
-    transport: str = "http"   # "http" | "sse" | "stdio"
+    url: Optional[str] = None        # required for http / sse
+    command: Optional[str] = None    # required for stdio
+    transport: str = "http"          # "http" | "sse" | "stdio"
     auth: Optional[AuthConfig] = None
     headers: Optional[Dict[str, str]] = None
     env_vars: Optional[Dict[str, str]] = None
@@ -105,15 +106,21 @@ async def connect_server(body: ConnectRequest):
     The session is stored in memory and expires after SESSION_TTL seconds of
     inactivity. Nothing is persisted to MongoDB.
     """
-    if not body.url:
-        raise HTTPException(400, "url is required")
+    target = body.command if body.transport == "stdio" else body.url
 
-    _validate_mcp_url(body.url)
+    if body.transport == "stdio":
+        if not body.command:
+            raise HTTPException(400, "command is required for stdio transport")
+    else:
+        if not body.url:
+            raise HTTPException(400, "url is required")
+        _validate_mcp_url(body.url)
 
     auth_dict = body.auth.model_dump() if body.auth else {}
 
     session = InspectorSession(
-        url=body.url,
+        url=body.url or "stdio://local",
+        command=body.command,
         transport=body.transport,
         auth=auth_dict,
         headers=body.headers,
@@ -126,7 +133,7 @@ async def connect_server(body: ConnectRequest):
         server_info = await session.initialize()
     except Exception as e:
         await session.close()
-        logger.warning(f"Inspector: failed to connect to {body.url} — {e}")
+        logger.warning(f"Inspector: failed to connect to {target!r} — {e}")
         raise HTTPException(502, f"Failed to connect to MCP server: {str(e)}")
 
     # Fetch tools immediately so frontend gets everything in one response
@@ -134,13 +141,13 @@ async def connect_server(body: ConnectRequest):
         tools = await session.list_tools()
     except Exception as e:
         await session.close()
-        logger.warning(f"Inspector: connected but failed to list tools for {body.url} — {e}")
+        logger.warning(f"Inspector: connected but failed to list tools for {target!r} — {e}")
         raise HTTPException(502, f"Connected but failed to fetch tools: {str(e)}")
 
     session_id = str(uuid.uuid4())
     sessions[session_id] = session
 
-    logger.info(f"Inspector: new session {session_id} for {body.url} ({body.transport}), {len(tools)} tools")
+    logger.info(f"Inspector: new session {session_id} for {target!r} ({body.transport}), {len(tools)} tools")
 
     return {
         "session_id": session_id,
@@ -241,14 +248,19 @@ async def list_resources(session_id: str):
     if not session:
         raise HTTPException(404, "Session not found or expired")
 
+    resources, templates = [], []
     try:
         resources = await session.list_resources()
-        templates = await session.list_resource_templates()
-        combined = resources + templates
-        return {"resources": combined, "count": len(combined)}
     except Exception as e:
-        logger.error(f"Inspector: list_resources failed for session {session_id} — {e}")
-        raise HTTPException(500, f"Failed to fetch resources: {str(e)}")
+        if "Method not found" not in str(e):
+            logger.warning(f"Inspector: list_resources failed for session {session_id} — {e}")
+    try:
+        templates = await session.list_resource_templates()
+    except Exception as e:
+        if "Method not found" not in str(e):
+            logger.warning(f"Inspector: list_resource_templates failed for session {session_id} — {e}")
+    combined = resources + templates
+    return {"resources": combined, "count": len(combined)}
 
 
 @router.post("/inspector/{session_id}/resources/read")
@@ -288,6 +300,8 @@ async def list_prompts(session_id: str):
         prompts = await session.list_prompts()
         return {"prompts": prompts, "count": len(prompts)}
     except Exception as e:
+        if "Method not found" in str(e):
+            return {"prompts": [], "count": 0}
         logger.error(f"Inspector: list_prompts failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to fetch prompts: {str(e)}")
 

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 import asyncio
 import time
@@ -113,6 +114,9 @@ async def connect_server(body: ConnectRequest):
     target = body.command if body.transport == "stdio" else body.url
 
     if body.transport == "stdio":
+        _val = os.getenv("FMCP_INSPECTOR_ALLOW_STDIO", "").strip().lower()
+        if _val not in ("1", "true", "yes"):
+            raise HTTPException(403, "stdio transport is disabled on this deployment")
         if not body.command:
             raise HTTPException(400, "command is required for stdio transport")
     else:

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -398,6 +398,11 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
         except Exception:
             pass
 
+        # Redact API key values echoed back in provider error messages
+        # e.g. "Incorrect API key provided: sk-abc123" or "provided: aaaaaaaaa"
+        import re as _re
+        user_message = _re.sub(r"(provided|key):\s*\S+", r"\1: [REDACTED]", user_message, flags=_re.IGNORECASE)
+
         is_auth = any(kw in err_str.lower() for kw in (
             "api key", "apikey", "invalid_api_key", "unauthorized",
             "authentication", "403", "401", "permission", "incorrect api key",

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -243,7 +243,9 @@ async def list_resources(session_id: str):
 
     try:
         resources = await session.list_resources()
-        return {"resources": resources, "count": len(resources)}
+        templates = await session.list_resource_templates()
+        combined = resources + templates
+        return {"resources": combined, "count": len(combined)}
     except Exception as e:
         logger.error(f"Inspector: list_resources failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to fetch resources: {str(e)}")
@@ -269,6 +271,39 @@ async def read_resource(session_id: str, body: ReadResourceRequest):
     except Exception as e:
         logger.error(f"Inspector: read_resource failed for session {session_id} — {e}")
         raise HTTPException(500, f"Failed to read resource: {str(e)}")
+
+
+class GetPromptRequest(BaseModel):
+    name: str
+    arguments: Optional[dict] = Field(default_factory=dict)
+
+
+@router.get("/inspector/{session_id}/prompts")
+async def list_prompts(session_id: str):
+    """List all prompts available on the connected MCP server."""
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    try:
+        prompts = await session.list_prompts()
+        return {"prompts": prompts, "count": len(prompts)}
+    except Exception as e:
+        logger.error(f"Inspector: list_prompts failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to fetch prompts: {str(e)}")
+
+
+@router.post("/inspector/{session_id}/prompts/get")
+async def get_prompt(session_id: str, body: GetPromptRequest):
+    """Get a prompt by name with optional arguments."""
+    session = sessions.get(session_id)
+    if not session:
+        raise HTTPException(404, "Session not found or expired")
+    try:
+        result = await session.get_prompt(body.name, body.arguments or {})
+        return result
+    except Exception as e:
+        logger.error(f"Inspector: get_prompt failed for session {session_id} — {e}")
+        raise HTTPException(500, f"Failed to get prompt: {str(e)}")
 
 
 @router.post("/inspector/{session_id}/chat")

--- a/fluidmcp/cli/api/inspector.py
+++ b/fluidmcp/cli/api/inspector.py
@@ -40,6 +40,10 @@ class ConnectRequest(BaseModel):
 class ChatRequest(BaseModel):
     message: str
     chat_history: Optional[list] = Field(default_factory=list)
+    provider: Optional[str] = "groq"       # "groq" | "openai" | "anthropic" | "gemini"
+    model: Optional[str] = None            # None → use provider default
+    api_key: Optional[str] = None          # None → fall back to env var
+    system_prompt: Optional[str] = None
 
 class ReadResourceRequest(BaseModel):
     uri: str
@@ -345,9 +349,15 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
                 "message": "No tools available on this server."
             }
 
-        # Call the Groq agent, passing chat history for multi-turn context
+        # Call the agent with the requested provider/model/key
         agent_result = await choose_tool_with_llm(
-            body.message, tools, chat_history=body.chat_history or []
+            body.message,
+            tools,
+            chat_history=body.chat_history or [],
+            provider=body.provider or "groq",
+            model=body.model or None,
+            api_key=body.api_key or None,
+            system_prompt=body.system_prompt or None,
         )
 
         # Validate the response has the expected fields
@@ -371,8 +381,40 @@ async def chat_with_tools(session_id: str, body: ChatRequest):
 
     except Exception as e:
         logger.error(f"Inspector chat error: {e}")
+        err_str = str(e)
+
+        # Try to extract just the human-readable message from provider error dicts
+        # e.g. "Error code: 401 - {'error': {'message': 'Incorrect API key...', ...}}"
+        user_message = err_str
+        try:
+            import re, ast
+            match = re.search(r"\{.*\}", err_str, re.DOTALL)
+            if match:
+                parsed = ast.literal_eval(match.group())
+                if isinstance(parsed, dict):
+                    inner = parsed.get("error", parsed)
+                    if isinstance(inner, dict) and "message" in inner:
+                        user_message = inner["message"]
+        except Exception:
+            pass
+
+        is_auth = any(kw in err_str.lower() for kw in (
+            "api key", "apikey", "invalid_api_key", "unauthorized",
+            "authentication", "403", "401", "permission", "incorrect api key",
+            "no api key provided", "insufficient_quota", "quota",
+        ))
+
+        if is_auth:
+            is_quota = any(kw in err_str.lower() for kw in ("quota", "insufficient_quota", "429"))
+            prefix = "Quota exceeded" if is_quota else "Authentication failed"
+            return {
+                "clarification_needed": True,
+                "message": f"{prefix}: {user_message}",
+                "error_type": "auth",
+            }
 
         return {
             "clarification_needed": True,
-            "message": "Unable to determine which tool to run."
+            "message": f"LLM error: {user_message}",
+            "error_type": "llm",
         }

--- a/fluidmcp/cli/services/inspector_agent.py
+++ b/fluidmcp/cli/services/inspector_agent.py
@@ -4,6 +4,15 @@ import asyncio
 from loguru import logger
 
 
+# Default models per provider
+PROVIDER_DEFAULTS = {
+    "groq":      {"label": "Groq",      "model": "llama-3.1-8b-instant", "base_url": "https://api.groq.com/openai/v1"},
+    "openai":    {"label": "OpenAI",    "model": "gpt-4o-mini",           "base_url": "https://api.openai.com/v1"},
+    "gemini":    {"label": "Gemini",    "model": "gemini-2.0-flash",      "base_url": "https://generativelanguage.googleapis.com/v1beta/openai/"},
+    "anthropic": {"label": "Anthropic", "model": "claude-haiku-4-5-20251001", "base_url": None},
+}
+
+
 def format_tools_for_prompt(tools):
     """
     Convert MCP tools into a readable prompt format.
@@ -38,13 +47,24 @@ Parameters:
     return "\n".join(formatted)
 
 
-async def choose_tool_with_llm(message: str, tools: list, chat_history: list | None = None):
+async def choose_tool_with_llm(
+    message: str,
+    tools: list,
+    chat_history: list | None = None,
+    provider: str = "groq",
+    model: str | None = None,
+    api_key: str | None = None,
+    system_prompt: str | None = None,
+):
     """
-    Universal MCP agent powered by Groq.
+    Universal MCP agent with multi-provider support.
 
-    Imports and initialises the Groq client lazily so the server can start
-    even when GROQ_API_KEY is absent — the error surfaces only when the chat
-    endpoint is actually called.
+    Supported providers: groq, openai, anthropic, gemini
+    - groq/openai/gemini: use the openai-compatible client
+    - anthropic: use the anthropic SDK directly
+
+    API keys are passed in from the frontend (stored in localStorage per provider).
+    Falls back to environment variables if no key is provided.
     """
 
     if chat_history is None:
@@ -53,23 +73,8 @@ async def choose_tool_with_llm(message: str, tools: list, chat_history: list | N
     if not tools:
         raise RuntimeError("No tools available")
 
-    logger.info(f"Inspector chat message: {message}")
-
-    # Lazy imports — avoids startup failure when GROQ_API_KEY is absent
-    from dotenv import load_dotenv
-    from openai import OpenAI
-
-    load_dotenv()
-
-    groq_api_key = os.getenv("GROQ_API_KEY")
-    if not groq_api_key:
-        raise RuntimeError("GROQ_API_KEY not configured")
-
-    # Build client inside the function — no module-level side effects
-    client = OpenAI(
-        api_key=groq_api_key,
-        base_url="https://api.groq.com/openai/v1"
-    )
+    provider = provider.lower()
+    logger.info(f"Inspector chat — provider={provider}, message={message!r}")
 
     tool_description = format_tools_for_prompt(tools)
 
@@ -87,24 +92,7 @@ Instructions:
 Return ONLY JSON.
 """
 
-    try:
-        # The OpenAI client is synchronous — run in a thread to avoid blocking
-        # the event loop.
-        # Build prior turns from chat_history for multi-turn context
-        history_messages = [
-            {"role": "user" if m.get("type") == "user" else "assistant",
-             "content": str(m.get("content", ""))}
-            for m in chat_history
-            if m.get("type") in ("user", "assistant") and m.get("content")
-        ]
-
-        def _call_llm():
-            return client.chat.completions.create(
-                model="llama-3.1-8b-instant",
-                messages=[
-                    {
-                        "role": "system",
-                        "content": """
+    sys_content = system_prompt.strip() if system_prompt and system_prompt.strip() else """
 You are a strict JSON API for MCP tool selection.
 
 You MUST return ONLY valid JSON.
@@ -121,51 +109,158 @@ Rules:
 - No extra text
 - Always return JSON
 """
-                    },
-                    *history_messages,
-                    {
-                        "role": "user",
-                        "content": prompt
-                    }
-                ],
-                temperature=0,
-                max_tokens=200
-            )
 
-        response = await asyncio.to_thread(_call_llm)
+    history_messages = [
+        {"role": "user" if m.get("type") == "user" else "assistant",
+         "content": str(m.get("content", ""))}
+        for m in chat_history
+        if m.get("type") in ("user", "assistant") and m.get("content")
+    ]
 
-        content = response.choices[0].message.content.strip()
+    if provider == "anthropic":
+        return await _call_anthropic(
+            message=prompt,
+            sys_content=sys_content,
+            history_messages=history_messages,
+            model=model,
+            api_key=api_key,
+        )
+    else:
+        return await _call_openai_compatible(
+            message=prompt,
+            sys_content=sys_content,
+            history_messages=history_messages,
+            provider=provider,
+            model=model,
+            api_key=api_key,
+        )
 
-        logger.info(f"LLM raw response: {repr(content)}")
 
-        # First attempt: direct parse
-        try:
-            result = json.loads(content)
-            logger.info(f"LLM parsed result (direct): {result}")
-            return result
+async def _call_openai_compatible(
+    message: str,
+    sys_content: str,
+    history_messages: list,
+    provider: str,
+    model: str | None,
+    api_key: str | None,
+):
+    """Call Groq, OpenAI, or Gemini via the OpenAI-compatible client."""
+    from openai import OpenAI
+    from dotenv import load_dotenv
 
-        except json.JSONDecodeError:
-            logger.warning("Direct JSON parse failed, attempting extraction...")
+    load_dotenv()
 
-            # Fallback: extract JSON block
-            start = content.find("{")
-            end = content.rfind("}") + 1
+    defaults = PROVIDER_DEFAULTS.get(provider)
+    if not defaults:
+        raise RuntimeError(f"Unknown provider: {provider!r}")
 
-            if start == -1 or end == 0:
-                raise ValueError(f"No JSON found in LLM response: {content}")
+    resolved_model = model or defaults["model"]
+    base_url = defaults["base_url"]
 
-            json_str = content[start:end]
+    # Key resolution: explicit > env var
+    env_key_names = {
+        "groq":   "GROQ_API_KEY",
+        "openai": "OPENAI_API_KEY",
+        "gemini": "GEMINI_API_KEY",
+    }
+    resolved_key = api_key or os.getenv(env_key_names.get(provider, ""), "")
+    if not resolved_key:
+        raise RuntimeError(
+            f"No API key provided for {defaults['label']}. "
+            "Please add your API key in the LLM settings."
+        )
 
-            try:
-                result = json.loads(json_str)
-                logger.info(f"LLM parsed result (extracted): {result}")
-                return result
+    # Gemini's OpenAI-compatible endpoint requires the key as a query param.
+    # Use default_query so the OpenAI client appends ?key=... to every request
+    # without corrupting the path (appending to base_url breaks path construction).
+    if provider == "gemini":
+        client = OpenAI(api_key="not-used", base_url=base_url, default_query={"key": resolved_key})
+    else:
+        client = OpenAI(api_key=resolved_key, base_url=base_url)
 
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to parse extracted JSON.\nRaw response: {content}\nExtracted: {json_str}"
-                ) from e
+    def _call():
+        return client.chat.completions.create(
+            model=resolved_model,
+            messages=[
+                {"role": "system", "content": sys_content},
+                *history_messages,
+                {"role": "user", "content": message},
+            ],
+            temperature=0,
+            max_tokens=200,
+        )
 
+    response = await asyncio.to_thread(_call)
+    content = response.choices[0].message.content.strip()
+    logger.info(f"[{provider}] raw response: {repr(content)}")
+    return _parse_json_response(content)
+
+
+async def _call_anthropic(
+    message: str,
+    sys_content: str,
+    history_messages: list,
+    model: str | None,
+    api_key: str | None,
+):
+    """Call Anthropic Claude via the anthropic SDK."""
+    from anthropic import Anthropic
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    resolved_model = model or "claude-haiku-4-5-20251001"
+    resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY", "")
+    if not resolved_key:
+        raise RuntimeError(
+            "No API key provided for Anthropic. "
+            "Please add your API key in the LLM settings."
+        )
+
+    client = Anthropic(api_key=resolved_key)
+
+    # Anthropic uses system param separately; convert history
+    anthropic_messages = []
+    for m in history_messages:
+        anthropic_messages.append({"role": m["role"], "content": m["content"]})
+    anthropic_messages.append({"role": "user", "content": message})
+
+    def _call():
+        return client.messages.create(
+            model=resolved_model,
+            system=sys_content,
+            messages=anthropic_messages,
+            temperature=0,
+            max_tokens=200,
+        )
+
+    response = await asyncio.to_thread(_call)
+    content = response.content[0].text.strip()
+    logger.info(f"[anthropic] raw response: {repr(content)}")
+    return _parse_json_response(content)
+
+
+def _parse_json_response(content: str) -> dict:
+    """Parse JSON from LLM response, with fallback extraction."""
+    try:
+        result = json.loads(content)
+        logger.info(f"LLM parsed result (direct): {result}")
+        return result
+    except json.JSONDecodeError:
+        logger.warning("Direct JSON parse failed, attempting extraction...")
+
+    start = content.find("{")
+    end = content.rfind("}") + 1
+
+    if start == -1 or end == 0:
+        raise ValueError(f"No JSON found in LLM response: {content}")
+
+    json_str = content[start:end]
+    try:
+        result = json.loads(json_str)
+        logger.info(f"LLM parsed result (extracted): {result}")
+        return result
     except Exception as e:
-        logger.error(f"Groq agent error: {e}")
-        raise
+        raise ValueError(
+            f"Failed to parse extracted JSON.\nRaw: {content}\nExtracted: {json_str}"
+        ) from e

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -1,5 +1,6 @@
 import time
 import json
+import shlex
 import asyncio
 import ipaddress
 from datetime import datetime, timezone
@@ -36,16 +37,20 @@ class InspectorSession:
     """
     Manages a temporary connection to an external MCP server for the inspector.
 
-    HTTP transport: raw JSON-RPC POST, response comes back in the same HTTP response.
-    SSE transport:  persistent GET /sse connection (background task) receives all
-                    responses; requests are sent via POST to the messages endpoint.
-                    This matches the MCP SSE spec — the stream must stay open.
+    HTTP transport:  raw JSON-RPC POST, response comes back in the same HTTP response.
+    SSE transport:   persistent GET /sse connection (background task) receives all
+                     responses; requests are sent via POST to the messages endpoint.
+                     This matches the MCP SSE spec — the stream must stay open.
+    stdio transport: spawns the MCP server as a child subprocess and communicates
+                     over stdin/stdout pipes (JSON-RPC, newline-delimited).
+                     The server only exists while this session is open.
     """
 
     def __init__(
         self,
         url: str,
         transport: str,
+        command: Optional[str] = None,
         auth: Optional[Dict[str, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
         env_vars: Optional[Dict[str, str]] = None,
@@ -53,6 +58,7 @@ class InspectorSession:
     ):
         self.url = url.rstrip("/")
         self.transport = transport.lower()
+        self.command = command  # shell command string for stdio transport
         self.auth = auth or {}
         self.extra_headers = headers or {}
         self.env_vars = env_vars or {}
@@ -70,6 +76,9 @@ class InspectorSession:
         self._sse_ready = asyncio.Event()      # set once endpoint URL is known
         self._sse_pending: Dict[int, "asyncio.Future[dict]"] = {}  # id → Future
         self._sse_task: Optional[asyncio.Task] = None
+
+        # stdio state
+        self._process: Optional[asyncio.subprocess.Process] = None
 
         # Shared httpx client for HTTP/POST requests
         self._client: Optional[httpx.AsyncClient] = None
@@ -226,13 +235,153 @@ class InspectorSession:
                 future.cancel()
             raise
 
+    # ── stdio transport ───────────────────────────────────────────────────────
+
+    async def _start_stdio_process(self) -> Dict[str, Any]:
+        """
+        Spawn the MCP server subprocess and run the MCP initialize handshake.
+        Returns server info dict (name, version, protocol_version).
+
+        Ported from package_launcher.initialize_mcp_server() but fully async:
+        uses asyncio.create_subprocess_exec + await readline instead of
+        blocking subprocess.Popen + asyncio.to_thread.
+        """
+        if not self.command:
+            raise Exception("stdio transport requires a command")
+
+        parts = shlex.split(self.command)
+
+        # Merge env_vars on top of the current process environment
+        import os
+        proc_env = {**os.environ, **self.env_vars} if self.env_vars else None
+
+        if self.env_vars:
+            logger.info(f"Inspector stdio: spawning {parts[0]!r} with env vars: {list(self.env_vars.keys())}")
+        else:
+            logger.info(f"Inspector stdio: spawning {parts[0]!r}")
+
+        self._process = await asyncio.create_subprocess_exec(
+            *parts,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=proc_env,
+        )
+
+        # MCP initialize handshake
+        init_request = {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {
+                    "extensions": {
+                        "io.modelcontextprotocol/ui": {
+                            "mimeTypes": ["text/html+mcp", "text/html;profile=mcp-app"]
+                        }
+                    }
+                },
+                "clientInfo": {"name": "FluidMCP Inspector", "version": "1.0.0"},
+            },
+        }
+
+        self._process.stdin.write((json.dumps(init_request) + "\n").encode())
+        await self._process.stdin.drain()
+
+        # Read lines until we get the initialize response (skip non-JSON stdout noise)
+        deadline = asyncio.get_event_loop().time() + 30.0
+        while asyncio.get_event_loop().time() < deadline:
+            if self._process.returncode is not None:
+                stderr_bytes = await self._process.stderr.read(4096)
+                raise Exception(
+                    f"stdio process died during handshake (exit {self._process.returncode}): "
+                    f"{stderr_bytes.decode(errors='replace').strip()}"
+                )
+            try:
+                raw = await asyncio.wait_for(self._process.stdout.readline(), timeout=2.0)
+            except asyncio.TimeoutError:
+                continue
+
+            if not raw:
+                raise Exception("stdio process closed stdout during handshake")
+
+            line = raw.decode(errors="replace").strip()
+            if not line:
+                continue
+
+            try:
+                msg = json.loads(line)
+            except json.JSONDecodeError:
+                logger.debug(f"Inspector stdio: skipping non-JSON line: {line[:200]}")
+                continue
+
+            if msg.get("id") == 0 and "result" in msg:
+                # Send notifications/initialized to complete the handshake
+                notif = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+                self._process.stdin.write((json.dumps(notif) + "\n").encode())
+                await self._process.stdin.drain()
+                logger.info("Inspector stdio: handshake complete")
+                result = msg.get("result", {})
+                server_info = result.get("serverInfo", {})
+                return {
+                    "name": server_info.get("name", "Unknown MCP Server"),
+                    "version": server_info.get("version", "unknown"),
+                    "protocol_version": result.get("protocolVersion", "unknown"),
+                }
+
+        raise Exception("stdio process did not respond to initialize within 30s")
+
+    async def _stdio_send(self, request: dict) -> dict:
+        """
+        Write one JSON-RPC request to the subprocess stdin, read the matching
+        response from stdout. Skips non-JSON lines (log output from the server).
+        """
+        if not self._process or self._process.returncode is not None:
+            raise Exception("stdio process is not running")
+
+        line = (json.dumps(request) + "\n").encode()
+        self._process.stdin.write(line)
+        await self._process.stdin.drain()
+
+        req_id = request.get("id")
+        deadline = asyncio.get_event_loop().time() + self.timeout
+
+        while asyncio.get_event_loop().time() < deadline:
+            if self._process.returncode is not None:
+                raise Exception("stdio process died while waiting for response")
+            try:
+                raw = await asyncio.wait_for(self._process.stdout.readline(), timeout=2.0)
+            except asyncio.TimeoutError:
+                continue
+
+            if not raw:
+                raise Exception("stdio process closed stdout unexpectedly")
+
+            decoded = raw.decode(errors="replace").strip()
+            if not decoded:
+                continue
+
+            try:
+                msg = json.loads(decoded)
+            except json.JSONDecodeError:
+                logger.debug(f"Inspector stdio: skipping non-JSON line: {decoded[:200]}")
+                continue
+
+            if msg.get("id") == req_id:
+                return msg
+
+        raise Exception(f"stdio: no response for request id={req_id} within {self.timeout}s")
+
     # ── Transport dispatcher ──────────────────────────────────────────────────
 
     def _make_request(self, method: str, params: dict) -> dict:
         return {"jsonrpc": "2.0", "id": self._next_id(), "method": method, "params": params}
 
     async def _send(self, request: dict) -> dict:
-        """Route request through SSE or plain HTTP depending on transport."""
+        """Route request through stdio, SSE, or plain HTTP depending on transport."""
+        if self.transport == "stdio":
+            return await self._stdio_send(request)
         if self.transport == "sse":
             return await self._sse_request(request)
 
@@ -245,6 +394,14 @@ class InspectorSession:
 
     async def initialize(self) -> Dict[str, Any]:
         self.last_used = time.time()
+
+        if self.transport == "stdio":
+            # Spawn subprocess and run the full MCP handshake.
+            # _start_stdio_process() sends initialize + notifications/initialized
+            # and stores the initialize result so we can return server info here.
+            info = await self._start_stdio_process()
+            self.add_log("connect", f"Connected to {info['name']} (STDIO)")
+            return info
 
         if self.transport == "sse":
             # Kick off the background SSE listener before sending any requests
@@ -349,6 +506,15 @@ class InspectorSession:
 
     async def close(self) -> None:
         self.add_log("disconnect", "Session closed")
+        if self._process is not None:
+            try:
+                self._process.terminate()
+                await asyncio.wait_for(self._process.wait(), timeout=3.0)
+            except asyncio.TimeoutError:
+                self._process.kill()
+            except Exception:
+                pass
+            self._process = None
         if self._sse_task:
             self._sse_task.cancel()
             try:

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -1,14 +1,17 @@
 import os
+import re
 import time
 import json
 import shlex
 import asyncio
 import ipaddress
+from pathlib import Path
 from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 from urllib.parse import urlparse
 import httpx
 from loguru import logger
+from fastapi import HTTPException
 
 
 def _validate_url(url: str) -> None:
@@ -32,6 +35,72 @@ def _validate_url(url: str) -> None:
 
     if addr.is_private or addr.is_loopback or addr.is_link_local or addr.is_reserved:
         raise ValueError("Connections to private/internal addresses are not allowed")
+
+
+# ── Per-binary argument schemas ───────────────────────────────────────────────
+# Each entry defines which flags are permitted and whether non-flag args are
+# package names or local file paths. Anything not in allowed_flags is rejected.
+# URL arguments (http://, https://) are always blocked — remote fetch is not a
+# supported MCP use case and would allow deno/bun to pull attacker-controlled code.
+
+_BINARY_SCHEMAS = {
+    "npx":     {"allowed_flags": {"-y", "--yes", "--package"}, "arg_type": "package"},
+    "uvx":     {"allowed_flags": {"--from", "--with"},         "arg_type": "package"},
+    "node":    {"allowed_flags": set(),                        "arg_type": "filepath"},
+    "python":  {"allowed_flags": set(),                        "arg_type": "filepath"},
+    "python3": {"allowed_flags": set(),                        "arg_type": "filepath"},
+    "deno":    {"allowed_flags": {"run"},                      "arg_type": "filepath"},
+    "bun":     {"allowed_flags": set(),                        "arg_type": "filepath"},
+}
+
+_PACKAGE_RE = re.compile(r'^[@a-zA-Z0-9][\w.\-/]*$')
+
+_ALLOWED_ROOTS = [Path("/home"), Path("/app"), Path("/workspace"), Path("/workspaces"), Path("/tmp")]
+
+
+def _validate_stdio_args(binary: str, parts: list) -> None:
+    """Validate flags and non-flag arguments for a stdio command against its per-binary schema.
+
+    For package-type binaries (npx, uvx), validation stops once the package name is
+    consumed — remaining args are passthrough to the MCP server package and are not
+    interpreted by node/python, so interpreter flag injection is not possible there.
+    """
+    schema = _BINARY_SCHEMAS[binary]
+    package_consumed = False  # only relevant for arg_type == "package"
+
+    for arg in parts[1:]:
+        # Block remote URLs unconditionally — remote fetch via deno/bun is not a
+        # supported MCP use case and would allow execution of attacker-controlled code.
+        if arg.startswith("http://") or arg.startswith("https://"):
+            raise HTTPException(400, "Remote URLs are not permitted as arguments")
+
+        # Once the package name has been seen for npx/uvx, remaining args are
+        # passthrough to the MCP server package — stop validating them.
+        if schema["arg_type"] == "package" and package_consumed:
+            continue
+
+        if arg.startswith("-") or arg in schema["allowed_flags"]:
+            # Flag or subcommand (e.g. deno's "run")
+            if arg not in schema["allowed_flags"]:
+                raise HTTPException(400, f"Flag '{arg}' is not permitted for '{binary}'")
+        elif schema["arg_type"] == "filepath":
+            _validate_stdio_filepath(arg)
+        else:
+            # Package name — validate then mark as consumed
+            if not _PACKAGE_RE.match(arg):
+                raise HTTPException(400, f"Invalid package name: '{arg}'")
+            package_consumed = True
+
+
+def _validate_stdio_filepath(path_str: str) -> None:
+    """Resolve path and ensure it stays within an allowed root directory."""
+    try:
+        resolved = Path(path_str).resolve()
+    except Exception:
+        raise HTTPException(400, f"Invalid path: '{path_str}'")
+
+    if not any(str(resolved).startswith(str(root)) for root in _ALLOWED_ROOTS):
+        raise HTTPException(400, f"Path '{path_str}' is outside allowed directories")
 
 
 class InspectorSession:
@@ -255,13 +324,19 @@ class InspectorSession:
         # ── Command allowlist ─────────────────────────────────────────────────
         # Only permit known MCP server launchers. Check basename so full paths
         # like /usr/local/bin/npx still pass.
-        _ALLOWED_EXECUTABLES = {"npx", "uvx", "node", "python", "python3", "deno", "bun"}
         exe_basename = os.path.basename(parts[0])
-        if exe_basename not in _ALLOWED_EXECUTABLES:
-            raise Exception(
+        if exe_basename not in _BINARY_SCHEMAS:
+            raise HTTPException(
+                400,
                 f"Command '{exe_basename}' is not allowed. "
-                f"Permitted launchers: {', '.join(sorted(_ALLOWED_EXECUTABLES))}"
+                f"Permitted launchers: {', '.join(sorted(_BINARY_SCHEMAS))}"
             )
+
+        # ── Argument validation ───────────────────────────────────────────────
+        # Per-binary schema: validates flags against a per-interpreter allowlist
+        # and checks non-flag args as either safe package names or local file
+        # paths within allowed roots. Blocks -c/-e/--eval and remote URLs.
+        _validate_stdio_args(exe_basename, parts)
 
         # ── Subprocess environment ────────────────────────────────────────────
         # Build a minimal safe env from a fixed allowlist of system variables

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -309,7 +309,36 @@ class InspectorSession:
         data = await self._send(self._make_request("resources/list", {}))
         if "error" in data:
             raise Exception(f"resources/list error: {data['error'].get('message', 'Unknown error')}")
-        return data.get("result", {}).get("resources", [])
+        resources = data.get("result", {}).get("resources", [])
+        for r in resources:
+            r["isTemplate"] = False
+        return resources
+
+    async def list_resource_templates(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("resources/templates/list", {}))
+        if "error" in data:
+            return []  # not all servers implement templates — silently skip
+        templates = data.get("result", {}).get("resourceTemplates", [])
+        # Normalise: rename uriTemplate → uri so the frontend uses one field
+        for t in templates:
+            t["uri"] = t.pop("uriTemplate", t.get("uri", ""))
+            t["isTemplate"] = True
+        return templates
+
+    async def list_prompts(self) -> list:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("prompts/list", {}))
+        if "error" in data:
+            raise Exception(f"prompts/list error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {}).get("prompts", [])
+
+    async def get_prompt(self, name: str, arguments: dict) -> dict:
+        self.last_used = time.time()
+        data = await self._send(self._make_request("prompts/get", {"name": name, "arguments": arguments}))
+        if "error" in data:
+            raise Exception(f"prompts/get error: {data['error'].get('message', 'Unknown error')}")
+        return data.get("result", {})
 
     async def read_resource(self, uri: str) -> dict:
         self.last_used = time.time()

--- a/fluidmcp/cli/services/inspector_session.py
+++ b/fluidmcp/cli/services/inspector_session.py
@@ -1,3 +1,4 @@
+import os
 import time
 import json
 import shlex
@@ -251,14 +252,42 @@ class InspectorSession:
 
         parts = shlex.split(self.command)
 
-        # Merge env_vars on top of the current process environment
-        import os
-        proc_env = {**os.environ, **self.env_vars} if self.env_vars else None
+        # ── Command allowlist ─────────────────────────────────────────────────
+        # Only permit known MCP server launchers. Check basename so full paths
+        # like /usr/local/bin/npx still pass.
+        _ALLOWED_EXECUTABLES = {"npx", "uvx", "node", "python", "python3", "deno", "bun"}
+        exe_basename = os.path.basename(parts[0])
+        if exe_basename not in _ALLOWED_EXECUTABLES:
+            raise Exception(
+                f"Command '{exe_basename}' is not allowed. "
+                f"Permitted launchers: {', '.join(sorted(_ALLOWED_EXECUTABLES))}"
+            )
+
+        # ── Subprocess environment ────────────────────────────────────────────
+        # Build a minimal safe env from a fixed allowlist of system variables
+        # so FluidMCP's own secrets (BEARER_TOKEN, MONGODB_URI, API_KEY,
+        # etc.) are never visible to the spawned process. User-supplied env_vars
+        # are layered on top — they can only add/override within this safe base.
+        _SYSTEM_ENV_ALLOWLIST = {
+            "PATH", "HOME", "USER", "TMPDIR", "TEMP", "TMP",
+            "LANG", "LC_ALL", "LC_CTYPE",
+            "NODE_PATH", "NPM_CONFIG_CACHE", "NPM_CONFIG_PREFIX",
+            "PYTHONPATH", "VIRTUAL_ENV",
+            "DENO_DIR", "BUN_INSTALL",
+            "XDG_CACHE_HOME", "XDG_CONFIG_HOME",
+        }
+        proc_env = {
+            k: v for k, v in os.environ.items()
+            if k in _SYSTEM_ENV_ALLOWLIST
+        }
+        # Layer user-supplied vars on top (they cannot see what's not in base)
+        if self.env_vars:
+            proc_env.update(self.env_vars)
 
         if self.env_vars:
-            logger.info(f"Inspector stdio: spawning {parts[0]!r} with env vars: {list(self.env_vars.keys())}")
+            logger.info(f"Inspector stdio: spawning {exe_basename!r} with env vars: {list(self.env_vars.keys())}")
         else:
-            logger.info(f"Inspector stdio: spawning {parts[0]!r}")
+            logger.info(f"Inspector stdio: spawning {exe_basename!r}")
 
         self._process = await asyncio.create_subprocess_exec(
             *parts,

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -13,6 +13,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
   const [height, setHeight] = useState(400);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMsg, setErrorMsg] = useState('');
+  const [isFullscreen, setIsFullscreen] = useState(false);
   // Tracks pending requests WE sent to the widget (id → resolve/reject)
   const pendingRef = useRef<Map<number, { resolve: (v: any) => void; reject: (e: any) => void }>>(new Map());
   // Fallback timeout: if widget doesn't complete MCP handshake, auto-clear loading state
@@ -52,7 +53,9 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
       if (method === 'ui/notifications/sandbox-proxy-ready') {
         try {
           const res = await apiClient.readInspectorResource(sessionId, resourceUri);
-          const html: string = res?.text || res?.content || '';
+          // MCP spec: resources/read returns {contents: [{uri, mimeType, text}]}
+          const firstContent = res?.contents?.[0];
+          const html: string = firstContent?.text || firstContent?.content || res?.text || res?.content || '';
           if (!html) {
             setStatus('error');
             setErrorMsg('Widget resource returned empty HTML');
@@ -169,39 +172,77 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
     };
   }, [sessionId, resourceUri, toolInput, toolResult]);
 
-  if (status === 'error') {
-    return (
-      <div style={{
-        marginTop: '0.5rem', padding: '0.5rem 0.75rem',
-        fontSize: '0.75rem', color: '#fca5a5',
-        background: 'rgba(239,68,68,0.1)',
-        border: '1px solid rgba(239,68,68,0.3)',
-        borderRadius: '6px',
-      }}>
-        Widget error: {errorMsg}
-      </div>
-    );
-  }
-
+  // Single stable DOM tree — never changes depth regardless of fullscreen state.
+  // This prevents React from remounting the iframe (which would wipe the loaded widget).
   return (
-    <div style={{ background: '#fff', position: 'relative', overflow: 'hidden' }}>
-      {status === 'loading' && (
+    <div style={isFullscreen ? {
+      position: 'fixed', inset: 0, zIndex: 9999,
+      display: 'flex', flexDirection: 'column',
+      background: 'rgba(0,0,0,0.92)',
+    } : {}}>
+      {/* Header — always at depth 1 */}
+      <div style={{
+        padding: '0.4rem 0.75rem',
+        borderBottom: '1px solid rgba(99,102,241,0.15)',
+        fontSize: '0.72rem', fontWeight: 600,
+        color: 'rgba(99,102,241,0.8)',
+        display: 'flex', alignItems: 'center', gap: '0.4rem',
+        background: isFullscreen ? '#0f0f13' : 'rgba(99,102,241,0.06)',
+        flexShrink: 0,
+      }}>
+        <span>⬡</span>
+        <span style={{ flex: 1 }}>Widget</span>
+        <button
+          onClick={() => setIsFullscreen(f => !f)}
+          title={isFullscreen ? 'Exit fullscreen' : 'Expand widget'}
+          style={{
+            background: 'none', border: 'none', cursor: 'pointer',
+            color: 'rgba(99,102,241,0.7)', padding: '0 2px',
+            fontSize: '0.85rem', lineHeight: 1, display: 'flex', alignItems: 'center',
+          }}
+        >
+          {isFullscreen ? '✕' : '⤢'}
+        </button>
+      </div>
+
+      {/* Error state — replaces iframe area, but wrapper stays stable */}
+      {status === 'error' ? (
         <div style={{
-          position: 'absolute', inset: 0,
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          background: 'rgba(9,9,11,0.7)', fontSize: '0.75rem',
-          color: 'rgba(255,255,255,0.5)', zIndex: 1,
+          padding: '0.5rem 0.75rem',
+          fontSize: '0.75rem', color: '#fca5a5',
+          background: 'rgba(239,68,68,0.1)',
         }}>
-          Loading widget...
+          Widget error: {errorMsg}
+        </div>
+      ) : (
+        /* iframe container — always at depth 1, styles adjust for fullscreen */
+        <div style={{
+          background: '#fff', position: 'relative', overflow: 'hidden',
+          ...(isFullscreen ? { flex: 1 } : {}),
+        }}>
+          {status === 'loading' && (
+            <div style={{
+              position: 'absolute', inset: 0,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              background: 'rgba(9,9,11,0.7)', fontSize: '0.75rem',
+              color: 'rgba(255,255,255,0.5)', zIndex: 1,
+            }}>
+              Loading widget...
+            </div>
+          )}
+          <iframe
+            ref={iframeRef}
+            src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
+            sandbox="allow-scripts allow-same-origin allow-forms"
+            title="MCP Widget"
+            style={{
+              width: '100%',
+              height: isFullscreen ? '100%' : `${height}px`,
+              border: 'none', display: 'block', transition: 'height 0.15s ease',
+            }}
+          />
         </div>
       )}
-      <iframe
-        ref={iframeRef}
-        src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
-        sandbox="allow-scripts allow-same-origin allow-forms"
-        title="MCP Widget"
-        style={{ width: '100%', height: `${height}px`, border: 'none', display: 'block', transition: 'height 0.15s ease' }}
-      />
     </div>
   );
 }

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -233,7 +233,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
           <iframe
             ref={iframeRef}
             src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
-            sandbox="allow-scripts allow-same-origin allow-forms"
+            sandbox="allow-scripts allow-forms"
             title="MCP Widget"
             style={{
               width: '100%',

--- a/fluidmcp/frontend/src/components/WidgetSandbox.tsx
+++ b/fluidmcp/frontend/src/components/WidgetSandbox.tsx
@@ -10,7 +10,7 @@ interface WidgetSandboxProps {
 
 export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }: WidgetSandboxProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState(300);
+  const [height, setHeight] = useState(400);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMsg, setErrorMsg] = useState('');
   // Tracks pending requests WE sent to the widget (id → resolve/reject)
@@ -140,7 +140,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
       if (method === 'ui/notifications/size-change') {
         const { height: h } = msg.params || {};
         if (typeof h === 'number' && h > 0) {
-          setHeight(Math.min(h + 20, 800));
+          setHeight(Math.min(h + 40, 1600));
         }
         return;
       }
@@ -184,14 +184,7 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
   }
 
   return (
-    <div style={{
-      marginTop: '0.6rem',
-      borderRadius: '8px',
-      overflow: 'hidden',
-      border: '1px solid rgba(99,102,241,0.35)',
-      background: '#fff',
-      position: 'relative',
-    }}>
+    <div style={{ background: '#fff', position: 'relative', overflow: 'hidden' }}>
       {status === 'loading' && (
         <div style={{
           position: 'absolute', inset: 0,
@@ -205,15 +198,9 @@ export function WidgetSandbox({ sessionId, resourceUri, toolInput, toolResult }:
       <iframe
         ref={iframeRef}
         src={`${import.meta.env.BASE_URL}sandbox-proxy.html`}
-        sandbox="allow-scripts allow-forms"
+        sandbox="allow-scripts allow-same-origin allow-forms"
         title="MCP Widget"
-        style={{
-          width: '100%',
-          height: `${height}px`,
-          border: 'none',
-          display: 'block',
-          transition: 'height 0.15s ease',
-        }}
+        style={{ width: '100%', height: `${height}px`, border: 'none', display: 'block', transition: 'height 0.15s ease' }}
       />
     </div>
   );

--- a/fluidmcp/frontend/src/components/result/ToolResult.tsx
+++ b/fluidmcp/frontend/src/components/result/ToolResult.tsx
@@ -274,8 +274,6 @@ export const ToolResult: React.FC<ToolResultProps> = ({
           border: '1px solid rgba(63, 63, 70, 0.5)',
           borderRadius: '0.5rem',
           padding: '1.5rem',
-          maxHeight: '70vh',
-          overflow: 'auto'
         }}>
           {viewMode === 'raw' ? (
             <pre style={{ 

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,17 +1,28 @@
-// import React from "react";
-import { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 // Compact collapsible result bubble for chat mode
-function ChatResultBubble({ result }: { result: unknown }) {
+function ChatResultBubble({ result, initialView = "formatted", hideTabSwitcher = false }: { result: unknown; initialView?: "formatted" | "raw"; hideTabSwitcher?: boolean }) {
   const [expanded, setExpanded] = useState(true);
-  const [viewMode, setViewMode] = useState<"formatted" | "raw">("formatted");
+  const [viewMode, setViewMode] = useState<"formatted" | "raw">(initialView);
+  useEffect(() => { setViewMode(initialView); }, [initialView]);
   const isMcp = typeof result === "object" && result !== null &&
     "content" in result && Array.isArray((result as any).content);
   const isMcpArray = Array.isArray(result) && result.length > 0 &&
     (result as any[]).every((i: any) => typeof i === "object" && i !== null && "type" in i);
-  const preview = typeof result === "object" && result !== null
-    ? `{${Object.keys(result as object).length} keys}`
-    : String(result).slice(0, 60);
+  const preview = (() => {
+    if (isMcp) {
+      const texts = ((result as any).content || []).filter((c: any) => c.type === "text" && c.text);
+      if (texts.length > 0) return String(texts[0].text).slice(0, 80);
+      return `[${(result as any).content?.length || 0} items]`;
+    }
+    if (isMcpArray) {
+      const texts = (result as any[]).filter((c: any) => c.type === "text" && c.text);
+      if (texts.length > 0) return String(texts[0].text).slice(0, 80);
+      return `[${(result as any[]).length} items]`;
+    }
+    if (typeof result === "object" && result !== null) return `{${Object.keys(result as object).length} keys}`;
+    return String(result).slice(0, 60);
+  })();
 
   const tabStyle = (active: boolean) => ({
     padding: "0.2rem 0.5rem", borderRadius: "0.25rem", border: "none",
@@ -33,7 +44,7 @@ function ChatResultBubble({ result }: { result: unknown }) {
         >
           {expanded ? "▼" : "▶"} Result:{!expanded && <span style={{ color: "rgba(255,255,255,0.6)", fontWeight: 400, marginLeft: "0.3rem" }}>{preview}</span>}
         </button>
-        {expanded && (
+        {expanded && !hideTabSwitcher && (
           <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
             <div style={{ display: "flex", background: "rgba(0,0,0,0.3)", borderRadius: "0.25rem", padding: "0.15rem", gap: "0.15rem" }}>
               <button style={tabStyle(viewMode === "formatted")} onClick={() => setViewMode("formatted")}>Formatted</button>
@@ -51,16 +62,17 @@ function ChatResultBubble({ result }: { result: unknown }) {
       </div>
       {expanded && (
         <div style={{
-          maxHeight: "260px", overflowY: "auto", overflowX: "hidden",
           background: "rgba(0,0,0,0.3)",
           border: "1px solid rgba(63,63,70,0.5)",
           borderRadius: "0.5rem",
           padding: "0.75rem",
           marginTop: "0.25rem",
           width: "100%", boxSizing: "border-box",
+          maxHeight: "350px",
+          overflowY: "auto",
         }}>
           {viewMode === "raw"
-            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-all", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
+            ? <pre style={{ margin: 0, fontSize: "0.75rem", color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word", fontFamily: "ui-monospace, monospace", width: "100%", boxSizing: "border-box" as const }}>{JSON.stringify(result, null, 2)}</pre>
             : <div style={{ minWidth: 0, width: "100%", overflow: "hidden" }}>
                 {(isMcp || isMcpArray)
                   ? <McpContentView content={isMcpArray ? result as any : (result as any).content} />
@@ -112,7 +124,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
 }
 
 // ── Timeline block for one agent turn (thinking → tool_call → tool_result) ───
-function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; run?: ExecutionRun; sessionId?: string }) {
+function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: ExecutionRun }) {
   const [collapsed, setCollapsed] = useState(false);
   const thinking  = steps.find(s => s.type === "thinking");
   const toolCall  = steps.find(s => s.type === "tool_call");
@@ -131,7 +143,7 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
   );
 
   return (
-    <div style={{ maxWidth: "90%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px", overflow: "hidden" }}>
+    <div style={{ width: "100%", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "10px" }}>
       {/* Header */}
       <div
         onClick={() => setCollapsed(v => !v)}
@@ -209,21 +221,15 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
             <div style={{ display: "flex", gap: "0.6rem" }}>
               {dot("#22c55e")}
               <div style={{ flex: 1 }}>
+                {/* Result label */}
                 <div style={{ fontSize: "0.72rem", color: "#4ade80", fontWeight: 600, display: "flex", gap: "0.4rem", alignItems: "center" }}>
                   Result
                   {toolMs !== null && <span style={{ fontWeight: 400, opacity: 0.65 }}>{toolMs}ms</span>}
                 </div>
+                {/* Result bubble — always shows Formatted/Raw tabs */}
                 <div style={{ marginTop: "0.2rem" }}>
                   <ChatResultBubble result={toolResult.result} />
                 </div>
-                {toolResult.resourceUri && sessionId && toolCall && (
-                  <WidgetSandbox
-                    sessionId={sessionId}
-                    resourceUri={toolResult.resourceUri}
-                    toolInput={toolCall.params || {}}
-                    toolResult={toolResult.result}
-                  />
-                )}
               </div>
             </div>
           )}
@@ -247,7 +253,6 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
 }
 
 import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
 import { apiClient } from "@/services/api";
 import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
 import { ToolResult } from '../components/result/ToolResult';
@@ -312,6 +317,7 @@ export default function MCPInspector() {
   const [headerKey, setHeaderKey] = useState("")
   const [headerValue, setHeaderValue] = useState("")
 
+  const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [url, setUrl] = useState("");
   const [transport, setTransport] = useState("http");
@@ -689,7 +695,7 @@ export default function MCPInspector() {
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
 
-  setChatHistory(prev => [...prev, userMsg])
+  updateChat(prev => [...prev, userMsg])
 
   // 3A-4: start an ExecutionRun for this agent turn
   const runId = crypto.randomUUID()
@@ -880,36 +886,69 @@ export default function MCPInspector() {
   return (
     <div
       className="dashboard"
-      style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+      style={inspectorFullscreen
+        ? { position: "fixed", inset: 0, zIndex: 1000, height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden", background: "#09090b", maxWidth: "none", margin: 0, padding: 0 }
+        : { height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden", maxWidth: "100%", padding: 0 }
+      }
     >
       <style>{`@keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}`}</style>
-      <Navbar />
+      {!inspectorFullscreen && <Navbar />}
 
-      <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
+      <div style={{ paddingTop: inspectorFullscreen ? "0" : "64px", flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
         <div
           style={{
-            maxWidth: "1600px",
+            maxWidth: inspectorFullscreen ? "none" : "1600px",
             width: "100%",
-            margin: "0 auto",
-            padding: "2rem",
+            margin: inspectorFullscreen ? "0" : "0 auto",
+            padding: inspectorFullscreen ? "0.4rem 0.5rem" : "2rem",
             flex: 1,
+            minHeight: 0,
             display: "flex",
             flexDirection: "column",
+            overflow: "hidden",
           }}
         >
-          {/* Page Header */}
-          <div style={{ marginBottom: "1.5rem" }}>
-            <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>
-              MCP Inspector
-            </h1>
-            <p style={{ color: "rgba(255,255,255,0.6)", marginTop: "0.5rem" }}>
-              Connect to any MCP server and inspect its tools.
-            </p>
-          </div>
+          {/* Page Header — hidden in fullscreen to maximise space */}
+          {inspectorFullscreen ? (
+            <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: "0.4rem", flexShrink: 0 }}>
+              <button
+                onClick={() => setInspectorFullscreen(false)}
+                style={{
+                  background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
+                  borderRadius: "0.4rem", cursor: "pointer", padding: "0.3rem 0.6rem",
+                  fontSize: "0.75rem", color: "rgba(255,255,255,0.7)", display: "flex", alignItems: "center", gap: "0.4rem",
+                }}
+              >
+                ✕ Exit Fullscreen
+              </button>
+            </div>
+          ) : (
+            <div style={{ marginBottom: "1.5rem", flexShrink: 0, display: "flex", alignItems: "flex-start", justifyContent: "space-between" }}>
+              <div>
+                <h1 style={{ fontSize: "2rem", fontWeight: "bold" }}>MCP Inspector</h1>
+                <p style={{ color: "rgba(255,255,255,0.6)", marginTop: "0.5rem" }}>
+                  Connect to any MCP server and inspect its tools.
+                </p>
+              </div>
+              <button
+                onClick={() => setInspectorFullscreen(true)}
+                title="Fullscreen"
+                style={{
+                  background: "rgba(255,255,255,0.06)", border: "1px solid rgba(255,255,255,0.12)",
+                  borderRadius: "0.4rem", cursor: "pointer", padding: "0.4rem 0.75rem",
+                  fontSize: "0.8rem", color: "rgba(255,255,255,0.7)", display: "flex", alignItems: "center", gap: "0.4rem",
+                  marginTop: "0.25rem", flexShrink: 0,
+                }}
+              >
+                ⤢ Fullscreen
+              </button>
+            </div>
+          )}
 
-          {/* Main Layout — fills remaining height */}
-          <PanelGroup 
-            direction="horizontal" 
+          {/* Main Layout — fills remaining height, never grows beyond it */}
+          <PanelGroup
+            key={inspectorFullscreen ? "fs" : "normal"}
+            direction="horizontal"
             onLayout={(sizes) => {
               setPanelSizes(prev => {
                 const updated = { ...prev, left: sizes[0] };
@@ -917,17 +956,13 @@ export default function MCPInspector() {
                 return updated;
               });
             }}
-            style={{ 
-              flex: 1,
-              // Minimum height so it doesn't collapse
-              minHeight: "calc(100vh - 220px)",
-            }}
+            style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
           >
             {/* ── LEFT PANEL (outer) ─────────────────────────────────────── */}
-            <Panel 
-              defaultSize={panelSizes.left} 
-              minSize={18} 
-              maxSize={50}
+            <Panel
+              defaultSize={inspectorFullscreen ? Math.min(panelSizes.left, 25) : panelSizes.left}
+              minSize={inspectorFullscreen ? 12 : 18}
+              maxSize={inspectorFullscreen ? 30 : 50}
               style={{ display: "flex", flexDirection: "column", overflow: "hidden" }}
             >
               {/* LEFT PANEL INNER: vertical split — Servers+Tools (top) / Logs (bottom) */}
@@ -940,14 +975,14 @@ export default function MCPInspector() {
                     return updated;
                   });
                 }}
-                style={{ flex: 1, height: "100%" }}
+                style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
               >
 
                 {/* ── TOP: Servers + Tools ────────────────────────────────── */}
                 <Panel 
                   defaultSize={100 - panelSizes.logs} 
                   minSize={30}
-                  style={{ overflow: "auto", display: "flex", flexDirection: "column" }}
+                  style={{ overflow: "hidden", display: "flex", flexDirection: "column", minHeight: 0 }}
                 >
                   <div
                     style={{
@@ -955,11 +990,12 @@ export default function MCPInspector() {
                       borderRadius: "0.75rem",
                       padding: "1.25rem",
                       background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-                      height: "100%",
+                      flex: 1,
+                      minHeight: 0,
                       boxSizing: "border-box",
                       display: "flex",
                       flexDirection: "column",
-                      overflow: "auto",
+                      overflow: "hidden",
                     }}
                   >
                     {/* Header */}
@@ -1356,12 +1392,12 @@ export default function MCPInspector() {
                   borderRadius: "0.75rem",
                   padding: "1.5rem",
                   background: "linear-gradient(to bottom right, rgba(39,39,42,0.9), rgba(24,24,27,0.9))",
-                  height: "100%",
+                  flex: 1,
+                  minHeight: 0,
                   boxSizing: "border-box",
                   display: "flex",
                   flexDirection: "column",
                   overflow: "hidden",
-                  minHeight: 0,
                 }}
               >
                 <h2 style={{ fontSize: "1.1rem", fontWeight: "600", flexShrink: 0 }}>
@@ -1399,7 +1435,7 @@ export default function MCPInspector() {
                 {/* ── MANUAL MODE ─── */}
                 <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
-                    <div>
+                    <div style={{ overflowY: "auto", flex: 1, minHeight: 0, paddingBottom: "0.5rem" }}>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
 
                       {selectedServer.status === "connected" ? (
@@ -1434,27 +1470,62 @@ export default function MCPInspector() {
 
                   {/* ── CHAT MODE ─── */}
                   {mode === "chat" && selectedServer && (
-                    <div style={{ display: "grid", gridTemplateRows: "1fr auto", flex: 1, minHeight: 0, overflow: "hidden" }}>
+                    <div style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0, overflow: "hidden" }}>
                       {selectedServer.status === "connected" ? (
                         <>
-                          {/* Chat History — grid row 1 (1fr = all remaining space) */}
+                          {/* Chat History — fills remaining flex space, scrolls */}
                           <div
                             ref={chatRef}
                             style={{
-                              overflowY: "auto",
+                              flex: 1,
                               minHeight: 0,
-                              display: "flex",
-                              flexDirection: "column",
-                              gap: "0.5rem",
-                              padding: "0.5rem 0.5rem 0.75rem 0.25rem"
+                              overflowY: "auto",
+                              padding: "0.5rem 0.5rem 2rem 0.25rem"
                             }}
                           >
-                            {groupMessages(chatHistory, executionHistory).map((group) => {
+                            {/* Inner wrapper: flex layout for gap spacing.
+                                Kept separate from the scroll container so flex items
+                                don't shrink-to-fit and prevent overflow scrolling. */}
+                            <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                            {groupMessages(chatHistory, executionHistory).map((group, _idx, _arr) => {
+                              const isLast = _idx === _arr.length - 1;
                               if (group.kind === "run") {
+                                const toolResult = group.steps.find(s => s.type === "tool_result");
+                                const toolCall = group.steps.find(s => s.type === "tool_call");
+                                const sessionId = selectedServer?.session_id ?? undefined;
+                                const hasWidget = !!(toolResult?.resourceUri && sessionId && toolCall);
                                 return (
-                                  <div key={group.runId} style={{ display: "flex", justifyContent: "flex-start" }}>
-                                    <ExecutionRunBlock steps={group.steps} run={group.run} sessionId={selectedServer?.session_id ?? undefined} />
-                                  </div>
+                                  <React.Fragment key={group.runId}>
+                                    <ExecutionRunBlock steps={group.steps} run={group.run} />
+                                    {hasWidget && (
+                                      <div style={{
+                                        width: "100%",
+                                        border: "1px solid rgba(99,102,241,0.3)",
+                                        borderRadius: "10px",
+                                        overflow: "hidden",
+                                        background: "rgba(99,102,241,0.04)",
+                                      }}>
+                                        <div style={{
+                                          padding: "0.4rem 0.75rem",
+                                          borderBottom: "1px solid rgba(99,102,241,0.15)",
+                                          fontSize: "0.72rem", fontWeight: 600,
+                                          color: "rgba(99,102,241,0.8)",
+                                          display: "flex", alignItems: "center", gap: "0.4rem",
+                                          background: "rgba(99,102,241,0.06)",
+                                        }}>
+                                          <span>⬡</span> Widget
+                                        </div>
+                                        <WidgetSandbox
+                                          sessionId={sessionId!}
+                                          resourceUri={toolResult!.resourceUri!}
+                                          toolInput={toolCall!.params || {}}
+                                          toolResult={toolResult!.result}
+                                        />
+                                      </div>
+                                    )}
+                                    {/* Scroll anchor: AFTER widget so auto-scroll reveals the full widget */}
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
@@ -1462,51 +1533,57 @@ export default function MCPInspector() {
 
                               if (msg.type === "user") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
-                                    <div style={{
-                                      background: "rgba(37,99,235,0.85)",
-                                      border: "1px solid rgba(59,130,246,0.4)",
-                                      color: "#fff",
-                                      padding: "0.55rem 0.85rem",
-                                      borderRadius: "16px 16px 4px 16px",
-                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                    }}>
-                                      {msg.content}
+                                  <React.Fragment key={msg.id}>
+                                    <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                                      <div style={{
+                                        background: "rgba(37,99,235,0.85)",
+                                        border: "1px solid rgba(59,130,246,0.4)",
+                                        color: "#fff",
+                                        padding: "0.55rem 0.85rem",
+                                        borderRadius: "16px 16px 4px 16px",
+                                        maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                      }}>
+                                        {msg.content}
+                                      </div>
                                     </div>
-                                  </div>
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
-                                    <div style={{
-                                      width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
-                                      background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
-                                      display: "flex", alignItems: "center", justifyContent: "center",
-                                      fontSize: "0.65rem",
-                                    }}>🤖</div>
-                                    <div style={{
-                                      background: "rgba(39,39,42,0.8)",
-                                      border: "1px solid rgba(63,63,70,0.6)",
-                                      padding: "0.55rem 0.85rem",
-                                      borderRadius: "4px 16px 16px 16px",
-                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                      color: "rgba(255,255,255,0.85)",
-                                    }}>
-                                      {msg.content}
+                                  <React.Fragment key={msg.id}>
+                                    <div style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
+                                      <div style={{
+                                        width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
+                                        background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                        display: "flex", alignItems: "center", justifyContent: "center",
+                                        fontSize: "0.65rem",
+                                      }}>🤖</div>
+                                      <div style={{
+                                        background: "rgba(39,39,42,0.8)",
+                                        border: "1px solid rgba(63,63,70,0.6)",
+                                        padding: "0.55rem 0.85rem",
+                                        borderRadius: "4px 16px 16px 16px",
+                                        maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                        color: "rgba(255,255,255,0.85)",
+                                      }}>
+                                        {msg.content}
+                                      </div>
                                     </div>
-                                  </div>
+                                    {isLast && <div ref={chatBottomRef} />}
+                                  </React.Fragment>
                                 );
                               }
 
                               return null;
                             })}
-                            <div ref={chatBottomRef} />
+                            </div>{/* close inner flex wrapper */}
                           </div>
 
-                          {/* Chat Input — grid row 2 (auto height, always at bottom) */}
-                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
+                          {/* Chat Input — always at bottom, shrinks to its content */}
+                          <div style={{ flexShrink: 0, display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
 
                             {/* ── Toolbar row: model badge · system prompt · clear ── */}
                             <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
@@ -1822,7 +1899,6 @@ export default function MCPInspector() {
         </div>
       )}
 
-      <Footer />
     </div>
   );
 }

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -130,7 +130,7 @@ function ExecutionRunBlock({ steps, run }: { steps: ChatMessage[]; run?: Executi
   const toolCall  = steps.find(s => s.type === "tool_call");
   const toolResult = steps.find(s => s.type === "tool_result");
   const errorStep = steps.find(s => s.type === "error");
-  const isActive  = !toolResult && !errorStep; // run still in progress
+  const isActive  = !toolResult && !errorStep && !run?.endTime; // run still in progress
 
   const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
   const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
@@ -424,6 +424,69 @@ export default function MCPInspector() {
   const [systemPrompt, setSystemPrompt] = useState("")
   const [systemPromptDraft, setSystemPromptDraft] = useState("")
   const [systemPromptOpen, setSystemPromptOpen] = useState(false)
+
+  // 5A: Multi-provider LLM selector
+  type LLMProvider = "groq" | "openai" | "anthropic" | "gemini"
+  const PROVIDER_DEFAULTS: Record<LLMProvider, { model: string; label: string; models: { id: string; label: string }[] }> = {
+    groq: {
+      label: "Groq", model: "llama-3.1-8b-instant",
+      models: [
+        { id: "llama-3.1-8b-instant",  label: "Llama 3.1 8B (fast)" },
+        { id: "llama-3.3-70b-versatile", label: "Llama 3.3 70B" },
+        { id: "llama-3.1-70b-versatile", label: "Llama 3.1 70B" },
+        { id: "mixtral-8x7b-32768",    label: "Mixtral 8x7B" },
+      ],
+    },
+    openai: {
+      label: "OpenAI", model: "gpt-4o-mini",
+      models: [
+        { id: "gpt-4o-mini",  label: "GPT-4o Mini (fast)" },
+        { id: "gpt-4o",       label: "GPT-4o" },
+        { id: "gpt-4-turbo",  label: "GPT-4 Turbo" },
+        { id: "o1-mini",      label: "o1 Mini" },
+      ],
+    },
+    anthropic: {
+      label: "Anthropic", model: "claude-haiku-4-5-20251001",
+      models: [
+        { id: "claude-haiku-4-5-20251001",  label: "Claude Haiku 4.5 (fast)" },
+        { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+        { id: "claude-opus-4-5",   label: "Claude Opus 4.5" },
+      ],
+    },
+    gemini: {
+      label: "Gemini", model: "gemini-2.0-flash",
+      models: [
+        { id: "gemini-2.0-flash",      label: "Gemini 2.0 Flash (fast)" },
+        { id: "gemini-2.0-flash-lite", label: "Gemini 2.0 Flash Lite" },
+        { id: "gemini-1.5-pro",        label: "Gemini 1.5 Pro" },
+        { id: "gemini-1.5-flash",      label: "Gemini 1.5 Flash" },
+      ],
+    },
+  }
+  const loadLLMSettings = () => {
+    try {
+      const raw = localStorage.getItem("fmcp_llm_settings")
+      if (raw) return JSON.parse(raw)
+    } catch { /* ignore */ }
+    return { provider: "groq", model: "llama-3.1-8b-instant", apiKeys: {} }
+  }
+  const [llmSettings, setLLMSettings] = useState<{
+    provider: LLMProvider; model: string; apiKeys: Record<string, string>
+  }>(loadLLMSettings)
+  const [llmSelectorOpen, setLLMSelectorOpen] = useState(false)
+  const [llmDraft, setLLMDraft] = useState(llmSettings)
+
+  const saveLLMSettings = (next: typeof llmSettings) => {
+    const providerChanged = next.provider !== llmSettings.provider || next.model !== llmSettings.model
+    setLLMSettings(next)
+    localStorage.setItem("fmcp_llm_settings", JSON.stringify(next))
+    // Clear chat for all servers when provider/model changes — history from a
+    // different model context is misleading and can confuse the new model
+    if (providerChanged) {
+      setChatHistoryByServer({})
+    }
+  }
 
   // Helper to update chat for the currently selected server
   const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
@@ -818,6 +881,11 @@ export default function MCPInspector() {
           type: m.type,
           content: m.content
         })),
+        provider: llmSettings.provider,
+        model: llmSettings.model,
+        ...(llmSettings.apiKeys[llmSettings.provider]
+          ? { api_key: llmSettings.apiKeys[llmSettings.provider] }
+          : {}),
         ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
       }
     )
@@ -825,16 +893,20 @@ export default function MCPInspector() {
     updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
+      const isAuthError = res.error_type === "auth" || res.error_type === "llm"
+      // No runId — renders as a standalone red bubble below the (now-closed) run block
       const assistantMsg: ChatMessage = {
         id: generateId(),
-        runId,
         type: "assistant",
-        content: res.message,
+        content: isAuthError
+          ? res.message
+          : (res.message || "Could not determine which tool to run."),
         timestamp: Date.now(),
-        perfMark: performance.now()
+        perfMark: performance.now(),
+        ...(isAuthError ? { errorType: res.error_type } : {})
       }
       updateChat(prev => [...prev, assistantMsg])
-      // save run (no tool call — just clarification)
+      // Save run with endTime so isActive becomes false in ExecutionRunBlock
       setExecutionHistoryByServer(prev => ({
         ...prev,
         [capturedServerId]: [{ runId, serverId: capturedServerId, startTime: runStartTime, endTime: Date.now(), steps: runSteps }, ...(prev[capturedServerId] ?? [])]
@@ -892,17 +964,20 @@ export default function MCPInspector() {
 
   } catch (err: any) {
 
+    // Always clear the thinking bubble before showing the error
+    updateChat(prev => prev.filter((m: ChatMessage) => m.type !== "thinking"))
+
+    // No runId — renders as a standalone red bubble below the (now-closed) run block
     const errorMsg: ChatMessage = {
       id: generateId(),
-      runId,
-      type: "error",
-      content: err?.message || "Chat error",
+      type: "assistant",
+      content: err?.message || "Something went wrong. Check your LLM settings.",
       timestamp: Date.now(),
-      perfMark: performance.now()
-    }
+      perfMark: performance.now(),
+      errorType: "llm",
+    } as any
 
     updateChat(prev => [...prev, errorMsg])
-    runSteps.push(errorMsg)
 
     // save failed run
     setExecutionHistoryByServer(prev => ({
@@ -1761,24 +1836,39 @@ export default function MCPInspector() {
                               }
 
                               if (msg.type === "assistant") {
+                                const isErrMsg = !!(msg as any).errorType
                                 return (
                                   <React.Fragment key={msg.id}>
                                     <div style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
                                       <div style={{
                                         width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
-                                        background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                        background: isErrMsg ? "rgba(239,68,68,0.15)" : "rgba(99,102,241,0.2)",
+                                        border: `1px solid ${isErrMsg ? "rgba(239,68,68,0.4)" : "rgba(99,102,241,0.4)"}`,
                                         display: "flex", alignItems: "center", justifyContent: "center",
                                         fontSize: "0.65rem",
-                                      }}>🤖</div>
+                                      }}>{isErrMsg ? "⚠" : "🤖"}</div>
                                       <div style={{
-                                        background: "rgba(39,39,42,0.8)",
-                                        border: "1px solid rgba(63,63,70,0.6)",
+                                        background: isErrMsg ? "rgba(239,68,68,0.08)" : "rgba(39,39,42,0.8)",
+                                        border: `1px solid ${isErrMsg ? "rgba(239,68,68,0.35)" : "rgba(63,63,70,0.6)"}`,
                                         padding: "0.55rem 0.85rem",
                                         borderRadius: "4px 16px 16px 16px",
                                         maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
-                                        color: "rgba(255,255,255,0.85)",
+                                        color: isErrMsg ? "rgba(252,165,165,0.9)" : "rgba(255,255,255,0.85)",
+                                        display: "flex", flexDirection: "column", gap: "0.5rem",
                                       }}>
-                                        {msg.content}
+                                        <span>{msg.content}</span>
+                                        {isErrMsg && (
+                                          <button
+                                            onClick={() => { setLLMDraft(llmSettings); setLLMSelectorOpen(true); }}
+                                            style={{
+                                              fontSize: "0.7rem", padding: "0.25rem 0.6rem", borderRadius: "6px", cursor: "pointer",
+                                              background: "rgba(239,68,68,0.15)", border: "1px solid rgba(239,68,68,0.35)",
+                                              color: "rgba(252,165,165,0.9)", alignSelf: "flex-start",
+                                            }}
+                                          >
+                                            Fix LLM settings
+                                          </button>
+                                        )}
                                       </div>
                                     </div>
                                     {isLast && <div ref={chatBottomRef} />}
@@ -1796,14 +1886,19 @@ export default function MCPInspector() {
 
                             {/* ── Toolbar row: model badge · system prompt · clear ── */}
                             <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
-                              {/* Model badge */}
-                              <span style={{
-                                fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
-                                background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
-                                color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
-                              }}>
-                                Groq · llama-3.1-8b
-                              </span>
+                              {/* Model badge — clickable to open LLM selector */}
+                              <button
+                                onClick={() => { setLLMDraft(llmSettings); setLLMSelectorOpen(true); }}
+                                title="Change LLM provider / model"
+                                style={{
+                                  fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                  background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
+                                  color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
+                                  cursor: "pointer",
+                                }}
+                              >
+                                {PROVIDER_DEFAULTS[llmSettings.provider]?.label ?? llmSettings.provider} · {llmSettings.model.length > 20 ? llmSettings.model.slice(0, 20) + "…" : llmSettings.model}
+                              </button>
 
                               {/* System prompt button */}
                               <button
@@ -1869,6 +1964,139 @@ export default function MCPInspector() {
                                     </button>
                                     <button
                                       onClick={() => { setSystemPrompt(systemPromptDraft); setSystemPromptOpen(false); }}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
+                                    >
+                                      Save
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* ── LLM selector dialog ── */}
+                            {llmSelectorOpen && (
+                              <div style={{
+                                position: "fixed", inset: 0, zIndex: 50,
+                                background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center",
+                              }}
+                                onClick={(e) => { if (e.target === e.currentTarget) setLLMSelectorOpen(false); }}
+                              >
+                                <div style={{
+                                  background: "#18181b", border: "1px solid rgba(63,63,70,0.7)",
+                                  borderRadius: "12px", padding: "1.25rem", width: "420px", maxWidth: "90vw",
+                                  display: "flex", flexDirection: "column", gap: "0.85rem",
+                                }}>
+                                  <div style={{ fontSize: "0.9rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>LLM Settings</div>
+
+                                  {/* Warning when provider/model differs from saved */}
+                                  {(llmDraft.provider !== llmSettings.provider || llmDraft.model !== llmSettings.model) && chatHistory.length > 0 && (
+                                    <div style={{
+                                      fontSize: "0.72rem", padding: "0.4rem 0.65rem", borderRadius: "6px",
+                                      background: "rgba(234,179,8,0.1)", border: "1px solid rgba(234,179,8,0.3)",
+                                      color: "rgba(253,224,71,0.85)", display: "flex", alignItems: "center", gap: "0.4rem",
+                                    }}>
+                                      ⚠ Changing provider or model will clear the current chat
+                                    </div>
+                                  )}
+
+                                  {/* Provider selector */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>Provider</label>
+                                    <div style={{ display: "flex", gap: "0.4rem", flexWrap: "wrap" }}>
+                                      {(["groq", "openai", "anthropic", "gemini"] as LLMProvider[]).map(p => (
+                                        <button key={p}
+                                          onClick={() => setLLMDraft(d => ({
+                                            ...d,
+                                            provider: p,
+                                            model: PROVIDER_DEFAULTS[p].model,
+                                          }))}
+                                          style={{
+                                            fontSize: "0.75rem", padding: "0.3rem 0.7rem", borderRadius: "6px", cursor: "pointer",
+                                            background: llmDraft.provider === p ? "rgba(99,102,241,0.8)" : "rgba(39,39,42,0.8)",
+                                            border: llmDraft.provider === p ? "1px solid rgba(99,102,241,0.6)" : "1px solid rgba(63,63,70,0.5)",
+                                            color: llmDraft.provider === p ? "#fff" : "rgba(255,255,255,0.6)",
+                                            fontWeight: llmDraft.provider === p ? 600 : 400,
+                                          }}
+                                        >
+                                          {PROVIDER_DEFAULTS[p].label}
+                                        </button>
+                                      ))}
+                                    </div>
+                                  </div>
+
+                                  {/* Model selector */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>Model</label>
+                                    <select
+                                      value={PROVIDER_DEFAULTS[llmDraft.provider].models.some(m => m.id === llmDraft.model) ? llmDraft.model : "__custom__"}
+                                      onChange={e => {
+                                        if (e.target.value !== "__custom__") {
+                                          setLLMDraft(d => ({ ...d, model: e.target.value }))
+                                        }
+                                      }}
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                        borderRadius: "6px", padding: "0.45rem 0.6rem",
+                                        color: "#fff", fontSize: "0.8rem", fontFamily: "monospace",
+                                        cursor: "pointer",
+                                      }}
+                                    >
+                                      {PROVIDER_DEFAULTS[llmDraft.provider].models.map(m => (
+                                        <option key={m.id} value={m.id}>{m.label}</option>
+                                      ))}
+                                      <option value="__custom__" disabled style={{ color: "rgba(255,255,255,0.4)" }}>
+                                        ── custom (type below) ──
+                                      </option>
+                                    </select>
+                                    {/* Custom model input — shown when selection isn't in the list */}
+                                    <input
+                                      value={llmDraft.model}
+                                      onChange={e => setLLMDraft(d => ({ ...d, model: e.target.value }))}
+                                      placeholder="or type a custom model ID"
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.4)",
+                                        borderRadius: "6px", padding: "0.4rem 0.6rem",
+                                        color: "rgba(255,255,255,0.7)", fontSize: "0.75rem", fontFamily: "monospace",
+                                      }}
+                                    />
+                                  </div>
+
+                                  {/* API key input */}
+                                  <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+                                    <label style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.5)" }}>
+                                      API Key
+                                      {llmDraft.provider === "groq" && (
+                                        <span style={{ marginLeft: "0.4rem", color: "rgba(134,239,172,0.7)" }}>(free key at console.groq.com)</span>
+                                      )}
+                                    </label>
+                                    <input
+                                      type="password"
+                                      value={llmDraft.apiKeys[llmDraft.provider] ?? ""}
+                                      onChange={e => setLLMDraft(d => ({
+                                        ...d,
+                                        apiKeys: { ...d.apiKeys, [d.provider]: e.target.value }
+                                      }))}
+                                      placeholder={llmDraft.provider === "groq" ? "gsk_... (leave blank for env var)" : "Paste your API key"}
+                                      style={{
+                                        background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                        borderRadius: "6px", padding: "0.45rem 0.6rem",
+                                        color: "#fff", fontSize: "0.8rem", fontFamily: "monospace",
+                                      }}
+                                    />
+                                    <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)" }}>
+                                      Stored in localStorage · never sent to FluidMCP servers
+                                    </span>
+                                  </div>
+
+                                  <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                                    <button
+                                      onClick={() => setLLMSelectorOpen(false)}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "transparent", border: "1px solid rgba(63,63,70,0.5)", color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                                    >
+                                      Cancel
+                                    </button>
+                                    <button
+                                      onClick={() => { saveLLMSettings(llmDraft); setLLMSelectorOpen(false); }}
                                       style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
                                     >
                                       Save

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -306,6 +306,14 @@ type ExecutionRun = {
   endTime?: number     // set on completion or error
   steps: ChatMessage[] // thinking + tool_call + tool_result in order
 }
+interface MCPResource {
+  uri: string;
+  name?: string;
+  mimeType?: string;
+  description?: string;
+  isTemplate?: boolean;
+}
+
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
@@ -337,7 +345,26 @@ export default function MCPInspector() {
   const [executionHistoryByServer, setExecutionHistoryByServer] = useState<Record<string, ExecutionRun[]>>({})
   const executionHistory = executionHistoryByServer[selectedServerId ?? ""] ?? []
 
-  const [mode, setMode] = useState<"manual" | "chat">("manual")
+  const [mode, setMode] = useState<"manual" | "chat" | "resources" | "prompts">("manual")
+
+  // 4B: Resources tab state
+  const [resourcesByServer, setResourcesByServer] = useState<Record<string, MCPResource[]>>({})
+  const resources = resourcesByServer[selectedServerId ?? ""] ?? []
+  const [selectedResourceUri, setSelectedResourceUri] = useState<string | null>(null)
+  const [resourceContent, setResourceContent] = useState<{ text?: string; blob?: string; mimeType?: string } | null>(null)
+  const [resourcesLoading, setResourcesLoading] = useState(false)
+  const [resourceContentLoading, setResourceContentLoading] = useState(false)
+  // Template param inputs: { paramName → value }
+  const [templateParams, setTemplateParams] = useState<Record<string, string>>({})
+
+  // 4B: Prompts tab state
+  const [promptsByServer, setPromptsByServer] = useState<Record<string, any[]>>({})
+  const prompts = promptsByServer[selectedServerId ?? ""] ?? []
+  const [selectedPrompt, setSelectedPrompt] = useState<any | null>(null)
+  const [promptArgs, setPromptArgs] = useState<Record<string, string>>({})
+  const [promptResult, setPromptResult] = useState<any | null>(null)
+  const [promptsLoading, setPromptsLoading] = useState(false)
+  const [promptResultLoading, setPromptResultLoading] = useState(false)
 
   const [chatInput, setChatInput] = useState("")
   // 3A-2: Per-server logs
@@ -827,6 +854,42 @@ export default function MCPInspector() {
     setToolError(null)
     setExecutionTime(null)
   }, [selectedTool])
+
+  // 4B: Fetch prompts list when Prompts tab becomes active
+  useEffect(() => {
+    if (mode !== "prompts") return;
+    const sessionId = selectedServer?.session_id;
+    if (!sessionId) return;
+    if (promptsByServer[selectedServerId!]) return;
+    setPromptsLoading(true);
+    apiClient.listInspectorPrompts(sessionId)
+      .then(res => {
+        setPromptsByServer(prev => ({ ...prev, [selectedServerId!]: res?.prompts ?? [] }));
+      })
+      .catch(() => {
+        setPromptsByServer(prev => ({ ...prev, [selectedServerId!]: [] }));
+      })
+      .finally(() => setPromptsLoading(false));
+  }, [mode, selectedServer?.session_id])
+
+  // 4B: Fetch resource list when Resources tab becomes active
+  useEffect(() => {
+    if (mode !== "resources") return;
+    const sessionId = selectedServer?.session_id;
+    if (!sessionId) return;
+    // Already cached for this server — no refetch needed
+    if (resourcesByServer[selectedServerId!]) return;
+    setResourcesLoading(true);
+    apiClient.listInspectorResources(sessionId)
+      .then(res => {
+        const list: MCPResource[] = res?.resources ?? [];
+        setResourcesByServer(prev => ({ ...prev, [selectedServerId!]: list }));
+      })
+      .catch(() => {
+        setResourcesByServer(prev => ({ ...prev, [selectedServerId!]: [] }));
+      })
+      .finally(() => setResourcesLoading(false));
+  }, [mode, selectedServer?.session_id])
 
   useEffect(() => {
     const saved = sessionStorage.getItem('inspector-panel-sizes')
@@ -1430,6 +1493,39 @@ export default function MCPInspector() {
                   >
                     Chat
                   </button>
+                  <button
+                    onClick={() => {
+                      setMode("resources");
+                      setSelectedResourceUri(null);
+                      setResourceContent(null);
+                    }}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "resources" ? "#fff" : "transparent",
+                      color: mode === "resources" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Resources
+                  </button>
+                  <button
+                    onClick={() => {
+                      setMode("prompts");
+                      setSelectedPrompt(null);
+                      setPromptArgs({});
+                      setPromptResult(null);
+                    }}
+                    style={{
+                      padding: "0.35rem 0.75rem", borderRadius: "0.35rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: mode === "prompts" ? "#fff" : "transparent",
+                      color: mode === "prompts" ? "#000" : "#fff",
+                      cursor: "pointer",
+                    }}
+                  >
+                    Prompts
+                  </button>
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
@@ -1707,6 +1803,226 @@ export default function MCPInspector() {
                     </div>
                   )}
 
+                  {/* ── RESOURCES MODE ─── */}
+                  {mode === "resources" && selectedServer?.status === "connected" && (
+                    <div style={{ display: "flex", flex: 1, minHeight: 0, gap: "0.75rem", overflow: "hidden" }}>
+
+                      {/* Resource list — left column */}
+                      <div style={{
+                        width: "38%", flexShrink: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        <div style={{
+                          padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                          display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0,
+                          background: "rgba(24,24,27,0.6)",
+                        }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "rgba(255,255,255,0.7)" }}>
+                            Resources {resources.length > 0 && <span style={{ color: "rgba(255,255,255,0.35)", fontWeight: 400 }}>({resources.length})</span>}
+                          </span>
+                          <button
+                            onClick={() => {
+                              if (!selectedServer?.session_id || !selectedServerId) return;
+                              setResourcesByServer(prev => { const next = { ...prev }; delete next[selectedServerId]; return next; });
+                              setSelectedResourceUri(null);
+                              setResourceContent(null);
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Refresh
+                          </button>
+                        </div>
+                        <div style={{ flex: 1, overflowY: "auto" }}>
+                          {resourcesLoading ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                              Loading resources...
+                            </div>
+                          ) : resources.length === 0 ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                              No resources found
+                            </div>
+                          ) : (
+                            resources.map(r => {
+                              const isSelected = r.uri === selectedResourceUri;
+                              // Extract {param} names from template URIs
+                              const templateVars = r.isTemplate
+                                ? (r.uri.match(/\{([^}]+)\}/g) ?? []).map(v => v.slice(1, -1))
+                                : [];
+                              const loadResource = async (uri: string) => {
+                                setSelectedResourceUri(r.uri);
+                                setResourceContent(null);
+                                setResourceContentLoading(true);
+                                try {
+                                  const res = await apiClient.readInspectorResource(selectedServer.session_id!, uri);
+                                  const first = res?.contents?.[0];
+                                  setResourceContent({
+                                    text: first?.text ?? first?.content ?? res?.text ?? "",
+                                    blob: first?.blob,
+                                    mimeType: first?.mimeType ?? r.mimeType ?? "text/plain",
+                                  });
+                                } catch {
+                                  setResourceContent({ text: "Failed to load resource.", mimeType: "text/plain" });
+                                } finally {
+                                  setResourceContentLoading(false);
+                                }
+                              };
+                              return (
+                                <div
+                                  key={r.uri}
+                                  onClick={() => {
+                                    if (r.isTemplate) {
+                                      // Just select — param form shows in right panel
+                                      setSelectedResourceUri(r.uri);
+                                      setResourceContent(null);
+                                      setTemplateParams({});
+                                    } else {
+                                      if (isSelected) return;
+                                      loadResource(r.uri);
+                                    }
+                                  }}
+                                  style={{
+                                    padding: "0.55rem 0.75rem",
+                                    borderBottom: "1px solid rgba(63,63,70,0.25)",
+                                    cursor: "pointer",
+                                    background: isSelected ? "rgba(99,102,241,0.12)" : "transparent",
+                                    borderLeft: isSelected ? "2px solid rgba(99,102,241,0.8)" : "2px solid transparent",
+                                    transition: "background 0.1s",
+                                  }}
+                                >
+                                  <div style={{ fontSize: "0.75rem", fontWeight: 600, color: isSelected ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.85)", wordBreak: "break-all" }}>
+                                    {r.name || r.uri}
+                                  </div>
+                                  {r.name && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.3)", marginTop: "0.1rem", wordBreak: "break-all" }}>
+                                      {r.uri}
+                                    </div>
+                                  )}
+                                  <div style={{ display: "flex", gap: "0.35rem", marginTop: "0.25rem", flexWrap: "wrap" }}>
+                                    {r.mimeType && (
+                                      <span style={{
+                                        fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                        background: "rgba(99,102,241,0.15)", border: "1px solid rgba(99,102,241,0.3)",
+                                        color: "rgba(165,180,252,0.8)", fontFamily: "monospace",
+                                      }}>
+                                        {r.mimeType}
+                                      </span>
+                                    )}
+                                    {r.isTemplate && (
+                                      <span style={{
+                                        fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                        background: "rgba(245,158,11,0.15)", border: "1px solid rgba(245,158,11,0.3)",
+                                        color: "rgba(252,211,77,0.9)", fontFamily: "monospace",
+                                      }}>
+                                        template
+                                      </span>
+                                    )}
+                                  </div>
+                                  {r.description && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", marginTop: "0.2rem" }}>
+                                      {r.description}
+                                    </div>
+                                  )}
+                                  {/* Inline param form for selected templates */}
+                                  {r.isTemplate && isSelected && templateVars.length > 0 && (
+                                    <div
+                                      onClick={e => e.stopPropagation()}
+                                      style={{ marginTop: "0.5rem", display: "flex", flexDirection: "column", gap: "0.35rem" }}
+                                    >
+                                      {templateVars.map(v => (
+                                        <div key={v} style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                                          <span style={{ fontSize: "0.65rem", color: "rgba(252,211,77,0.8)", fontFamily: "monospace", flexShrink: 0 }}>{v}</span>
+                                          <input
+                                            value={templateParams[v] ?? ""}
+                                            onChange={e => setTemplateParams(prev => ({ ...prev, [v]: e.target.value }))}
+                                            placeholder={v}
+                                            style={{
+                                              flex: 1, padding: "0.2rem 0.4rem", fontSize: "0.7rem",
+                                              background: "rgba(0,0,0,0.3)", border: "1px solid rgba(63,63,70,0.6)",
+                                              borderRadius: "4px", color: "#fff",
+                                            }}
+                                          />
+                                        </div>
+                                      ))}
+                                      <button
+                                        onClick={() => {
+                                          let uri = r.uri;
+                                          templateVars.forEach(v => { uri = uri.replace(`{${v}}`, encodeURIComponent(templateParams[v] ?? "")); });
+                                          loadResource(uri);
+                                        }}
+                                        style={{
+                                          marginTop: "0.15rem", padding: "0.25rem 0.5rem", fontSize: "0.7rem",
+                                          background: "rgba(99,102,241,0.8)", border: "none", borderRadius: "4px",
+                                          color: "#fff", cursor: "pointer", alignSelf: "flex-end",
+                                        }}
+                                      >
+                                        Load
+                                      </button>
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Resource content viewer — right column */}
+                      <div style={{
+                        flex: 1, minWidth: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        {!selectedResourceUri ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.3)", fontSize: "0.8rem" }}>
+                            Select a resource to view its content
+                          </div>
+                        ) : resourceContentLoading ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>
+                            Loading...
+                          </div>
+                        ) : resourceContent ? (() => {
+                          const mime = resourceContent.mimeType ?? "text/plain";
+                          const text = resourceContent.text ?? "";
+                          const isImage = mime.startsWith("image/");
+                          const isJson = mime.includes("json") || (() => { try { JSON.parse(text); return text.trim().startsWith("{") || text.trim().startsWith("["); } catch { return false; } })();
+                          return (
+                            <>
+                              <div style={{
+                                padding: "0.4rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                                display: "flex", alignItems: "center", gap: "0.5rem", flexShrink: 0,
+                                background: "rgba(24,24,27,0.6)",
+                              }}>
+                                <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.5)", wordBreak: "break-all", flex: 1 }}>{selectedResourceUri}</span>
+                                <span style={{
+                                  fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px", flexShrink: 0,
+                                  background: "rgba(99,102,241,0.15)", border: "1px solid rgba(99,102,241,0.3)",
+                                  color: "rgba(165,180,252,0.8)", fontFamily: "monospace",
+                                }}>{mime}</span>
+                              </div>
+                              <div style={{ flex: 1, overflow: "auto", padding: "0.75rem" }}>
+                                {isImage ? (
+                                  <img
+                                    src={resourceContent.blob ? `data:${mime};base64,${resourceContent.blob}` : text}
+                                    alt={selectedResourceUri}
+                                    style={{ maxWidth: "100%", borderRadius: "4px" }}
+                                  />
+                                ) : (
+                                  <pre style={{
+                                    margin: 0, fontSize: "0.75rem", lineHeight: 1.6,
+                                    color: isJson ? "#a5f3fc" : "rgba(255,255,255,0.8)",
+                                    fontFamily: "ui-monospace, monospace",
+                                    whiteSpace: "pre-wrap", wordBreak: "break-word",
+                                  }}>
+                                    {isJson ? (() => { try { return JSON.stringify(JSON.parse(text), null, 2); } catch { return text; } })() : text}
+                                  </pre>
+                                )}
+                              </div>
+                            </>
+                          );
+                        })() : null}
+                      </div>
+                    </div>
+                  )}
+
                   {/* Empty states */}
                   {mode === "manual" && (!selectedServer || !selectedTool) && (
                     <div style={{
@@ -1722,6 +2038,233 @@ export default function MCPInspector() {
                       borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
                     }}>
                       {!selectedServer ? "Select a connected server to chat" : "Server is not connected. Please reconnect to chat."}
+                    </div>
+                  )}
+                  {mode === "resources" && (!selectedServer || selectedServer.status !== "connected") && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      {!selectedServer ? "Select a connected server to browse resources" : "Server is not connected."}
+                    </div>
+                  )}
+
+                  {/* ── PROMPTS MODE ─── */}
+                  {mode === "prompts" && selectedServer?.status === "connected" && (
+                    <div style={{ display: "flex", flex: 1, minHeight: 0, gap: "0.75rem", overflow: "hidden" }}>
+
+                      {/* Prompt list — left column */}
+                      <div style={{
+                        width: "38%", flexShrink: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        <div style={{
+                          padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                          display: "flex", alignItems: "center", justifyContent: "space-between", flexShrink: 0,
+                          background: "rgba(24,24,27,0.6)",
+                        }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: 600, color: "rgba(255,255,255,0.7)" }}>
+                            Prompts {prompts.length > 0 && <span style={{ color: "rgba(255,255,255,0.35)", fontWeight: 400 }}>({prompts.length})</span>}
+                          </span>
+                          <button
+                            onClick={() => {
+                              if (!selectedServerId) return;
+                              setPromptsByServer(prev => { const n = { ...prev }; delete n[selectedServerId]; return n; });
+                              setSelectedPrompt(null); setPromptArgs({}); setPromptResult(null);
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Refresh
+                          </button>
+                        </div>
+                        <div style={{ flex: 1, overflowY: "auto" }}>
+                          {promptsLoading ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>Loading prompts...</div>
+                          ) : prompts.length === 0 ? (
+                            <div style={{ padding: "1rem", textAlign: "center", color: "rgba(255,255,255,0.35)", fontSize: "0.75rem" }}>No prompts found</div>
+                          ) : (
+                            prompts.map((p: any) => {
+                              const isSelected = selectedPrompt?.name === p.name;
+                              const argCount = p.arguments?.length ?? 0;
+                              return (
+                                <div
+                                  key={p.name}
+                                  onClick={() => {
+                                    setSelectedPrompt(p);
+                                    setPromptArgs({});
+                                    setPromptResult(null);
+                                  }}
+                                  style={{
+                                    padding: "0.55rem 0.75rem",
+                                    borderBottom: "1px solid rgba(63,63,70,0.25)",
+                                    cursor: "pointer",
+                                    background: isSelected ? "rgba(99,102,241,0.12)" : "transparent",
+                                    borderLeft: isSelected ? "2px solid rgba(99,102,241,0.8)" : "2px solid transparent",
+                                    transition: "background 0.1s",
+                                  }}
+                                >
+                                  <div style={{ fontSize: "0.75rem", fontWeight: 600, color: isSelected ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.85)" }}>
+                                    {p.name}
+                                  </div>
+                                  {p.description && (
+                                    <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", marginTop: "0.15rem" }}>
+                                      {p.description}
+                                    </div>
+                                  )}
+                                  {argCount > 0 && (
+                                    <div style={{ marginTop: "0.25rem", display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
+                                      {p.arguments.map((a: any) => (
+                                        <span key={a.name} style={{
+                                          fontSize: "0.6rem", padding: "0.05rem 0.35rem", borderRadius: "999px",
+                                          background: a.required ? "rgba(99,102,241,0.15)" : "rgba(63,63,70,0.4)",
+                                          border: `1px solid ${a.required ? "rgba(99,102,241,0.3)" : "rgba(63,63,70,0.6)"}`,
+                                          color: a.required ? "rgba(165,180,252,0.9)" : "rgba(255,255,255,0.4)",
+                                          fontFamily: "monospace",
+                                        }}>
+                                          {a.name}{a.required ? "" : "?"}
+                                        </span>
+                                      ))}
+                                    </div>
+                                  )}
+                                </div>
+                              );
+                            })
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Prompt detail + result — right column */}
+                      <div style={{
+                        flex: 1, minWidth: 0, display: "flex", flexDirection: "column",
+                        border: "1px solid rgba(63,63,70,0.5)", borderRadius: "0.5rem", overflow: "hidden",
+                      }}>
+                        {!selectedPrompt ? (
+                          <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "rgba(255,255,255,0.3)", fontSize: "0.8rem" }}>
+                            Select a prompt to fill its arguments
+                          </div>
+                        ) : (
+                          <>
+                            {/* Header */}
+                            <div style={{
+                              padding: "0.5rem 0.75rem", borderBottom: "1px solid rgba(63,63,70,0.4)",
+                              background: "rgba(24,24,27,0.6)", flexShrink: 0,
+                            }}>
+                              <div style={{ fontSize: "0.8rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>{selectedPrompt.name}</div>
+                              {selectedPrompt.description && (
+                                <div style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)", marginTop: "0.15rem" }}>{selectedPrompt.description}</div>
+                              )}
+                            </div>
+
+                            {/* Argument form */}
+                            <div style={{ padding: "0.75rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
+                              {(selectedPrompt.arguments?.length ?? 0) === 0 ? (
+                                <div style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.35)", fontStyle: "italic" }}>No arguments required</div>
+                              ) : (
+                                <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                                  {selectedPrompt.arguments.map((a: any) => (
+                                    <div key={a.name}>
+                                      <div style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.5)", marginBottom: "0.2rem", fontFamily: "monospace" }}>
+                                        {a.name}{a.required ? <span style={{ color: "rgba(239,68,68,0.8)" }}> *</span> : <span style={{ color: "rgba(255,255,255,0.25)" }}> (optional)</span>}
+                                      </div>
+                                      {a.description && (
+                                        <div style={{ fontSize: "0.62rem", color: "rgba(255,255,255,0.3)", marginBottom: "0.2rem" }}>{a.description}</div>
+                                      )}
+                                      <input
+                                        value={promptArgs[a.name] ?? ""}
+                                        onChange={e => setPromptArgs(prev => ({ ...prev, [a.name]: e.target.value }))}
+                                        placeholder={a.name}
+                                        style={{
+                                          width: "100%", boxSizing: "border-box",
+                                          padding: "0.3rem 0.5rem", fontSize: "0.75rem",
+                                          background: "rgba(0,0,0,0.3)", border: "1px solid rgba(63,63,70,0.6)",
+                                          borderRadius: "4px", color: "#fff",
+                                        }}
+                                      />
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                              <button
+                                disabled={promptResultLoading}
+                                onClick={async () => {
+                                  if (!selectedServer?.session_id) return;
+                                  setPromptResultLoading(true);
+                                  setPromptResult(null);
+                                  try {
+                                    const res = await apiClient.getInspectorPrompt(selectedServer.session_id, selectedPrompt.name, promptArgs);
+                                    setPromptResult(res);
+                                  } catch (e: any) {
+                                    setPromptResult({ error: e.message });
+                                  } finally {
+                                    setPromptResultLoading(false);
+                                  }
+                                }}
+                                style={{
+                                  marginTop: "0.6rem", padding: "0.35rem 0.85rem",
+                                  background: "rgba(99,102,241,0.85)", border: "none", borderRadius: "6px",
+                                  color: "#fff", fontWeight: 600, fontSize: "0.75rem",
+                                  cursor: promptResultLoading ? "not-allowed" : "pointer",
+                                  opacity: promptResultLoading ? 0.6 : 1,
+                                }}
+                              >
+                                {promptResultLoading ? "Loading..." : "Get Prompt"}
+                              </button>
+                            </div>
+
+                            {/* Messages preview */}
+                            <div style={{ flex: 1, overflowY: "auto", padding: "0.75rem", display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+                              {promptResult?.error ? (
+                                <div style={{ fontSize: "0.75rem", color: "#fca5a5", padding: "0.5rem", background: "rgba(239,68,68,0.1)", borderRadius: "6px", border: "1px solid rgba(239,68,68,0.3)" }}>
+                                  Error: {promptResult.error}
+                                </div>
+                              ) : promptResult?.messages ? (
+                                promptResult.messages.map((msg: any, i: number) => {
+                                  // Unwrap role from nested message objects if SDK wraps them
+                                  const role = msg.role ?? msg?.content?.role ?? "user";
+                                  const rawContent = msg.content ?? msg;
+                                  const text = typeof rawContent === "string"
+                                    ? rawContent
+                                    : typeof rawContent?.text === "string"
+                                      ? rawContent.text
+                                      : Array.isArray(rawContent)
+                                        ? rawContent.map((c: any) => c.text ?? JSON.stringify(c)).join("\n")
+                                        : typeof rawContent === "object" && rawContent !== null && "text" in rawContent
+                                          ? rawContent.text
+                                          : JSON.stringify(rawContent, null, 2);
+                                  return (
+                                  <div key={i} style={{
+                                    padding: "0.5rem 0.75rem",
+                                    borderRadius: "8px",
+                                    background: role === "user" ? "rgba(37,99,235,0.15)" : "rgba(39,39,42,0.8)",
+                                    border: `1px solid ${role === "user" ? "rgba(59,130,246,0.3)" : "rgba(63,63,70,0.5)"}`,
+                                  }}>
+                                    <div style={{ fontSize: "0.62rem", fontWeight: 700, color: role === "user" ? "rgba(147,197,253,0.9)" : "rgba(165,180,252,0.9)", marginBottom: "0.3rem", textTransform: "uppercase", letterSpacing: "0.05em" }}>
+                                      {role}
+                                    </div>
+                                    <div style={{ fontSize: "0.75rem", color: "rgba(255,255,255,0.8)", whiteSpace: "pre-wrap", lineHeight: 1.5 }}>
+                                      {text}
+                                    </div>
+                                  </div>
+                                  );
+                                })
+                              ) : !promptResultLoading && (
+                                <div style={{ color: "rgba(255,255,255,0.25)", fontSize: "0.75rem", textAlign: "center", marginTop: "1rem" }}>
+                                  Fill in arguments and click Get Prompt
+                                </div>
+                              )}
+                            </div>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  )}
+
+                  {mode === "prompts" && (!selectedServer || selectedServer.status !== "connected") && (
+                    <div style={{
+                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
+                    }}>
+                      {!selectedServer ? "Select a connected server to browse prompts" : "Server is not connected."}
                     </div>
                   )}
                 </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1,13 +1,5 @@
+// import React from "react";
 import { useState, useEffect, useRef } from "react";
-import { Navbar } from "@/components/Navbar";
-import { Footer } from "@/components/Footer";
-import { apiClient } from "@/services/api";
-import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
-import { ToolResult } from '../components/result/ToolResult';
-import { JsonResultView } from '../components/result/JsonResultView';
-import { McpContentView } from '../components/result/McpContentView';
-import { WidgetSandbox } from '../components/WidgetSandbox';
-import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
 
 // Compact collapsible result bubble for chat mode
 function ChatResultBubble({ result }: { result: unknown }) {
@@ -84,14 +76,13 @@ function ChatResultBubble({ result }: { result: unknown }) {
 // ── Animated thinking indicator ──────────────────────────────────────────────
 function ThinkingDots() {
   return (
-    <span style={{ display: "inline-flex", gap: "3px", alignItems: "center", marginLeft: "4px" }}>
-      {[0, 1, 2].map(i => (
-        <span key={i} style={{
-          width: "4px", height: "4px", borderRadius: "50%",
-          background: "rgba(255,255,255,0.55)", display: "inline-block",
-          animation: `thinking-blink 1.4s infinite ${i * 0.2}s`,
-        }} />
-      ))}
+    <span style={{ fontStyle: "italic", color: "rgba(255,255,255,0.4)", fontSize: "0.72rem" }}>
+      Thinking
+      <span style={{ display: "inline-flex", gap: "1px" }}>
+        {[0, 1, 2].map(i => (
+          <span key={i} style={{ animation: `thinking-blink 1.4s ease-in-out ${i * 0.2}s infinite` }}>.</span>
+        ))}
+      </span>
     </span>
   );
 }
@@ -103,17 +94,6 @@ type DisplayGroup =
 
 function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): DisplayGroup[] {
   const runMap = new Map(execHistory.map(r => [r.runId, r]));
-
-  // Pre-build runId → steps map in a single pass to avoid O(n²) inner filter
-  const stepsByRunId = new Map<string, ChatMessage[]>();
-  for (const msg of messages) {
-    if (msg.runId) {
-      const arr = stepsByRunId.get(msg.runId);
-      if (arr) arr.push(msg);
-      else stepsByRunId.set(msg.runId, [msg]);
-    }
-  }
-
   const seen = new Set<string>();
   return messages.reduce<DisplayGroup[]>((acc, msg) => {
     if (!msg.runId) {
@@ -123,7 +103,7 @@ function groupMessages(messages: ChatMessage[], execHistory: ExecutionRun[]): Di
       acc.push({
         kind: "run",
         runId: msg.runId,
-        steps: stepsByRunId.get(msg.runId) ?? [],
+        steps: messages.filter(m => m.runId === msg.runId),
         run: runMap.get(msg.runId),
       });
     }
@@ -138,7 +118,7 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
   const toolCall  = steps.find(s => s.type === "tool_call");
   const toolResult = steps.find(s => s.type === "tool_result");
   const errorStep = steps.find(s => s.type === "error");
-  const isActive  = run ? !run.endTime : !toolResult && !errorStep; // use run.endTime when available
+  const isActive  = !toolResult && !errorStep; // run still in progress
 
   const totalMs    = run?.endTime ? run.endTime - run.startTime : null;
   const thinkingMs = (toolCall?.perfMark && thinking?.perfMark)
@@ -201,14 +181,25 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
                 <div style={{ fontSize: "0.72rem", color: "#fbbf24", fontWeight: 600 }}>
                   Tool: {toolCall.toolName}
                 </div>
-                <pre style={{
-                  margin: "0.2rem 0 0", padding: "0.35rem 0.5rem",
-                  background: "rgba(0,0,0,0.3)", borderRadius: "6px",
-                  fontSize: "0.7rem", overflowX: "auto", whiteSpace: "pre-wrap",
-                  wordBreak: "break-all", color: "#e5e7eb", fontFamily: "ui-monospace,monospace",
-                }}>
-                  {JSON.stringify(toolCall.params, null, 2)}
-                </pre>
+                {toolCall.params && Object.keys(toolCall.params).length > 0 ? (
+                  <div style={{ marginTop: "0.25rem", display: "flex", flexDirection: "column", gap: "0.2rem" }}>
+                    {Object.entries(toolCall.params).map(([k, v]) => (
+                      <div key={k} style={{ display: "flex", gap: "0.4rem", alignItems: "baseline", fontSize: "0.7rem" }}>
+                        <span style={{ color: "#fbbf24", opacity: 0.7, fontFamily: "monospace", flexShrink: 0 }}>{k}</span>
+                        <span style={{ color: "rgba(255,255,255,0.2)", flexShrink: 0 }}>→</span>
+                        <span style={{
+                          background: "rgba(0,0,0,0.25)", borderRadius: "4px",
+                          padding: "0.05rem 0.35rem", color: "#e5e7eb", fontFamily: "monospace",
+                          wordBreak: "break-all",
+                        }}>
+                          {typeof v === "string" ? v : JSON.stringify(v)}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <span style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)", fontStyle: "italic" }}>no params</span>
+                )}
               </div>
             </div>
           )}
@@ -254,6 +245,17 @@ function ExecutionRunBlock({ steps, run, sessionId }: { steps: ChatMessage[]; ru
     </div>
   );
 }
+
+import { Navbar } from "@/components/Navbar";
+import { Footer } from "@/components/Footer";
+import { apiClient } from "@/services/api";
+import { JsonSchemaForm } from '../components/form/JsonSchemaForm';
+import { ToolResult } from '../components/result/ToolResult';
+import { JsonResultView } from '../components/result/JsonResultView';
+import { McpContentView } from '../components/result/McpContentView';
+import { WidgetSandbox } from '../components/WidgetSandbox';
+import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels';
+
 // Type for server object
 interface MCPServer {
   id: string;
@@ -335,22 +337,33 @@ export default function MCPInspector() {
   // 3A-2: Per-server logs
   const [logsByServer, setLogsByServer] = useState<Record<string, LogEntry[]>>({})
   const logs = logsByServer[selectedServerId ?? ""] ?? []
+  // Tracks how many backend logs to skip per server after a manual clear.
+  // Using a ref so the polling closure always reads the latest value.
+  const logsClearedOffsetRef = useRef<Record<string, number>>({})
+  // 5B: Log filter pill state
+  const [logFilter, setLogFilter] = useState<'all' | 'connect' | 'tool_call' | 'tool_error' | 'chat'>('all')
+  const filteredLogs = logFilter === 'all' ? logs : logs.filter(l =>
+    logFilter === 'tool_error' ? (l.type === 'tool_error') :
+    logFilter === 'tool_call' ? (l.type === 'tool_call' || l.type === 'tool_result') :
+    l.type === logFilter
+  )
 
   // 3A-3: Per-server chat memory
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
   const chatHistory = chatHistoryByServer[selectedServerId ?? ""] ?? []
 
-  // Helper to update chat — accepts explicit serverId so async flows
-  // (runChatTool) stay pinned to the originating server even if the user
-  // switches selection while the request is in-flight.
-  const updateChat = (
-    serverId: string,
-    updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])
-  ) => {
+  // 5A: System prompt + dialog state
+  const [systemPrompt, setSystemPrompt] = useState("")
+  const [systemPromptDraft, setSystemPromptDraft] = useState("")
+  const [systemPromptOpen, setSystemPromptOpen] = useState(false)
+
+  // Helper to update chat for the currently selected server
+  const updateChat = (updater: ChatMessage[] | ((prev: ChatMessage[]) => ChatMessage[])) => {
+    if (!selectedServerId) return;
     setChatHistoryByServer(prev => ({
       ...prev,
-      [serverId]: typeof updater === "function"
-        ? updater(prev[serverId] ?? [])
+      [selectedServerId]: typeof updater === "function"
+        ? updater(prev[selectedServerId] ?? [])
         : updater
     }));
   };
@@ -363,8 +376,6 @@ export default function MCPInspector() {
   const logsRef = useRef<HTMLDivElement>(null);
   const chatRef = useRef<HTMLDivElement>(null);
   const chatBottomRef = useRef<HTMLDivElement>(null);
-  // Tracks how many backend log entries existed when the user last cleared, per server
-  const logsClearedOffsetRef = useRef<Record<string, number>>({});
 
   const handleConnect = async () => {
 
@@ -434,6 +445,9 @@ export default function MCPInspector() {
       const res = await apiClient.connectInspectorServer(payload)
 
 
+      // Reset log offset for this server — new session, fresh log stream
+      logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
+
       setServers(prev =>
         prev.map(s =>
           s.id === serverId
@@ -451,7 +465,7 @@ export default function MCPInspector() {
       setChatHistoryByServer(prev => ({
         ...prev,
         [serverId]: [{
-          id: generateId(),
+          id: crypto.randomUUID(),
           type: "assistant",
           content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
           timestamp: Date.now(),
@@ -553,6 +567,8 @@ export default function MCPInspector() {
       }
       
       const res = await apiClient.connectInspectorServer(payload);
+      // Reset log offset — reconnect starts a new session with a fresh log stream
+      logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
       // Update with connected state and new session
       setServers((prev) =>
         prev.map((s) =>
@@ -573,7 +589,7 @@ export default function MCPInspector() {
         [serverId]: [
           ...(prev[serverId] ?? []),
           {
-            id: generateId(),
+            id: crypto.randomUUID(),
             type: "assistant" as const,
             content: `Reconnected to ${res.server_info?.name || "server"}.`,
             timestamp: Date.now(),
@@ -607,12 +623,6 @@ export default function MCPInspector() {
     if (selectedServerId === serverId) setSelectedServerId(null);
   };
 
-  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
-  const generateId = () =>
-    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-      ? crypto.randomUUID()
-      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
-
   const runTool = async (params: any) => {
     if (!selectedServer?.session_id || !selectedTool || executing) return;
 
@@ -633,15 +643,15 @@ export default function MCPInspector() {
       setToolResult(res);
       setExecutionTime((end - start) / 1000);
       if (selectedServerId) {
-        const runId = generateId();
+        const runId = crypto.randomUUID();
         const run: ExecutionRun = {
           runId,
           serverId: selectedServerId,
           startTime: Date.now() - Math.round(end - start),
           endTime: Date.now(),
           steps: [
-            { id: generateId(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
-            { id: generateId(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
+            { id: crypto.randomUUID(), runId, type: "tool_call", toolName: selectedTool.name, params, timestamp: Date.now(), perfMark: start },
+            { id: crypto.randomUUID(), runId, type: "tool_result", result: res, timestamp: Date.now(), perfMark: end },
           ]
         };
         setExecutionHistoryByServer(prev => ({ ...prev, [selectedServerId]: [run, ...(prev[selectedServerId] ?? [])] }));
@@ -653,6 +663,12 @@ export default function MCPInspector() {
       setExecuting(false);
     }
   };
+
+  // Stable UUID helper — falls back for non-secure contexts (e.g. plain HTTP)
+  const generateId = () =>
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `msg_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
  const runChatTool = async () => {
   // Guard against concurrent requests
@@ -672,14 +688,14 @@ export default function MCPInspector() {
   // Capture history with userMsg before any state updates — used below to
   // send an accurate chat_history to the backend (avoids stale closure).
   const nextHistory = [...chatHistory, userMsg]
-  const capturedServerId = selectedServerId
 
-  updateChat(capturedServerId, prev => [...prev, userMsg])
+  setChatHistory(prev => [...prev, userMsg])
 
   // 3A-4: start an ExecutionRun for this agent turn
-  const runId = generateId()
+  const runId = crypto.randomUUID()
   const runStartTime = Date.now()
   const runSteps: ChatMessage[] = []
+  const capturedServerId = selectedServerId
 
   try {
     setChatLoading(true)
@@ -693,29 +709,33 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(capturedServerId, prev => [...prev, thinkingMsg])
+    updateChat(prev => [...prev, thinkingMsg])
     runSteps.push(thinkingMsg)
 
     const res = await apiClient.chatWithInspector(
       selectedServer.session_id,
       {
         message,
-        chat_history: nextHistory.slice(-8).map((m: ChatMessage) => ({
+        chat_history: nextHistory.slice(-8).map(m => ({
           type: m.type,
           content: m.content
-        }))
+        })),
+        ...(systemPrompt.trim() ? { system_prompt: systemPrompt.trim() } : {})
       }
     )
+
+    updateChat(prev => prev.filter((m: ChatMessage) => m.id !== thinkingMsg.id))
 
     if (res.clarification_needed) {
       const assistantMsg: ChatMessage = {
         id: generateId(),
+        runId,
         type: "assistant",
         content: res.message,
         timestamp: Date.now(),
         perfMark: performance.now()
       }
-      updateChat(capturedServerId, prev => [...prev, assistantMsg])
+      updateChat(prev => [...prev, assistantMsg])
       // save run (no tool call — just clarification)
       setExecutionHistoryByServer(prev => ({
         ...prev,
@@ -734,7 +754,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(capturedServerId, prev => [...prev, toolCallMsg])
+    updateChat(prev => [...prev, toolCallMsg])
     runSteps.push(toolCallMsg)
 
     const result = await apiClient.runInspectorTool(
@@ -763,7 +783,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(capturedServerId, prev => [...prev, resultMsg])
+    updateChat(prev => [...prev, resultMsg])
     runSteps.push(resultMsg)
 
     // save completed run
@@ -783,7 +803,7 @@ export default function MCPInspector() {
       perfMark: performance.now()
     }
 
-    updateChat(capturedServerId, prev => [...prev, errorMsg])
+    updateChat(prev => [...prev, errorMsg])
     runSteps.push(errorMsg)
 
     // save failed run
@@ -801,48 +821,6 @@ export default function MCPInspector() {
     setToolError(null)
     setExecutionTime(null)
   }, [selectedTool])
-
-  // ── Session persistence ────────────────────────────────────────────────────
-  // Restore servers + selected server on mount (survives page navigation)
-  useEffect(() => {
-    const savedServers = sessionStorage.getItem('inspector-servers')
-    const savedSelectedId = sessionStorage.getItem('inspector-selected-server-id')
-
-    if (savedServers) {
-      try {
-        const parsed: MCPServer[] = JSON.parse(savedServers)
-        // Any mid-connect server was interrupted — treat as disconnected on restore
-        const restored = parsed.map(s =>
-          s.status === 'connecting'
-            ? { ...s, status: 'disconnected' as const, session_id: null }
-            : s
-        )
-        setServers(restored)
-      } catch {
-        // ignore malformed storage
-      }
-    }
-
-    if (savedSelectedId) setSelectedServerId(savedSelectedId)
-  }, [])
-
-  // Persist servers list — strip auth secrets (tokens/header values) before writing
-  useEffect(() => {
-    const safeServers = servers.map(s => ({
-      ...s,
-      auth: s.auth ? { type: s.auth.type } : undefined,
-    }));
-    sessionStorage.setItem('inspector-servers', JSON.stringify(safeServers))
-  }, [servers])
-
-  // Persist selected server ID whenever it changes
-  useEffect(() => {
-    if (selectedServerId) {
-      sessionStorage.setItem('inspector-selected-server-id', selectedServerId)
-    } else {
-      sessionStorage.removeItem('inspector-selected-server-id')
-    }
-  }, [selectedServerId])
 
   useEffect(() => {
     const saved = sessionStorage.getItem('inspector-panel-sizes')
@@ -904,7 +882,7 @@ export default function MCPInspector() {
       className="dashboard"
       style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
     >
-      <style>{`@keyframes thinking-blink{0%,80%,100%{opacity:0}40%{opacity:1}}`}</style>
+      <style>{`@keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}`}</style>
       <Navbar />
 
       <div style={{ paddingTop: "64px", flex: 1, display: "flex", flexDirection: "column" }}>
@@ -1057,10 +1035,12 @@ export default function MCPInspector() {
                               style={{
                                 marginTop: "0.75rem",
                                 padding: "0.9rem",
-                                border: "1px solid rgba(63,63,70,0.6)",
+                                border: isSelected ? "1px solid rgba(99,102,241,0.5)" : "1px solid rgba(63,63,70,0.6)",
+                                borderLeft: isSelected ? "3px solid rgba(99,102,241,0.9)" : "3px solid transparent",
                                 borderRadius: "0.6rem",
                                 cursor: "pointer",
-                                background: isSelected ? "rgba(255,255,255,0.08)" : "transparent",
+                                background: isSelected ? "rgba(99,102,241,0.08)" : "transparent",
+                                transition: "background 0.15s, border-color 0.15s",
                               }}
                             >
                               {/* HEADER */}
@@ -1236,29 +1216,57 @@ export default function MCPInspector() {
                     }}
                   >
                     {/* Logs header */}
-                    <div style={{ padding: "0.75rem 1rem 0.5rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-                      <div>
-                        <span style={{ fontSize: "0.8rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>
-                          LOGS
-                        </span>
-                        {logs.length > 0 && (
-                          <span style={{ marginLeft: "0.5rem", fontSize: "0.7rem", color: "rgba(255,255,255,0.35)" }}>
-                            {logs.length} entries
-                          </span>
+                    <div style={{ padding: "0.6rem 0.75rem 0.4rem", flexShrink: 0, borderBottom: "1px solid rgba(63,63,70,0.3)" }}>
+                      {/* Title row */}
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.4rem" }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                          <span style={{ fontSize: "0.75rem", fontWeight: "600", color: "rgba(255,255,255,0.7)", fontFamily: "monospace" }}>LOGS</span>
+                          {logs.length > 0 && (
+                            <span style={{ fontSize: "0.65rem", color: "rgba(255,255,255,0.3)" }}>
+                              {filteredLogs.length}{logFilter !== 'all' ? `/${logs.length}` : ''}
+                            </span>
+                          )}
+                        </div>
+                        {logs.length > 0 && selectedServerId && (
+                          <button
+                            onClick={() => {
+                              if (!selectedServerId) return;
+                              const currentOffset = logsClearedOffsetRef.current[selectedServerId] ?? 0;
+                              logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [selectedServerId]: currentOffset + logs.length };
+                              setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
+                            }}
+                            style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.35rem" }}
+                          >
+                            Clear
+                          </button>
                         )}
                       </div>
-                      {logs.length > 0 && selectedServerId && (
-                        <button
-                          onClick={() => {
-                            const currentTotal = (logsClearedOffsetRef.current[selectedServerId] ?? 0) + logs.length;
-                            logsClearedOffsetRef.current[selectedServerId] = currentTotal;
-                            setLogsByServer(prev => ({ ...prev, [selectedServerId]: [] }));
-                          }}
-                          style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
-                        >
-                          Clear
-                        </button>
-                      )}
+                      {/* Filter pills */}
+                      <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
+                        {([
+                          { key: 'all', label: 'All', count: logs.length },
+                          { key: 'connect', label: 'Connect', count: logs.filter(l => l.type === 'connect').length },
+                          { key: 'tool_call', label: 'Tool', count: logs.filter(l => l.type === 'tool_call' || l.type === 'tool_result').length },
+                          { key: 'tool_error', label: 'Error', count: logs.filter(l => l.type === 'tool_error').length },
+                          { key: 'chat', label: 'Chat', count: logs.filter(l => l.type === 'chat').length },
+                        ] as const).map(pill => (
+                          <button
+                            key={pill.key}
+                            onClick={() => setLogFilter(pill.key)}
+                            style={{
+                              fontSize: "0.65rem", padding: "0.1rem 0.45rem",
+                              borderRadius: "999px", cursor: "pointer",
+                              border: logFilter === pill.key ? "1px solid rgba(99,102,241,0.7)" : "1px solid rgba(63,63,70,0.5)",
+                              background: logFilter === pill.key ? "rgba(99,102,241,0.2)" : "transparent",
+                              color: logFilter === pill.key ? "rgba(165,180,252,1)" : "rgba(255,255,255,0.4)",
+                              fontFamily: "monospace",
+                              transition: "all 0.1s",
+                            }}
+                          >
+                            {pill.label}{pill.count > 0 ? ` (${pill.count})` : ''}
+                          </button>
+                        ))}
+                      </div>
                     </div>
 
                     {/* Logs content */}
@@ -1273,28 +1281,28 @@ export default function MCPInspector() {
                         fontSize: "0.78rem",
                       }}
                     >
-                      {logs.length === 0 ? (
+                      {filteredLogs.length === 0 ? (
                         <div style={{
                           display: "flex", alignItems: "center", justifyContent: "center",
                           height: "100%", color: "rgba(255,255,255,0.35)", fontSize: "0.8rem",
                         }}>
-                          {selectedServer?.session_id ? "No logs yet" : "Connect to a server to see logs"}
+                          {selectedServer?.session_id ? (logFilter !== 'all' ? "No matching logs" : "No logs yet") : "Connect to a server to see logs"}
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-                          {[...logs].reverse().map((log, i) => {
+                          {[...filteredLogs].reverse().map((log, i) => {
                             const color = logColors[log.type] || "#9ca3af";
                             return (
                               <div
                                 key={i}
                                 style={{
                                   display: "grid",
-                                  // Fixed columns: time | type | message
-                                  // time ~70px, type ~90px, message gets rest
                                   gridTemplateColumns: "70px 90px 1fr",
                                   gap: "0.5rem",
                                   paddingBottom: "3px",
                                   borderBottom: "1px solid rgba(63,63,70,0.2)",
+                                  borderLeft: `2px solid ${color}`,
+                                  paddingLeft: "0.4rem",
                                   alignItems: "start",
                                 }}
                               >
@@ -1306,7 +1314,7 @@ export default function MCPInspector() {
                                 <span style={{ color, fontWeight: "700", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                                   {log.type.toUpperCase()}
                                 </span>
-                                {/* Message — grid child auto-constrains width, word-break works correctly */}
+                                {/* Message */}
                                 <span style={{ color: "rgba(255,255,255,0.75)", wordBreak: "break-word", overflowWrap: "break-word" }}>
                                   {log.message}
                                 </span>
@@ -1456,10 +1464,12 @@ export default function MCPInspector() {
                                 return (
                                   <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
                                     <div style={{
-                                      background: "#2563eb", color: "#fff",
-                                      padding: "0.6rem 0.75rem",
-                                      borderRadius: "12px 12px 4px 12px",
-                                      maxWidth: "70%", fontSize: "0.9rem", lineHeight: 1.4
+                                      background: "rgba(37,99,235,0.85)",
+                                      border: "1px solid rgba(59,130,246,0.4)",
+                                      color: "#fff",
+                                      padding: "0.55rem 0.85rem",
+                                      borderRadius: "16px 16px 4px 16px",
+                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
                                     }}>
                                       {msg.content}
                                     </div>
@@ -1469,13 +1479,20 @@ export default function MCPInspector() {
 
                               if (msg.type === "assistant") {
                                 return (
-                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start" }}>
+                                  <div key={msg.id} style={{ display: "flex", justifyContent: "flex-start", gap: "0.5rem", alignItems: "flex-start" }}>
                                     <div style={{
-                                      background: "rgba(99,102,241,0.15)",
-                                      border: "1px solid rgba(99,102,241,0.3)",
-                                      padding: "0.6rem 0.75rem",
-                                      borderRadius: "12px 12px 12px 4px",
-                                      maxWidth: "70%", fontSize: "0.9rem"
+                                      width: "22px", height: "22px", borderRadius: "50%", flexShrink: 0, marginTop: "2px",
+                                      background: "rgba(99,102,241,0.2)", border: "1px solid rgba(99,102,241,0.4)",
+                                      display: "flex", alignItems: "center", justifyContent: "center",
+                                      fontSize: "0.65rem",
+                                    }}>🤖</div>
+                                    <div style={{
+                                      background: "rgba(39,39,42,0.8)",
+                                      border: "1px solid rgba(63,63,70,0.6)",
+                                      padding: "0.55rem 0.85rem",
+                                      borderRadius: "4px 16px 16px 16px",
+                                      maxWidth: "75%", fontSize: "0.875rem", lineHeight: 1.5,
+                                      color: "rgba(255,255,255,0.85)",
                                     }}>
                                       {msg.content}
                                     </div>
@@ -1489,48 +1506,125 @@ export default function MCPInspector() {
                           </div>
 
                           {/* Chat Input — grid row 2 (auto height, always at bottom) */}
-                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem" }}>
-                          {chatHistory.length > 1 && selectedServerId && (
-                            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+                          <div style={{ display: "flex", flexDirection: "column", gap: "0.35rem", paddingTop: "0.5rem", borderTop: "1px solid rgba(63,63,70,0.3)" }}>
+
+                            {/* ── Toolbar row: model badge · system prompt · clear ── */}
+                            <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", paddingTop: "0.3rem" }}>
+                              {/* Model badge */}
+                              <span style={{
+                                fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                background: "rgba(99,102,241,0.12)", border: "1px solid rgba(99,102,241,0.3)",
+                                color: "rgba(165,180,252,0.9)", fontFamily: "monospace", flexShrink: 0,
+                              }}>
+                                Groq · llama-3.1-8b
+                              </span>
+
+                              {/* System prompt button */}
                               <button
-                                onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
-                                style={{ fontSize: "0.7rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.4)", cursor: "pointer", padding: "0.15rem 0.4rem" }}
+                                onClick={() => { setSystemPromptDraft(systemPrompt); setSystemPromptOpen(true); }}
+                                title="System prompt"
+                                style={{
+                                  fontSize: "0.65rem", padding: "0.15rem 0.5rem", borderRadius: "999px",
+                                  background: systemPrompt ? "rgba(99,102,241,0.15)" : "transparent",
+                                  border: systemPrompt ? "1px solid rgba(99,102,241,0.4)" : "1px solid rgba(63,63,70,0.5)",
+                                  color: systemPrompt ? "rgba(165,180,252,0.9)" : "rgba(255,255,255,0.35)",
+                                  cursor: "pointer", flexShrink: 0,
+                                }}
                               >
-                                Clear Chat
+                                ⚙ {systemPrompt ? "Prompt set" : "System prompt"}
                               </button>
+
+                              {/* Spacer */}
+                              <div style={{ flex: 1 }} />
+
+                              {/* Clear chat */}
+                              {chatHistory.length > 1 && selectedServerId && (
+                                <button
+                                  onClick={() => setChatHistoryByServer(prev => ({ ...prev, [selectedServerId]: [] }))}
+                                  style={{ fontSize: "0.65rem", background: "none", border: "1px solid rgba(63,63,70,0.5)", borderRadius: "4px", color: "rgba(255,255,255,0.35)", cursor: "pointer", padding: "0.1rem 0.4rem", flexShrink: 0 }}
+                                >
+                                  Clear Chat
+                                </button>
+                              )}
                             </div>
-                          )}
+
+                            {/* ── System prompt dialog overlay ── */}
+                            {systemPromptOpen && (
+                              <div style={{
+                                position: "fixed", inset: 0, zIndex: 50,
+                                background: "rgba(0,0,0,0.6)", display: "flex", alignItems: "center", justifyContent: "center",
+                              }}
+                                onClick={(e) => { if (e.target === e.currentTarget) setSystemPromptOpen(false); }}
+                              >
+                                <div style={{
+                                  background: "#18181b", border: "1px solid rgba(63,63,70,0.7)",
+                                  borderRadius: "12px", padding: "1.25rem", width: "420px", maxWidth: "90vw",
+                                  display: "flex", flexDirection: "column", gap: "0.75rem",
+                                }}>
+                                  <div style={{ fontSize: "0.9rem", fontWeight: 600, color: "rgba(255,255,255,0.85)" }}>System Prompt</div>
+                                  <textarea
+                                    value={systemPromptDraft}
+                                    onChange={e => setSystemPromptDraft(e.target.value)}
+                                    placeholder="You are a helpful assistant with access to MCP tools."
+                                    rows={5}
+                                    style={{
+                                      background: "#09090b", border: "1px solid rgba(63,63,70,0.6)",
+                                      borderRadius: "6px", padding: "0.5rem 0.6rem",
+                                      color: "#fff", fontSize: "0.8rem", resize: "vertical",
+                                      fontFamily: "inherit", lineHeight: 1.5,
+                                    }}
+                                  />
+                                  <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+                                    <button
+                                      onClick={() => setSystemPromptOpen(false)}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "transparent", border: "1px solid rgba(63,63,70,0.5)", color: "rgba(255,255,255,0.5)", cursor: "pointer" }}
+                                    >
+                                      Cancel
+                                    </button>
+                                    <button
+                                      onClick={() => { setSystemPrompt(systemPromptDraft); setSystemPromptOpen(false); }}
+                                      style={{ fontSize: "0.75rem", padding: "0.35rem 0.75rem", borderRadius: "6px", background: "rgba(99,102,241,0.8)", border: "none", color: "#fff", cursor: "pointer", fontWeight: 600 }}
+                                    >
+                                      Save
+                                    </button>
+                                  </div>
+                                </div>
+                              </div>
+                            )}
+
+                            {/* ── Message input row ── */}
                           <div style={{ display: "flex", gap: "0.5rem" }}>
                             <input
                               value={chatInput}
                               disabled={chatLoading}
                               onChange={(e) => setChatInput(e.target.value)}
                               placeholder="Ask something..."
-                              onKeyDown={(e) => { 
+                              onKeyDown={(e) => {
                                 if (e.key === "Enter" && !e.shiftKey && chatInput.trim()) {
-                                  e.preventDefault(); 
+                                  e.preventDefault();
                                   runChatTool();
-                                } 
+                                }
                               }}
                               style={{
-                                flex: 1, minWidth: 0, padding: "0.5rem",
-                                borderRadius: "0.35rem", border: "1px solid rgba(63,63,70,0.6)",
-                                background: "#09090b", color: "#fff", opacity: chatLoading ? 0.6 : 1,
+                                flex: 1, minWidth: 0, padding: "0.5rem 0.75rem",
+                                borderRadius: "0.5rem", border: "1px solid rgba(63,63,70,0.6)",
+                                background: "rgba(24,24,27,0.8)", color: "#fff", opacity: chatLoading ? 0.6 : 1,
+                                fontSize: "0.875rem",
                               }}
                             />
                             <button
-                              onClick={()=>{
-                                if (chatInput.trim()) runChatTool();
-                              }}
+                              onClick={()=>{ if (chatInput.trim()) runChatTool(); }}
                               disabled={chatLoading || !chatInput.trim()}
                               style={{
-                                padding: "0.5rem 0.75rem", borderRadius: "0.35rem",
-                                background: "#fff", color: "#000", fontWeight: "600", flexShrink: 0,
-                                opacity: chatLoading || !chatInput.trim() ? 0.6 : 1,
-                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer"
+                                padding: "0.5rem 1rem", borderRadius: "0.5rem",
+                                background: "rgba(99,102,241,0.9)", color: "#fff", fontWeight: "600", flexShrink: 0,
+                                border: "none",
+                                opacity: chatLoading || !chatInput.trim() ? 0.45 : 1,
+                                cursor: chatLoading || !chatInput.trim() ? "not-allowed" : "pointer",
+                                fontSize: "0.875rem",
                               }}
                             >
-                              {chatLoading ? "Thinking..." : "Send"}
+                              {chatLoading ? <ThinkingDots /> : "Send"}
                             </button>
                           </div>
                           </div>

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -341,6 +341,8 @@ export default function MCPInspector() {
   const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [url, setUrl] = useState("");
+  const [command, setCommand] = useState("");
+  const [envVars, setEnvVars] = useState<{ key: string; value: string }[]>([]);
   const [customName, setCustomName] = useState("");
   const [transport, setTransport] = useState("http");
 
@@ -451,19 +453,22 @@ export default function MCPInspector() {
 
   const handleConnect = async () => {
 
-    if (!url) return;
-    if (authType === "bearer" && !token) {
-      alert("Please enter bearer token")
-      return
-    }
-
-    if (authType === "header" && (!headerKey || !headerValue)) {
-      alert("Please enter header key and value")
-      return
-    }
-    if (servers.some(s => s.url === url && s.status !== "failed")) {
-      alert("Server already added");
-      return;
+    if (transport === "stdio") {
+      if (!command.trim()) return;
+    } else {
+      if (!url) return;
+      if (authType === "bearer" && !token) {
+        alert("Please enter bearer token")
+        return
+      }
+      if (authType === "header" && (!headerKey || !headerValue)) {
+        alert("Please enter header key and value")
+        return
+      }
+      if (servers.some(s => s.url === url && s.status !== "failed")) {
+        alert("Server already added");
+        return;
+      }
     }
 
     // Disconnect any currently connected server before adding a new one
@@ -496,22 +501,32 @@ export default function MCPInspector() {
     try {
       setConnecting(true);
 
+      const serverUrl = transport === "stdio" ? `stdio://${command.trim().split(" ")[0]}` : url;
+
       setServers(prev => [
-        ...prev.filter(s => !(s.url === url && s.status === "failed")),
-        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const, auth: authConfig,
-          ...(customName.trim() ? { name: customName.trim() } : {})
+        ...prev.filter(s => !(s.url === serverUrl && s.status === "failed")),
+        { id: serverId, session_id: null, url: serverUrl, transport, tools: [], status: "connecting" as const, auth: authConfig,
+          ...(customName.trim() ? { name: customName.trim() } : {}),
+          ...(transport === "stdio" ? { name: customName.trim() || command.trim().split(" ").slice(0, 3).join(" ") } : {}),
         },
       ]);
 
-      const payload: any = { url, transport }
+      const envVarsObj = envVars.reduce((acc, { key, value }) => {
+        if (key.trim()) acc[key.trim()] = value;
+        return acc;
+      }, {} as Record<string, string>);
 
-      // Bearer Token
-      if (authType === "bearer" && token) {
-        payload.auth = {type: "bearer", token: token }
+      const payload: any = transport === "stdio"
+        ? { command: command.trim(), transport, ...(Object.keys(envVarsObj).length ? { env_vars: envVarsObj } : {}) }
+        : { url, transport }
+
+      // Bearer Token (not applicable for stdio)
+      if (transport !== "stdio" && authType === "bearer" && token) {
+        payload.auth = { type: "bearer", token: token }
       }
 
-      // Header Token
-      if (authType === "header" && headerKey && headerValue) {
+      // Header Token (not applicable for stdio)
+      if (transport !== "stdio" && authType === "header" && headerKey && headerValue) {
         payload.headers = { [headerKey]: headerValue }
       }
 
@@ -549,12 +564,14 @@ export default function MCPInspector() {
         }]
       }));
 
-      addRecentUrl(url);
+      if (transport !== "stdio") addRecentUrl(url);
       setAuthType("none")
       setToken("")
       setHeaderKey("")
       setHeaderValue("")
       setCustomName("")
+      setCommand("")
+      setEnvVars([])
       setShowAddModal(false);
       setUrl("");
       setTransport("http");
@@ -2380,8 +2397,8 @@ export default function MCPInspector() {
       {/* ── ADD SERVER MODAL ─────────────────────────────────────────────── */}
       {showAddModal && (
         <div
-          onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
-          onKeyDown={(e) => { if (e.key === "Escape") { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); } }}
+          onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
+          onKeyDown={(e) => { if (e.key === "Escape") { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); } }}
           style={{
             position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)",
             display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000,
@@ -2415,51 +2432,16 @@ export default function MCPInspector() {
               </div>
 
               <div>
-                <input
-                  placeholder="Server URL"
-                  style={{
-                    width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
-                    border: "1px solid rgba(63,63,70,0.6)",
-                    background: "#09090b", color: "#fff", boxSizing: "border-box",
-                  }}
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                />
-                {recentUrls.length > 0 && (
-                  <div style={{ marginTop: "0.4rem", display: "flex", flexWrap: "wrap", gap: "0.35rem" }}>
-                    <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.35)", alignSelf: "center" }}>Recent:</span>
-                    {recentUrls.map(u => (
-                      <button
-                        key={u}
-                        type="button"
-                        onClick={() => setUrl(u)}
-                        style={{
-                          fontSize: "0.72rem", padding: "0.15rem 0.5rem",
-                          borderRadius: "999px", border: "1px solid rgba(99,102,241,0.35)",
-                          background: url === u ? "rgba(99,102,241,0.2)" : "rgba(99,102,241,0.07)",
-                          color: "rgba(200,200,255,0.75)", cursor: "pointer",
-                          maxWidth: "200px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-                        }}
-                        title={u}
-                      >
-                        {u.replace(/^https?:\/\//, "").slice(0, 35)}{u.replace(/^https?:\/\//, "").length > 35 ? "…" : ""}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              <div>
                 <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", marginBottom: "0.3rem" }}>
                   <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)" }}>Transport</label>
                   <span
-                    title="HTTP: stateless request/response, simpler. SSE: persistent connection (Server-Sent Events), required for servers that push notifications."
+                    title="HTTP: stateless request/response. SSE: persistent connection for servers that push notifications. stdio: spawn a local MCP server by command (e.g. npx -y @modelcontextprotocol/server-filesystem /tmp)."
                     style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)", cursor: "help", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "50%", width: "14px", height: "14px", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}
                   >?</span>
                 </div>
                 <select
                   value={transport}
-                  onChange={(e) => setTransport(e.target.value)}
+                  onChange={(e) => { setTransport(e.target.value); setUrl(""); setCommand(""); }}
                   style={{
                     width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
                     border: "1px solid rgba(63,63,70,0.6)",
@@ -2468,102 +2450,205 @@ export default function MCPInspector() {
                 >
                   <option value="http">HTTP</option>
                   <option value="sse">SSE</option>
+                  <option value="stdio">STDIO (local subprocess)</option>
                 </select>
               </div>
 
-              {/* Auth Type */}
-              <div style={{ marginTop: "1rem" }}>
-                <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
-                  Auth Type
-                </label>
-
-                <select
-                  value={authType}
-                  onChange={(e) => setAuthType(e.target.value as any)}
-                  style={{
-                    width: "100%",
-                    marginTop: "0.3rem",
-                    padding: "0.5rem",
-                    borderRadius: "0.4rem",
-                    background: "#18181b",
-                    color: "#fff",
-                    border: "1px solid rgba(63,63,70,0.6)"
-                  }}
-                >
-                  <option value="none">None</option>
-                  <option value="bearer">Bearer Token</option>
-                  <option value="header">Header Token</option>
-                </select>
-              </div>
-
-              {authType === "bearer" && (
-                <div style={{ marginTop: "0.8rem" }}>
-                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
-                    Token
+              {transport === "stdio" ? (
+                <div>
+                  <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)", marginBottom: "0.3rem", display: "block" }}>
+                    Command
                   </label>
                   <input
-                    type="password"
-                    value={token}
-                    onChange={(e) => setToken(e.target.value)}
-                    placeholder="Enter bearer token"
+                    placeholder="npx -y @modelcontextprotocol/server-filesystem /tmp"
                     style={{
-                      width: "100%",
-                      marginTop: "0.3rem",
-                      padding: "0.5rem",
-                      borderRadius: "0.4rem",
-                      background: "#18181b",
-                      color: "#fff",
-                      border: "1px solid rgba(63,63,70,0.6)"
+                      width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: "#09090b", color: "#fff", boxSizing: "border-box",
+                      fontFamily: "ui-monospace, monospace", fontSize: "0.8rem",
                     }}
+                    value={command}
+                    onChange={(e) => setCommand(e.target.value)}
                   />
+                  <p style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.3)", marginTop: "0.3rem", marginBottom: 0 }}>
+                    The server will be spawned as a subprocess on the FluidMCP backend machine.
+                  </p>
+
+                  {/* Environment Variables */}
+                  <div style={{ marginTop: "0.9rem" }}>
+                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.4rem" }}>
+                      <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)" }}>
+                        Environment Variables <span style={{ color: "rgba(255,255,255,0.25)", fontWeight: 400 }}>(optional)</span>
+                        <span
+                          title="Env vars are passed to the subprocess at spawn time and cannot be changed while the server is running. Reconnect to update them."
+                          style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)", cursor: "help", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "50%", width: "14px", height: "14px", display: "inline-flex", alignItems: "center", justifyContent: "center", marginLeft: "0.3rem", flexShrink: 0 }}
+                        >?</span>
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => setEnvVars(prev => [...prev, { key: "", value: "" }])}
+                        style={{
+                          fontSize: "0.72rem", padding: "0.2rem 0.55rem",
+                          borderRadius: "0.3rem", border: "1px solid rgba(99,102,241,0.4)",
+                          background: "rgba(99,102,241,0.1)", color: "rgba(200,200,255,0.8)",
+                          cursor: "pointer",
+                        }}
+                      >+ Add</button>
+                    </div>
+                    {envVars.map((ev, i) => (
+                      <div key={i} style={{ display: "flex", gap: "0.4rem", marginBottom: "0.35rem", alignItems: "center" }}>
+                        <input
+                          placeholder="KEY"
+                          value={ev.key}
+                          onChange={(e) => setEnvVars(prev => prev.map((x, j) => j === i ? { ...x, key: e.target.value } : x))}
+                          style={{
+                            flex: "0 0 38%", padding: "0.4rem 0.5rem", borderRadius: "0.3rem",
+                            border: "1px solid rgba(63,63,70,0.6)", background: "#09090b",
+                            color: "#fff", fontSize: "0.78rem", fontFamily: "ui-monospace, monospace",
+                          }}
+                        />
+                        <input
+                          placeholder="value"
+                          value={ev.value}
+                          onChange={(e) => setEnvVars(prev => prev.map((x, j) => j === i ? { ...x, value: e.target.value } : x))}
+                          style={{
+                            flex: 1, padding: "0.4rem 0.5rem", borderRadius: "0.3rem",
+                            border: "1px solid rgba(63,63,70,0.6)", background: "#09090b",
+                            color: "#fff", fontSize: "0.78rem",
+                          }}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setEnvVars(prev => prev.filter((_, j) => j !== i))}
+                          style={{
+                            background: "transparent", border: "none", color: "rgba(255,100,100,0.6)",
+                            cursor: "pointer", fontSize: "1rem", lineHeight: 1, padding: "0 0.2rem",
+                          }}
+                        >×</button>
+                      </div>
+                    ))}
+                    {envVars.length === 0 && (
+                      <p style={{ fontSize: "0.71rem", color: "rgba(255,255,255,0.2)", marginTop: "0.2rem", marginBottom: 0 }}>
+                        e.g. API_KEY, OPENAI_API_KEY, …
+                      </p>
+                    )}
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <input
+                    placeholder="Server URL"
+                    style={{
+                      width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
+                      border: "1px solid rgba(63,63,70,0.6)",
+                      background: "#09090b", color: "#fff", boxSizing: "border-box",
+                    }}
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                  />
+                  {recentUrls.length > 0 && (
+                    <div style={{ marginTop: "0.4rem", display: "flex", flexWrap: "wrap", gap: "0.35rem" }}>
+                      <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.35)", alignSelf: "center" }}>Recent:</span>
+                      {recentUrls.map(u => (
+                        <button
+                          key={u}
+                          type="button"
+                          onClick={() => setUrl(u)}
+                          style={{
+                            fontSize: "0.72rem", padding: "0.15rem 0.5rem",
+                            borderRadius: "999px", border: "1px solid rgba(99,102,241,0.35)",
+                            background: url === u ? "rgba(99,102,241,0.2)" : "rgba(99,102,241,0.07)",
+                            color: "rgba(200,200,255,0.75)", cursor: "pointer",
+                            maxWidth: "200px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                          }}
+                          title={u}
+                        >
+                          {u.replace(/^https?:\/\//, "").slice(0, 35)}{u.replace(/^https?:\/\//, "").length > 35 ? "…" : ""}
+                        </button>
+                      ))}
+                    </div>
+                  )}
                 </div>
               )}
 
-              {authType === "header" && (
-                <div style={{ marginTop: "0.8rem" }}>
-                  
-                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
-                    Header Key
-                  </label>
-                  <input
-                    value={headerKey}
-                    onChange={(e) => setHeaderKey(e.target.value)}
-                    placeholder="X-Api-Key"
-                    style={{
-                      width: "100%",
-                      marginTop: "0.3rem",
-                      padding: "0.5rem",
-                      borderRadius: "0.4rem",
-                      background: "#18181b",
-                      color: "#fff",
-                      border: "1px solid rgba(63,63,70,0.6)"
-                    }}
-                  />
+              {/* Auth — not shown for stdio (local subprocess, no auth needed) */}
+              {transport !== "stdio" && (
+                <>
+                  <div style={{ marginTop: "1rem" }}>
+                    <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                      Auth Type
+                    </label>
+                    <select
+                      value={authType}
+                      onChange={(e) => setAuthType(e.target.value as any)}
+                      style={{
+                        width: "100%", marginTop: "0.3rem", padding: "0.5rem",
+                        borderRadius: "0.4rem", background: "#18181b", color: "#fff",
+                        border: "1px solid rgba(63,63,70,0.6)"
+                      }}
+                    >
+                      <option value="none">None</option>
+                      <option value="bearer">Bearer Token</option>
+                      <option value="header">Header Token</option>
+                    </select>
+                  </div>
 
-                  <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)", marginTop: "0.5rem", display: "block" }}>
-                    Header Value
-                  </label>
-                  <input
-                    type="password"
-                    value={headerValue}
-                    onChange={(e) => setHeaderValue(e.target.value)}
-                    placeholder="Enter token"
-                    style={{
-                      width: "100%",
-                      marginTop: "0.3rem",
-                      padding: "0.5rem",
-                      borderRadius: "0.4rem",
-                      background: "#18181b",
-                      color: "#fff",
-                      border: "1px solid rgba(63,63,70,0.6)"
-                    }}
-                  />
-                </div>
+                  {authType === "bearer" && (
+                    <div style={{ marginTop: "0.8rem" }}>
+                      <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                        Token
+                      </label>
+                      <input
+                        type="password"
+                        value={token}
+                        onChange={(e) => setToken(e.target.value)}
+                        placeholder="Enter bearer token"
+                        style={{
+                          width: "100%", marginTop: "0.3rem", padding: "0.5rem",
+                          borderRadius: "0.4rem", background: "#18181b", color: "#fff",
+                          border: "1px solid rgba(63,63,70,0.6)"
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  {authType === "header" && (
+                    <div style={{ marginTop: "0.8rem" }}>
+                      <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)" }}>
+                        Header Key
+                      </label>
+                      <input
+                        value={headerKey}
+                        onChange={(e) => setHeaderKey(e.target.value)}
+                        placeholder="X-Api-Key"
+                        style={{
+                          width: "100%", marginTop: "0.3rem", padding: "0.5rem",
+                          borderRadius: "0.4rem", background: "#18181b", color: "#fff",
+                          border: "1px solid rgba(63,63,70,0.6)"
+                        }}
+                      />
+                      <label style={{ fontSize: "0.85rem", color: "rgba(255,255,255,0.7)", marginTop: "0.5rem", display: "block" }}>
+                        Header Value
+                      </label>
+                      <input
+                        type="password"
+                        value={headerValue}
+                        onChange={(e) => setHeaderValue(e.target.value)}
+                        placeholder="Enter token"
+                        style={{
+                          width: "100%", marginTop: "0.3rem", padding: "0.5rem",
+                          borderRadius: "0.4rem", background: "#18181b", color: "#fff",
+                          border: "1px solid rgba(63,63,70,0.6)"
+                        }}
+                      />
+                    </div>
+                  )}
+                </>
               )}
               <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
                 <button
                   type="button"
-                  onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
+                  onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setCommand(""); setEnvVars([]); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
                   style={{
                     background: "transparent", border: "1px solid rgba(63,63,70,0.6)",
                     padding: "0.5rem 1rem", borderRadius: "0.4rem", color: "#fff",

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1505,16 +1505,6 @@ export default function MCPInspector() {
                                         overflow: "hidden",
                                         background: "rgba(99,102,241,0.04)",
                                       }}>
-                                        <div style={{
-                                          padding: "0.4rem 0.75rem",
-                                          borderBottom: "1px solid rgba(99,102,241,0.15)",
-                                          fontSize: "0.72rem", fontWeight: 600,
-                                          color: "rgba(99,102,241,0.8)",
-                                          display: "flex", alignItems: "center", gap: "0.4rem",
-                                          background: "rgba(99,102,241,0.06)",
-                                        }}>
-                                          <span>⬡</span> Widget
-                                        </div>
                                         <WidgetSandbox
                                           sessionId={sessionId!}
                                           resourceUri={toolResult!.resourceUri!}

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -269,6 +269,7 @@ interface MCPServer {
   server_info?: any;
   tools: any[];
   url: string;
+  command?: string;    // stdio only — the full command string used to spawn the process
   transport: string;
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
   connectedAt?: number; // timestamp (ms) when status became "connected"
@@ -507,7 +508,7 @@ export default function MCPInspector() {
         ...prev.filter(s => !(s.url === serverUrl && s.status === "failed")),
         { id: serverId, session_id: null, url: serverUrl, transport, tools: [], status: "connecting" as const, auth: authConfig,
           ...(customName.trim() ? { name: customName.trim() } : {}),
-          ...(transport === "stdio" ? { name: customName.trim() || command.trim().split(" ").slice(0, 3).join(" ") } : {}),
+          ...(transport === "stdio" ? { name: customName.trim() || command.trim().split(" ").slice(0, 3).join(" "), command: command.trim() } : {}),
         },
       ]);
 
@@ -637,22 +638,22 @@ export default function MCPInspector() {
             : s
         )
       );
-      // Build payload with auth
-      const payload: any = {
-        url: server.url,
-        transport: server.transport,
-      };
+      // Build payload — stdio uses command, http/sse use url
+      const payload: any = server.transport === "stdio"
+        ? { command: server.command, transport: server.transport }
+        : { url: server.url, transport: server.transport };
 
-      // Bearer
-      if (server.auth?.type === "bearer" && server.auth.token) {
+      // Bearer (not applicable for stdio)
+      if (server.transport !== "stdio" && server.auth?.type === "bearer" && server.auth.token) {
         payload.auth = {
           type: "bearer",
           token: server.auth.token,
         };
       }
 
-      // Header
+      // Header (not applicable for stdio)
       if (
+        server.transport !== "stdio" &&
         server.auth?.type === "header" &&
         server.auth.headerKey &&
         server.auth.headerValue
@@ -1018,7 +1019,10 @@ export default function MCPInspector() {
         : { height: "100vh", display: "flex", flexDirection: "column", overflow: "hidden", maxWidth: "100%", padding: 0 }
       }
     >
-      <style>{`@keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}`}</style>
+      <style>{`
+        @keyframes thinking-blink{0%,100%{opacity:0.2}50%{opacity:1}}
+        html, body { overflow: hidden; height: 100%; }
+      `}</style>
       {!inspectorFullscreen && <Navbar />}
 
       <div style={{ paddingTop: inspectorFullscreen ? "0" : "64px", flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -1648,9 +1652,9 @@ export default function MCPInspector() {
                 </div>
 
                 {/* ── MANUAL MODE ─── */}
-                <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", marginTop: "1rem", minHeight: 0 }}>
+                <div style={{ flex: 1, display: "flex", flexDirection: "column", overflow: "hidden", minHeight: 0 }}>
                   {mode === "manual" && selectedServer && selectedTool && (
-                    <div style={{ overflowY: "auto", flex: 1, minHeight: 0, paddingBottom: "0.5rem" }}>
+                    <div style={{ overflowY: "auto", flex: 1, minHeight: 0, paddingBottom: "0.5rem", marginTop: "1rem" }}>
                       <h3 style={{ marginBottom: "1rem" }}>{selectedTool.name}</h3>
 
                       {selectedServer.status === "connected" ? (
@@ -2145,7 +2149,7 @@ export default function MCPInspector() {
                   {/* Empty states */}
                   {mode === "manual" && (!selectedServer || !selectedTool) && (
                     <div style={{
-                      padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
+                      marginTop: "1rem", padding: "1rem", border: "1px dashed rgba(63,63,70,0.6)",
                       borderRadius: "0.5rem", textAlign: "center", color: "rgba(255,255,255,0.6)",
                     }}>
                       Select a tool to execute

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -265,11 +265,13 @@ import { PanelGroup, Panel , PanelResizeHandle} from 'react-resizable-panels';
 interface MCPServer {
   id: string;
   session_id: string | null;
+  name?: string;       // optional custom display name (overrides server_info.name)
   server_info?: any;
   tools: any[];
   url: string;
   transport: string;
   status: 'connecting' | 'connected' | 'disconnected' | 'failed';
+  connectedAt?: number; // timestamp (ms) when status became "connected"
   error?: string;
   auth?: {
     type: "none" | "bearer" | "header"
@@ -317,6 +319,17 @@ interface MCPResource {
 // Helper to generate unique server IDs
 const generateServerId = () => `server_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
 
+/** Returns a compact relative time string, e.g. "2m ago", "1h ago", "just now" */
+function relativeTime(ts: number): string {
+  const secs = Math.floor((Date.now() - ts) / 1000);
+  if (secs < 10) return "just now";
+  if (secs < 60) return `${secs}s ago`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  return `${hrs}h ago`;
+}
+
 export default function MCPInspector() {
 
   const [authType, setAuthType] = useState<"none" | "bearer" | "header">("none")
@@ -328,7 +341,21 @@ export default function MCPInspector() {
   const [inspectorFullscreen, setInspectorFullscreen] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [url, setUrl] = useState("");
+  const [customName, setCustomName] = useState("");
   const [transport, setTransport] = useState("http");
+
+  // Recently connected URLs (up to 3) — persisted in localStorage, no auth data stored
+  const [recentUrls, setRecentUrls] = useState<string[]>(() => {
+    try { return JSON.parse(localStorage.getItem("mcp_inspector_recent_urls") || "[]"); }
+    catch { return []; }
+  });
+  const addRecentUrl = (newUrl: string) => {
+    setRecentUrls(prev => {
+      const updated = [newUrl, ...prev.filter(u => u !== newUrl)].slice(0, 3);
+      try { localStorage.setItem("mcp_inspector_recent_urls", JSON.stringify(updated)); } catch {}
+      return updated;
+    });
+  };
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [connecting, setConnecting] = useState(false);
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
@@ -375,11 +402,16 @@ export default function MCPInspector() {
   const logsClearedOffsetRef = useRef<Record<string, number>>({})
   // 5B: Log filter pill state
   const [logFilter, setLogFilter] = useState<'all' | 'connect' | 'tool_call' | 'tool_error' | 'chat'>('all')
-  const filteredLogs = logFilter === 'all' ? logs : logs.filter(l =>
-    logFilter === 'tool_error' ? (l.type === 'tool_error') :
-    logFilter === 'tool_call' ? (l.type === 'tool_call' || l.type === 'tool_result') :
-    l.type === logFilter
-  )
+  const [logSearch, setLogSearch] = useState('')
+  const [toolSearch, setToolSearch] = useState('')
+  const filteredLogs = logs.filter(l => {
+    const matchesType = logFilter === 'all' ? true
+      : logFilter === 'tool_error' ? l.type === 'tool_error'
+      : logFilter === 'tool_call' ? (l.type === 'tool_call' || l.type === 'tool_result')
+      : l.type === logFilter;
+    const matchesSearch = logSearch.trim() === '' || l.message.toLowerCase().includes(logSearch.toLowerCase());
+    return matchesType && matchesSearch;
+  })
 
   // 3A-3: Per-server chat memory
   const [chatHistoryByServer, setChatHistoryByServer] = useState<Record<string, ChatMessage[]>>({})
@@ -400,6 +432,13 @@ export default function MCPInspector() {
         : updater
     }));
   };
+
+  // Tick every 30s to refresh relative timestamps on server cards
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick(t => t + 1), 30_000);
+    return () => clearInterval(id);
+  }, []);
 
   const [chatLoading, setChatLoading] = useState(false)
   const [panelSizes, setPanelSizes] = useState({
@@ -459,7 +498,8 @@ export default function MCPInspector() {
 
       setServers(prev => [
         ...prev.filter(s => !(s.url === url && s.status === "failed")),
-        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const, auth : authConfig
+        { id: serverId, session_id: null, url, transport, tools: [], status: "connecting" as const, auth: authConfig,
+          ...(customName.trim() ? { name: customName.trim() } : {})
         },
       ]);
 
@@ -481,10 +521,14 @@ export default function MCPInspector() {
       // Reset log offset for this server — new session, fresh log stream
       logsClearedOffsetRef.current = { ...logsClearedOffsetRef.current, [serverId]: 0 };
 
+      const displayName = customName.trim() || res.server_info?.name || "new server";
+
       setServers(prev =>
         prev.map(s =>
           s.id === serverId
-            ? { ...s, session_id: res.session_id, server_info: res.server_info, tools: res.tools || [], status: "connected" as const }
+            ? { ...s, session_id: res.session_id, server_info: res.server_info, tools: res.tools || [], status: "connected" as const,
+                connectedAt: Date.now(),
+                ...(customName.trim() ? { name: customName.trim() } : {}) }
             : s
         )
       );
@@ -500,15 +544,17 @@ export default function MCPInspector() {
         [serverId]: [{
           id: crypto.randomUUID(),
           type: "assistant",
-          content: `Connected to ${res.server_info?.name || "new server"}. Chat cleared — ready to go!`,
+          content: `Connected to ${displayName}. Chat cleared — ready to go!`,
           timestamp: Date.now(),
         }]
       }));
 
+      addRecentUrl(url);
       setAuthType("none")
       setToken("")
       setHeaderKey("")
       setHeaderValue("")
+      setCustomName("")
       setShowAddModal(false);
       setUrl("");
       setTransport("http");
@@ -612,6 +658,7 @@ export default function MCPInspector() {
                 server_info: res.server_info,
                 tools: res.tools || [],
                 status: 'connected' as const,
+                connectedAt: Date.now(),
               }
             : s
         )
@@ -1128,6 +1175,7 @@ export default function MCPInspector() {
                                 setSelectedTool(null);
                                 setToolResult(null);
                                 setToolError(null);
+                                setToolSearch('');
                                 // 3A-3: preserve chat history on switch (no reset)
                                 
                               }}
@@ -1145,7 +1193,7 @@ export default function MCPInspector() {
                               {/* HEADER */}
                               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
                                 <div style={{ fontWeight: "600", fontSize: "0.9rem" }}>
-                                  {server?.server_info?.name || "MCP Server"}
+                                  {server?.name || server?.server_info?.name || "MCP Server"}
                                 </div>
                                 <span
                                   style={{
@@ -1172,8 +1220,14 @@ export default function MCPInspector() {
                               >
                                 {server.url}
                               </div>
-                              <div style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)" }}>
-                                transport: {server.transport}
+                              <div style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.4)", display: "flex", gap: "0.6rem", flexWrap: "wrap", marginTop: "0.15rem" }}>
+                                <span>transport: {server.transport}</span>
+                                {server.status === "connected" && server.tools.length > 0 && (
+                                  <span style={{ color: "rgba(99,102,241,0.8)" }}>{server.tools.length} tool{server.tools.length !== 1 ? "s" : ""}</span>
+                                )}
+                                {server.status === "connected" && server.connectedAt && (
+                                  <span style={{ color: "rgba(34,197,94,0.6)" }}>● {relativeTime(server.connectedAt)}</span>
+                                )}
                               </div>
 
                               {/* ERROR */}
@@ -1250,7 +1304,33 @@ export default function MCPInspector() {
                               </div>
 
                               {/* TOOLS (only show when selected) */}
-                              {isSelected && server?.tools?.map((tool: any) => (
+                              {isSelected && (server?.tools?.length ?? 0) > 0 && (
+                                <div style={{ margin: "0.4rem 0.5rem 0.2rem", position: "relative" }}>
+                                  <input
+                                    value={toolSearch}
+                                    onChange={e => setToolSearch(e.target.value)}
+                                    placeholder="Search tools..."
+                                    onClick={e => e.stopPropagation()}
+                                    style={{
+                                      width: "100%", boxSizing: "border-box",
+                                      padding: "0.25rem 1.4rem 0.25rem 1.5rem",
+                                      fontSize: "0.7rem", borderRadius: "4px",
+                                      border: "1px solid rgba(63,63,70,0.5)",
+                                      background: "rgba(0,0,0,0.25)", color: "#fff",
+                                    }}
+                                  />
+                                  <span style={{ position: "absolute", left: "0.4rem", top: "50%", transform: "translateY(-50%)", fontSize: "0.65rem", color: "rgba(255,255,255,0.3)", pointerEvents: "none" }}>⌕</span>
+                                  {toolSearch && (
+                                    <span
+                                      onClick={e => { e.stopPropagation(); setToolSearch(''); }}
+                                      style={{ position: "absolute", right: "0.4rem", top: "50%", transform: "translateY(-50%)", fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", cursor: "pointer", lineHeight: 1 }}
+                                    >✕</span>
+                                  )}
+                                </div>
+                              )}
+                              {isSelected && server?.tools?.filter((t: any) =>
+                                toolSearch.trim() === '' || t.name.toLowerCase().includes(toolSearch.toLowerCase()) || (t.description ?? '').toLowerCase().includes(toolSearch.toLowerCase())
+                              ).map((tool: any) => (
                                 <div
                                   key={tool.name}
                                   onClick={(e) => {
@@ -1340,6 +1420,28 @@ export default function MCPInspector() {
                           </button>
                         )}
                       </div>
+                      {/* Log search input */}
+                      <div style={{ position: "relative", marginBottom: "0.35rem" }}>
+                        <input
+                          value={logSearch}
+                          onChange={e => setLogSearch(e.target.value)}
+                          placeholder="Search logs..."
+                          style={{
+                            width: "100%", boxSizing: "border-box",
+                            padding: "0.2rem 1.4rem 0.2rem 1.5rem",
+                            fontSize: "0.68rem", borderRadius: "4px",
+                            border: "1px solid rgba(63,63,70,0.5)",
+                            background: "rgba(0,0,0,0.25)", color: "#fff",
+                          }}
+                        />
+                        <span style={{ position: "absolute", left: "0.4rem", top: "50%", transform: "translateY(-50%)", fontSize: "0.65rem", color: "rgba(255,255,255,0.3)", pointerEvents: "none" }}>⌕</span>
+                        {logSearch && (
+                          <span
+                            onClick={() => setLogSearch('')}
+                            style={{ position: "absolute", right: "0.4rem", top: "50%", transform: "translateY(-50%)", fontSize: "0.65rem", color: "rgba(255,255,255,0.4)", cursor: "pointer", lineHeight: 1 }}
+                          >✕</span>
+                        )}
+                      </div>
                       {/* Filter pills */}
                       <div style={{ display: "flex", gap: "0.3rem", flexWrap: "wrap" }}>
                         {([
@@ -1385,7 +1487,7 @@ export default function MCPInspector() {
                           display: "flex", alignItems: "center", justifyContent: "center",
                           height: "100%", color: "rgba(255,255,255,0.35)", fontSize: "0.8rem",
                         }}>
-                          {selectedServer?.session_id ? (logFilter !== 'all' ? "No matching logs" : "No logs yet") : "Connect to a server to see logs"}
+                          {selectedServer?.session_id ? (logFilter !== 'all' || logSearch ? "No matching logs" : "No logs yet") : "Connect to a server to see logs"}
                         </div>
                       ) : (
                         <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
@@ -2278,12 +2380,15 @@ export default function MCPInspector() {
       {/* ── ADD SERVER MODAL ─────────────────────────────────────────────── */}
       {showAddModal && (
         <div
+          onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
+          onKeyDown={(e) => { if (e.key === "Escape") { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); } }}
           style={{
             position: "fixed", inset: 0, background: "rgba(0,0,0,0.6)",
             display: "flex", alignItems: "center", justifyContent: "center", zIndex: 1000,
           }}
         >
           <div
+            onClick={(e) => e.stopPropagation()}
             style={{
               background: "#18181b", padding: "2rem", borderRadius: "0.75rem",
               width: "420px", border: "1px solid rgba(63,63,70,0.6)",
@@ -2291,30 +2396,80 @@ export default function MCPInspector() {
           >
             <h2 style={{ fontSize: "1.3rem", marginBottom: "1rem" }}>Connect MCP Server</h2>
 
-            <div style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
-              <input
-                placeholder="Server URL"
-                style={{
-                  padding: "0.6rem", borderRadius: "0.4rem",
-                  border: "1px solid rgba(63,63,70,0.6)",
-                  background: "#09090b", color: "#fff",
-                }}
-                value={url}
-                onChange={(e) => setUrl(e.target.value)}
-              />
+            <form onSubmit={(e) => { e.preventDefault(); handleConnect(); }} style={{ display: "flex", flexDirection: "column", gap: "1rem" }}>
+              <div>
+                <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)", marginBottom: "0.3rem", display: "block" }}>
+                  Server Name <span style={{ color: "rgba(255,255,255,0.3)" }}>(optional)</span>
+                </label>
+                <input
+                  autoFocus
+                  placeholder="e.g. My Weather Server"
+                  style={{
+                    width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    background: "#09090b", color: "#fff", boxSizing: "border-box",
+                  }}
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                />
+              </div>
 
-              <select
-                value={transport}
-                onChange={(e) => setTransport(e.target.value)}
-                style={{
-                  padding: "0.6rem", borderRadius: "0.4rem",
-                  border: "1px solid rgba(63,63,70,0.6)",
-                  background: "#09090b", color: "#fff",
-                }}
-              >
-                <option value="http">HTTP</option>
-                <option value="sse">SSE</option>
-              </select>
+              <div>
+                <input
+                  placeholder="Server URL"
+                  style={{
+                    width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    background: "#09090b", color: "#fff", boxSizing: "border-box",
+                  }}
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                />
+                {recentUrls.length > 0 && (
+                  <div style={{ marginTop: "0.4rem", display: "flex", flexWrap: "wrap", gap: "0.35rem" }}>
+                    <span style={{ fontSize: "0.72rem", color: "rgba(255,255,255,0.35)", alignSelf: "center" }}>Recent:</span>
+                    {recentUrls.map(u => (
+                      <button
+                        key={u}
+                        type="button"
+                        onClick={() => setUrl(u)}
+                        style={{
+                          fontSize: "0.72rem", padding: "0.15rem 0.5rem",
+                          borderRadius: "999px", border: "1px solid rgba(99,102,241,0.35)",
+                          background: url === u ? "rgba(99,102,241,0.2)" : "rgba(99,102,241,0.07)",
+                          color: "rgba(200,200,255,0.75)", cursor: "pointer",
+                          maxWidth: "200px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+                        }}
+                        title={u}
+                      >
+                        {u.replace(/^https?:\/\//, "").slice(0, 35)}{u.replace(/^https?:\/\//, "").length > 35 ? "…" : ""}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div>
+                <div style={{ display: "flex", alignItems: "center", gap: "0.4rem", marginBottom: "0.3rem" }}>
+                  <label style={{ fontSize: "0.8rem", color: "rgba(255,255,255,0.5)" }}>Transport</label>
+                  <span
+                    title="HTTP: stateless request/response, simpler. SSE: persistent connection (Server-Sent Events), required for servers that push notifications."
+                    style={{ fontSize: "0.7rem", color: "rgba(255,255,255,0.3)", cursor: "help", border: "1px solid rgba(255,255,255,0.2)", borderRadius: "50%", width: "14px", height: "14px", display: "inline-flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}
+                  >?</span>
+                </div>
+                <select
+                  value={transport}
+                  onChange={(e) => setTransport(e.target.value)}
+                  style={{
+                    width: "100%", padding: "0.6rem", borderRadius: "0.4rem",
+                    border: "1px solid rgba(63,63,70,0.6)",
+                    background: "#09090b", color: "#fff",
+                  }}
+                >
+                  <option value="http">HTTP</option>
+                  <option value="sse">SSE</option>
+                </select>
+              </div>
 
               {/* Auth Type */}
               <div style={{ marginTop: "1rem" }}>
@@ -2407,7 +2562,8 @@ export default function MCPInspector() {
               )}
               <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
                 <button
-                  onClick={() => setShowAddModal(false)}
+                  type="button"
+                  onClick={() => { setShowAddModal(false); setCustomName(""); setUrl(""); setTransport("http"); setAuthType("none"); setToken(""); setHeaderKey(""); setHeaderValue(""); }}
                   style={{
                     background: "transparent", border: "1px solid rgba(63,63,70,0.6)",
                     padding: "0.5rem 1rem", borderRadius: "0.4rem", color: "#fff",
@@ -2417,7 +2573,7 @@ export default function MCPInspector() {
                 </button>
 
                 <button
-                  onClick={handleConnect}
+                  type="submit"
                   disabled={connecting}
                   style={{
                     background: "#fff", color: "#000",
@@ -2427,7 +2583,7 @@ export default function MCPInspector() {
                   {connecting ? "Connecting..." : "Connect"}
                 </button>
               </div>
-            </div>
+            </form>
           </div>
         </div>
       )}

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -339,6 +339,17 @@ class ApiClient {
     });
   }
 
+  async listInspectorPrompts(sessionId: string): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/prompts`);
+  }
+
+  async getInspectorPrompt(sessionId: string, name: string, args: Record<string, string>): Promise<any> {
+    return this.request(`/api/inspector/${sessionId}/prompts/get`, {
+      method: "POST",
+      body: JSON.stringify({ name, arguments: args }),
+    });
+  }
+
   /**
    * Clone a GitHub repository and register its MCP server(s).
    *

--- a/fluidmcp/frontend/src/services/api.ts
+++ b/fluidmcp/frontend/src/services/api.ts
@@ -282,7 +282,14 @@ class ApiClient {
   }
 
   // Inspector Tools APIs
-  async connectInspectorServer(payload: { url: string; transport: string }): Promise<any> {
+  async connectInspectorServer(payload: {
+    url?: string;
+    command?: string;
+    transport: string;
+    auth?: { type: string; token?: string };
+    headers?: Record<string, string>;
+    timeout?: number;
+  }): Promise<any> {
     return this.request(`/api/inspector/connect`, {
       method: "POST",
       body: JSON.stringify(payload),

--- a/fluidmcp/frontend/tsconfig.app.json
+++ b/fluidmcp/frontend/tsconfig.app.json
@@ -25,7 +25,6 @@
     "noUncheckedSideEffectImports": true,
 
     /* Path Mappings */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

These PRs were merged in a stacked chain but the final chain tip was never merged into `development`. This PR brings all 6 Inspector phases in at once.

### PRs included (in order)
- #616 — MCP-475: Inspector 3C: Chat revamp, log filters, UI polish
- #617 — MCP-480: Inspector 4A: Widget sandbox scroll/layout fixes
- #623 — MCP-483: Inspector 4B: Resources + Prompts tabs
- #625 — MCP-484: Inspector 4C: Search, custom server name, modal UX polish
- #635 — MCP-486: Inspector 4D: stdio transport — spawn local MCP servers by command
- #637 — MCP-490: Inspector 5A: multi-provider LLM + model selector

### What happened

PR #604 (Phase 3B widget sandbox) was merged into `development` at 19:34:37. PR #616 (Phase 3C) was merged into `mcp-jam-phase3b-widget-sandbox` at 19:34:43 — 6 seconds later — so the whole chain stacked on top of a branch that had already been snapshotted into `development`.

### Test plan
- [ ] MCP Inspector loads correctly
- [ ] Chat tab works (revamped UI from 3C)
- [ ] Resources and Prompts tabs visible
- [ ] Tool search works
- [ ] stdio transport connects to a local MCP server
- [ ] LLM provider selector shows multiple providers