### PR TITLE
MCP-562: feat(debugging): P3 - GET /api/servers/{id}/resources endpoint

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1776,6 +1776,83 @@ async def get_server_stderr(
     return {"server": id, **result}
 
 
+@router.get("/servers/{id}/resources")
+async def get_server_resources(request: Request, id: str):
+    manager = get_server_manager(request)
+
+    config = manager.configs.get(id)
+    if not config:
+        config = await manager.db.get_server_config(id)
+    if not config:
+        raise HTTPException(404, f"Server '{id}' not found")
+
+    process = manager.processes.get(id)
+    pid = getattr(process, "pid", None) if process else None
+
+    memory_limit_mb = (config or {}).get(
+        "memory_limit_mb",
+        int(os.getenv("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0"))
+    )
+    memory_limit_bytes = memory_limit_mb * 1024 * 1024 if memory_limit_mb > 0 else None
+
+    monitor = getattr(manager, "_health_monitor", None)
+    snapshot = monitor._last_resource_snapshot.get(id) if monitor else None
+
+    rss = cpu = open_fds = threads = None
+    status = "not_running"
+    try:
+        import psutil as _psutil
+        if pid and process and process.poll() is None:
+            proc = _psutil.Process(pid)
+            rss = proc.memory_info().rss
+            cpu = proc.cpu_percent(interval=None)
+            open_fds = proc.num_fds() if hasattr(proc, "num_fds") else None
+            threads = proc.num_threads()
+            status = "running"
+        else:
+            raise _psutil.NoSuchProcess(pid or 0)
+    except Exception:
+        if snapshot:
+            rss = snapshot.get("memory_rss_bytes")
+            cpu = snapshot.get("cpu_percent")
+            open_fds = snapshot.get("open_fds")
+        status = "not_running"
+
+    def _human(b: Optional[int]) -> Optional[str]:
+        if b is None:
+            return None
+        for unit in ("B", "KB", "MB", "GB"):
+            if b < 1024:
+                return f"{b:.1f} {unit}"
+            b //= 1024
+        return f"{b:.1f} TB"
+
+    memory_usage_pct = None
+    memory_limit_note = None
+    if memory_limit_bytes:
+        memory_usage_pct = round(rss / memory_limit_bytes * 100, 1) if rss else None
+    else:
+        memory_limit_note = "memory limit not configured — set FMCP_DEFAULT_MEMORY_LIMIT_MB to enable"
+
+    memory_trend = monitor.get_memory_trend(id) if monitor else "unknown"
+
+    return {
+        "server": id,
+        "pid": pid,
+        "status": status,
+        "memory_rss_bytes": rss,
+        "memory_rss_human": _human(rss),
+        "memory_trend": memory_trend,
+        "memory_limit_bytes": memory_limit_bytes,
+        "memory_limit_human": _human(memory_limit_bytes),
+        "memory_usage_pct": memory_usage_pct,
+        "memory_limit_note": memory_limit_note,
+        "cpu_percent": cpu,
+        "open_fds": open_fds,
+        "threads": threads,
+    }
+
+
 # ==================== Environment Variable Management ====================
 
 @router.get("/servers/{id}/instance/env")

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -54,6 +54,13 @@ except ImportError:
 
 from ..services.llm_provider_registry import get_model_type, get_model_config, list_models_by_type
 from ..services.server_manager import classify_exit_code
+
+try:
+    import psutil as _psutil
+    _psutil_available = True
+except ImportError:
+    _psutil = None
+    _psutil_available = False
 from ..services.replicate_openai_adapter import replicate_chat_completion
 from ..services.replicate_client import ReplicateClient, get_replicate_client
 from ..services.llm_metrics import get_metrics_collector
@@ -1801,7 +1808,8 @@ async def get_server_resources(request: Request, id: str):
     rss = cpu = open_fds = threads = None
     status = "not_running"
     try:
-        import psutil as _psutil
+        if not _psutil_available:
+            raise ImportError("psutil not available")
         if pid and process and process.poll() is None:
             proc = _psutil.Process(pid)
             rss = proc.memory_info().rss
@@ -1810,7 +1818,7 @@ async def get_server_resources(request: Request, id: str):
             threads = proc.num_threads()
             status = "running"
         else:
-            raise _psutil.NoSuchProcess(pid or 0)
+            raise RuntimeError("process not running")
     except Exception:
         if snapshot:
             rss = snapshot.get("memory_rss_bytes")

--- a/tests/test_debug_api_resources.py
+++ b/tests/test_debug_api_resources.py
@@ -1,0 +1,186 @@
+"""
+Tests for P3 debugging endpoint:
+- GET /api/servers/{id}/resources
+"""
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fluidmcp.cli.api.management import router
+from fluidmcp.cli.repositories import InMemoryBackend
+from fluidmcp.cli.services.server_manager import ServerManager, MCPHealthMonitor
+
+
+def make_app(server_manager, db_manager):
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.state.server_manager = server_manager
+    app.state.db_manager = db_manager
+    return app
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def client(server_manager, backend):
+    return TestClient(make_app(server_manager, backend))
+
+
+def _register(server_manager, server_id, name="Test", memory_limit_mb=0):
+    server_manager.configs[server_id] = {
+        "id": server_id,
+        "name": name,
+        "memory_limit_mb": memory_limit_mb,
+    }
+
+
+class TestGetServerResources:
+
+    def test_404_for_unknown_server(self, client):
+        resp = client.get("/api/servers/ghost/resources")
+        assert resp.status_code == 404
+
+    def test_not_running_when_no_process(self, client, server_manager):
+        _register(server_manager, "srv1")
+        resp = client.get("/api/servers/srv1/resources")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "not_running"
+        assert data["pid"] is None
+
+    def test_running_server_returns_psutil_data(self, client, server_manager):
+        _register(server_manager, "srv1")
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)  # alive
+        server_manager.processes["srv1"] = mock_process
+
+        mock_proc = Mock()
+        mock_proc.memory_info = Mock(return_value=Mock(rss=52428800))
+        mock_proc.cpu_percent = Mock(return_value=12.5)
+        mock_proc.num_fds = Mock(return_value=24)
+        mock_proc.num_threads = Mock(return_value=4)
+
+        with patch("psutil.Process", return_value=mock_proc):
+            resp = client.get("/api/servers/srv1/resources")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "running"
+        assert data["pid"] == 1234
+        assert data["memory_rss_bytes"] == 52428800
+        assert data["memory_rss_human"] == "50.0 MB"
+        assert data["cpu_percent"] == 12.5
+        assert data["open_fds"] == 24
+        assert data["threads"] == 4
+
+    def test_memory_usage_pct_computed_when_limit_set(self, client, server_manager):
+        _register(server_manager, "srv1", memory_limit_mb=100)
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv1"] = mock_process
+
+        mock_proc = Mock()
+        mock_proc.memory_info = Mock(return_value=Mock(rss=52428800))  # 50MB
+        mock_proc.cpu_percent = Mock(return_value=0.0)
+        mock_proc.num_fds = Mock(return_value=10)
+        mock_proc.num_threads = Mock(return_value=2)
+
+        with patch("psutil.Process", return_value=mock_proc):
+            resp = client.get("/api/servers/srv1/resources")
+
+        data = resp.json()
+        assert data["memory_limit_bytes"] == 100 * 1024 * 1024
+        assert data["memory_limit_human"] == "100.0 MB"
+        assert data["memory_usage_pct"] == 50.0
+        assert data["memory_limit_note"] is None
+
+    def test_memory_limit_note_when_no_limit_configured(self, client, server_manager):
+        _register(server_manager, "srv1", memory_limit_mb=0)
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv1"] = mock_process
+
+        mock_proc = Mock()
+        mock_proc.memory_info = Mock(return_value=Mock(rss=1024))
+        mock_proc.cpu_percent = Mock(return_value=0.0)
+        mock_proc.num_fds = Mock(return_value=5)
+        mock_proc.num_threads = Mock(return_value=1)
+
+        with patch("psutil.Process", return_value=mock_proc):
+            resp = client.get("/api/servers/srv1/resources")
+
+        data = resp.json()
+        assert data["memory_usage_pct"] is None
+        assert data["memory_limit_note"] is not None
+        assert "FMCP_DEFAULT_MEMORY_LIMIT_MB" in data["memory_limit_note"]
+
+    def test_falls_back_to_cached_snapshot_when_process_dead(self, client, server_manager):
+        _register(server_manager, "srv1")
+
+        # Process exists but has exited
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=1)  # dead
+        server_manager.processes["srv1"] = mock_process
+
+        # Health monitor has a cached snapshot
+        mock_monitor = Mock()
+        mock_monitor._last_resource_snapshot = {
+            "srv1": {"memory_rss_bytes": 10485760, "cpu_percent": 5.0, "open_fds": 8}
+        }
+        mock_monitor.get_memory_trend = Mock(return_value="stable")
+        server_manager._health_monitor = mock_monitor
+
+        import psutil
+        with patch("psutil.Process", side_effect=psutil.NoSuchProcess(pid=1234)):
+            resp = client.get("/api/servers/srv1/resources")
+
+        data = resp.json()
+        assert data["status"] == "not_running"
+        assert data["memory_rss_bytes"] == 10485760
+        assert data["cpu_percent"] == 5.0
+
+    def test_memory_trend_from_monitor(self, client, server_manager):
+        _register(server_manager, "srv1")
+
+        mock_monitor = Mock()
+        mock_monitor._last_resource_snapshot = {}
+        mock_monitor.get_memory_trend = Mock(return_value="increasing")
+        server_manager._health_monitor = mock_monitor
+
+        resp = client.get("/api/servers/srv1/resources")
+        assert resp.json()["memory_trend"] == "increasing"
+
+    def test_memory_trend_unknown_when_no_monitor(self, client, server_manager):
+        _register(server_manager, "srv1")
+        # No _health_monitor set
+        resp = client.get("/api/servers/srv1/resources")
+        assert resp.json()["memory_trend"] == "unknown"
+
+    def test_response_has_all_expected_keys(self, client, server_manager):
+        _register(server_manager, "srv1")
+        resp = client.get("/api/servers/srv1/resources")
+        assert resp.status_code == 200
+        keys = resp.json().keys()
+        for expected in [
+            "server", "pid", "status", "memory_rss_bytes", "memory_rss_human",
+            "memory_trend", "memory_limit_bytes", "memory_limit_human",
+            "memory_usage_pct", "memory_limit_note", "cpu_percent",
+            "open_fds", "threads",
+        ]:
+            assert expected in keys, f"missing key: {expected}"


### PR DESCRIPTION
## Summary
Adds a live resource snapshot endpoint per MCP server — lets you identify which MCP is consuming the most memory/CPU without needing shell access.

**Depends on:** #723 (P1), #735 (P2)

## Endpoint

### `GET /api/servers/{id}/resources`
```json
{
  "server": "my-mcp",
  "pid": 12345,
  "status": "running",
  "memory_rss_bytes": 524288000,
  "memory_rss_human": "500.0 MB",
  "memory_trend": "increasing",
  "memory_limit_bytes": 1073741824,
  "memory_limit_human": "1.0 GB",
  "memory_usage_pct": 48.8,
  "memory_limit_note": null,
  "cpu_percent": 23.4,
  "open_fds": 42,
  "threads": 8
}
```

**Behaviour:**
- Live psutil read when server is running
- Falls back to `MCPHealthMonitor` cached snapshot (updated every 30s) when process is dead
- `memory_trend` derived from ring buffer of last 3 RSS readings — no new polling
- `memory_usage_pct` computed only when `memory_limit_mb` is configured
- `memory_limit_note` explains when no limit is set (avoids silent `null` confusion)

## Tests
9 tests in `tests/test_debug_api_resources.py` — 404, not running, live psutil data, memory limit pct, limit note, dead process fallback, trend, unknown trend, all keys present.

Generated with Claude Code