### PR TITLE
MCP-563: feat(debugging): P4 - soft resource throttling and kill policy

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1784,7 +1784,7 @@ async def get_server_stderr(
 
 
 @router.get("/servers/{id}/resources")
-async def get_server_resources(request: Request, id: str):
+async def get_server_resources(request: Request, id: str, token: str = Depends(get_token)):
     manager = get_server_manager(request)
 
     config = manager.configs.get(id)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -1803,6 +1803,12 @@ class MCPHealthMonitor:
         # Tracks whether cpu_percent has been warmed up for each PID (first call returns 0.0)
         self._cpu_warmed_pids: set = set()
 
+        # Resource throttling state
+        # Consecutive cycles where cpu_percent exceeded cpu_warn_pct
+        self._high_cpu_cycles: Dict[str, int] = {}
+        # Timestamp of last resource-triggered kill per server (cooldown guard)
+        self._last_kill_time: Dict[str, float] = {}
+
     def start(self) -> None:
         """Start the background health monitor."""
         if self._running:
@@ -1887,6 +1893,8 @@ class MCPHealthMonitor:
                     self._restart_counts.pop(server_id, None)
             # Update resource snapshot while process is alive
             self._update_resource_snapshot(server_id, process)
+            # Check resource thresholds and kill/restart if exceeded
+            await self._check_resource_thresholds(server_id, process)
             return
 
         # Evict stale PID from warm-up tracking so the next restart gets a fresh warm-up
@@ -2031,3 +2039,90 @@ class MCPHealthMonitor:
         if len(set(readings)) == 1:
             return "stable"
         return "fluctuating"
+
+    async def _check_resource_thresholds(self, server_id: str, process) -> None:
+        """Kill or restart a server if it exceeds memory or CPU thresholds."""
+        snapshot = self._last_resource_snapshot.get(server_id)
+        if not snapshot:
+            return
+
+        config = self._sm.configs.get(server_id) or {}
+
+        # --- Memory kill policy ---
+        memory_warn_pct = float(config.get("memory_warn_pct",
+            os.getenv("FMCP_MEMORY_WARN_PCT", "90")))
+        memory_kill_pct = float(config.get("memory_kill_pct",
+            os.getenv("FMCP_MEMORY_KILL_PCT", "98")))
+
+        memory_limit_mb = config.get("memory_limit_mb",
+            int(os.getenv("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+        memory_limit_bytes = memory_limit_mb * 1024 * 1024 if memory_limit_mb > 0 else None
+
+        if memory_limit_bytes and snapshot.get("memory_rss_bytes"):
+            mem_pct = snapshot["memory_rss_bytes"] / memory_limit_bytes * 100
+
+            if mem_pct >= memory_kill_pct:
+                # Cooldown guard: at most one resource kill per 60s per server
+                now = time.monotonic()
+                last_kill = self._last_kill_time.get(server_id)
+                if last_kill and (now - last_kill) < 60:
+                    elapsed = now - last_kill
+                    logger.warning(
+                        f"[RESOURCE] {server_id} memory at {mem_pct:.1f}% — "
+                        f"kill skipped, cooldown active ({60 - elapsed:.0f}s remaining)"
+                    )
+                    return
+                self._last_kill_time[server_id] = now
+                logger.error(
+                    f"[RESOURCE] {server_id} memory at {mem_pct:.1f}% of limit "
+                    f"(>= {memory_kill_pct}%), killing to protect other servers"
+                )
+                op_lock = self._sm._get_operation_lock(server_id)
+                async with op_lock:
+                    if self._sm.processes.get(server_id) is process:
+                        await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+                return
+
+            elif mem_pct >= memory_warn_pct:
+                logger.warning(
+                    f"[RESOURCE] {server_id} memory at {mem_pct:.1f}% of limit "
+                    f"(>= {memory_warn_pct}%) — approaching kill threshold"
+                )
+
+        # --- CPU stuck policy ---
+        cpu_warn_pct = float(config.get("cpu_warn_pct",
+            os.getenv("FMCP_CPU_WARN_PCT", "90")))
+        cpu_kill_cycles = int(config.get("cpu_kill_cycles",
+            os.getenv("FMCP_CPU_KILL_CYCLES", "3")))
+
+        cpu_pct = snapshot.get("cpu_percent", 0) or 0
+        if cpu_pct >= cpu_warn_pct:
+            self._high_cpu_cycles[server_id] = self._high_cpu_cycles.get(server_id, 0) + 1
+            cycles = self._high_cpu_cycles[server_id]
+            logger.warning(
+                f"[RESOURCE] {server_id} CPU at {cpu_pct:.1f}% "
+                f"(cycle {cycles}/{cpu_kill_cycles})"
+            )
+            if cycles >= cpu_kill_cycles:
+                now = time.monotonic()
+                last_kill = self._last_kill_time.get(server_id)
+                if last_kill and (now - last_kill) < 60:
+                    elapsed = now - last_kill
+                    logger.warning(
+                        f"[RESOURCE] {server_id} CPU stuck — "
+                        f"kill skipped, cooldown active ({60 - elapsed:.0f}s remaining)"
+                    )
+                    return
+                self._last_kill_time[server_id] = now
+                self._high_cpu_cycles.pop(server_id, None)
+                logger.error(
+                    f"[RESOURCE] {server_id} CPU stuck at {cpu_pct:.1f}% "
+                    f"for {cpu_kill_cycles} consecutive cycles, restarting"
+                )
+                op_lock = self._sm._get_operation_lock(server_id)
+                async with op_lock:
+                    if self._sm.processes.get(server_id) is process:
+                        await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+        else:
+            # Reset counter on any healthy cycle
+            self._high_cpu_cycles.pop(server_id, None)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2092,6 +2092,14 @@ class MCPHealthMonitor:
                 op_lock = self._sm._get_operation_lock(server_id)
                 async with op_lock:
                     if self._sm.processes.get(server_id) is process:
+                        process.terminate()
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.to_thread(process.wait), timeout=10.0
+                            )
+                        except asyncio.TimeoutError:
+                            process.kill()
+                            await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
                 return
 
@@ -2142,6 +2150,14 @@ class MCPHealthMonitor:
                 op_lock = self._sm._get_operation_lock(server_id)
                 async with op_lock:
                     if self._sm.processes.get(server_id) is process:
+                        process.terminate()
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.to_thread(process.wait), timeout=10.0
+                            )
+                        except asyncio.TimeoutError:
+                            process.kill()
+                            await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
         else:
             # Reset counter on any healthy cycle

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2103,18 +2103,16 @@ class MCPHealthMonitor:
                     f"[RESOURCE] {server_id} memory at {mem_pct:.1f}% of limit "
                     f"(>= {memory_kill_pct}%), killing to protect other servers"
                 )
-                op_lock = self._sm._get_operation_lock(server_id)
-                async with op_lock:
-                    if self._sm.processes.get(server_id) is process:
-                        process.terminate()
-                        try:
-                            await asyncio.wait_for(
-                                asyncio.to_thread(process.wait), timeout=10.0
-                            )
-                        except asyncio.TimeoutError:
-                            process.kill()
-                            await asyncio.to_thread(process.wait)
-                        await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+                # Terminate the process; _restart_under_policy handles cleanup + restart
+                if self._sm.processes.get(server_id) is process:
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.to_thread(process.wait), timeout=10.0
+                        )
+                    except asyncio.TimeoutError:
+                        process.kill()
+                        await asyncio.to_thread(process.wait)
                 # Route through the same monitor restart-policy/backoff path as a natural death
                 await self._restart_under_policy(server_id, process, exit_code=-1, config=config)
                 return
@@ -2163,18 +2161,16 @@ class MCPHealthMonitor:
                     f"[RESOURCE] {server_id} CPU stuck at {cpu_pct:.1f}% "
                     f"for {cpu_kill_cycles} consecutive cycles, restarting"
                 )
-                op_lock = self._sm._get_operation_lock(server_id)
-                async with op_lock:
-                    if self._sm.processes.get(server_id) is process:
-                        process.terminate()
-                        try:
-                            await asyncio.wait_for(
-                                asyncio.to_thread(process.wait), timeout=10.0
-                            )
-                        except asyncio.TimeoutError:
-                            process.kill()
-                            await asyncio.to_thread(process.wait)
-                        await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+                # Terminate the process; _restart_under_policy handles cleanup + restart
+                if self._sm.processes.get(server_id) is process:
+                    process.terminate()
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.to_thread(process.wait), timeout=10.0
+                        )
+                    except asyncio.TimeoutError:
+                        process.kill()
+                        await asyncio.to_thread(process.wait)
                 # Route through the same monitor restart-policy/backoff path as a natural death
                 await self._restart_under_policy(server_id, process, exit_code=-1, config=config)
         else:

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2049,13 +2049,25 @@ class MCPHealthMonitor:
         config = self._sm.configs.get(server_id) or {}
 
         # --- Memory kill policy ---
-        memory_warn_pct = float(config.get("memory_warn_pct",
-            os.getenv("FMCP_MEMORY_WARN_PCT", "90")))
-        memory_kill_pct = float(config.get("memory_kill_pct",
-            os.getenv("FMCP_MEMORY_KILL_PCT", "98")))
+        try:
+            memory_warn_pct = float(config.get("memory_warn_pct",
+                os.getenv("FMCP_MEMORY_WARN_PCT", "90")))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_MEMORY_WARN_PCT value, using default 90%")
+            memory_warn_pct = 90.0
+        try:
+            memory_kill_pct = float(config.get("memory_kill_pct",
+                os.getenv("FMCP_MEMORY_KILL_PCT", "98")))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_MEMORY_KILL_PCT value, using default 98%")
+            memory_kill_pct = 98.0
 
-        memory_limit_mb = config.get("memory_limit_mb",
-            int(os.getenv("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+        try:
+            memory_limit_mb = config.get("memory_limit_mb",
+                int(os.getenv("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_DEFAULT_MEMORY_LIMIT_MB value, using default 0")
+            memory_limit_mb = 0
         memory_limit_bytes = memory_limit_mb * 1024 * 1024 if memory_limit_mb > 0 else None
 
         if memory_limit_bytes and snapshot.get("memory_rss_bytes"):
@@ -2090,10 +2102,18 @@ class MCPHealthMonitor:
                 )
 
         # --- CPU stuck policy ---
-        cpu_warn_pct = float(config.get("cpu_warn_pct",
-            os.getenv("FMCP_CPU_WARN_PCT", "90")))
-        cpu_kill_cycles = int(config.get("cpu_kill_cycles",
-            os.getenv("FMCP_CPU_KILL_CYCLES", "3")))
+        try:
+            cpu_warn_pct = float(config.get("cpu_warn_pct",
+                os.getenv("FMCP_CPU_WARN_PCT", "90")))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_CPU_WARN_PCT value, using default 90%")
+            cpu_warn_pct = 90.0
+        try:
+            cpu_kill_cycles = int(config.get("cpu_kill_cycles",
+                os.getenv("FMCP_CPU_KILL_CYCLES", "3")))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_CPU_KILL_CYCLES value, using default 3")
+            cpu_kill_cycles = 3
 
         cpu_pct = snapshot.get("cpu_percent", 0) or 0
         if cpu_pct >= cpu_warn_pct:

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2101,6 +2101,9 @@ class MCPHealthMonitor:
                             process.kill()
                             await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+                # Honour restart policy — fetch fresh instance state written by _cleanup_server
+                instance = await self._sm.db.get_instance_state(server_id) or {}
+                await self._sm._check_auto_restart_on_crash(server_id, instance)
                 return
 
             elif mem_pct >= memory_warn_pct:
@@ -2159,6 +2162,9 @@ class MCPHealthMonitor:
                             process.kill()
                             await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
+                # Honour restart policy — fetch fresh instance state written by _cleanup_server
+                instance = await self._sm.db.get_instance_state(server_id) or {}
+                await self._sm._check_auto_restart_on_crash(server_id, instance)
         else:
             # Reset counter on any healthy cycle
             self._high_cpu_cycles.pop(server_id, None)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -1919,6 +1919,20 @@ class MCPHealthMonitor:
                     await self._sm._cleanup_server(server_id, exit_code)
             return
 
+        await self._restart_under_policy(server_id, process, exit_code, config)
+
+    async def _restart_under_policy(
+        self,
+        server_id: str,
+        process,
+        exit_code: int,
+        config: Dict[str, Any],
+    ) -> None:
+        """Apply restart policy after a process death (natural or resource-triggered).
+
+        Shared by the dead-process monitor path and resource-kill paths so both
+        honour the same restart_policy / max_restarts / exponential-backoff logic.
+        """
         restart_policy = config.get("restart_policy", "on-failure")
         max_restarts = config.get("max_restarts", 3)
 
@@ -2101,9 +2115,8 @@ class MCPHealthMonitor:
                             process.kill()
                             await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
-                # Honour restart policy — fetch fresh instance state written by _cleanup_server
-                instance = await self._sm.db.get_instance_state(server_id) or {}
-                await self._sm._check_auto_restart_on_crash(server_id, instance)
+                # Route through the same monitor restart-policy/backoff path as a natural death
+                await self._restart_under_policy(server_id, process, exit_code=-1, config=config)
                 return
 
             elif mem_pct >= memory_warn_pct:
@@ -2162,9 +2175,8 @@ class MCPHealthMonitor:
                             process.kill()
                             await asyncio.to_thread(process.wait)
                         await self._sm._cleanup_server(server_id, exit_code=-1, intentional=False)
-                # Honour restart policy — fetch fresh instance state written by _cleanup_server
-                instance = await self._sm.db.get_instance_state(server_id) or {}
-                await self._sm._check_auto_restart_on_crash(server_id, instance)
+                # Route through the same monitor restart-policy/backoff path as a natural death
+                await self._restart_under_policy(server_id, process, exit_code=-1, config=config)
         else:
             # Reset counter on any healthy cycle
             self._high_cpu_cycles.pop(server_id, None)

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -550,6 +550,7 @@ class ServerManager:
                     "pid": process.pid,
                     "uptime": uptime,
                     "restart_count": instance.get("restart_count", 0) if instance else 0,
+                    "stability": instance.get("stability", "stable") if instance else "stable",
                     "exit_code": None
                 }
             else:
@@ -560,6 +561,7 @@ class ServerManager:
                     "pid": None,
                     "uptime": None,
                     "restart_count": 0,
+                    "stability": "stable",
                     "exit_code": process.returncode
                 }
 
@@ -586,6 +588,7 @@ class ServerManager:
                             "pid": None,
                             "uptime": None,
                             "restart_count": instance.get("restart_count", 0),
+                            "stability": instance.get("stability", "stable"),
                             "exit_code": -1
                         }
 
@@ -618,6 +621,7 @@ class ServerManager:
                         "pid": None,
                         "uptime": None,
                         "restart_count": instance.get("restart_count", 0),
+                        "stability": instance.get("stability", "stable"),
                         "exit_code": -1
                     }
 
@@ -628,6 +632,7 @@ class ServerManager:
                 "pid": pid,
                 "uptime": None,
                 "restart_count": instance.get("restart_count", 0),
+                "stability": instance.get("stability", "stable"),
                 "exit_code": instance.get("exit_code")
             }
 
@@ -638,6 +643,7 @@ class ServerManager:
             "pid": None,
             "uptime": None,
             "restart_count": 0,
+            "stability": "stable",
             "exit_code": None
         }
 
@@ -1809,6 +1815,9 @@ class MCPHealthMonitor:
         # Timestamp of last resource-triggered kill per server (cooldown guard)
         self._last_kill_time: Dict[str, float] = {}
 
+        # Stability tracking: sliding window of restart timestamps (10 min)
+        self._restart_timestamps: Dict[str, List[float]] = {}
+
     def start(self) -> None:
         """Start the background health monitor."""
         if self._running:
@@ -1891,6 +1900,8 @@ class MCPHealthMonitor:
                 uptime = self._sm.get_uptime(server_id)
                 if uptime and uptime > 300:
                     self._restart_counts.pop(server_id, None)
+                    self._restart_timestamps.pop(server_id, None)
+                    asyncio.ensure_future(self._clear_stability(server_id))
             # Update resource snapshot while process is alive
             self._update_resource_snapshot(server_id, process)
             # Check resource thresholds and kill/restart if exceeded
@@ -1986,6 +1997,7 @@ class MCPHealthMonitor:
                     )
                     success = False
             self._restart_counts[server_id] = count + 1
+            await self._check_stability(server_id)
             if success:
                 logger.info(f"MCP server '{server_id}' restarted successfully")
             else:
@@ -2176,3 +2188,43 @@ class MCPHealthMonitor:
         else:
             # Reset counter on any healthy cycle
             self._high_cpu_cycles.pop(server_id, None)
+
+    async def _check_stability(self, server_id: str) -> None:
+        """Record a restart timestamp and flag server as unstable if flapping."""
+        now = time.monotonic()
+        window = 600  # 10 minutes
+        try:
+            storm_threshold = int(os.getenv("FMCP_RESTART_STORM_THRESHOLD", "5"))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_RESTART_STORM_THRESHOLD value, using default 5")
+            storm_threshold = 5
+
+        timestamps = self._restart_timestamps.get(server_id, [])
+        timestamps.append(now)
+        # Keep only timestamps within the sliding window
+        timestamps = [t for t in timestamps if now - t <= window]
+        self._restart_timestamps[server_id] = timestamps
+
+        if len(timestamps) >= storm_threshold:
+            logger.warning(
+                f"[ALERT] {server_id} has restarted {len(timestamps)} times "
+                f"in the last 10 minutes — marking unstable"
+            )
+            try:
+                instance = await self._sm.db.get_instance_state(server_id) or {}
+                instance["server_id"] = server_id
+                instance["stability"] = "unstable"
+                await self._sm.db.save_instance_state(instance)
+            except Exception as e:
+                logger.error(f"Failed to update stability flag for '{server_id}': {e}")
+
+    async def _clear_stability(self, server_id: str) -> None:
+        """Clear the unstable flag after sustained healthy operation."""
+        try:
+            instance = await self._sm.db.get_instance_state(server_id)
+            if instance and instance.get("stability") == "unstable":
+                instance["stability"] = "stable"
+                await self._sm.db.save_instance_state(instance)
+                logger.info(f"[ALERT] {server_id} stability cleared after 5 minutes of healthy operation")
+        except Exception as e:
+            logger.error(f"Failed to clear stability flag for '{server_id}': {e}")

--- a/tests/test_resource_kill_policy.py
+++ b/tests/test_resource_kill_policy.py
@@ -306,3 +306,88 @@ class TestConfigOverrides:
 
         await monitor._check_resource_thresholds("srv", process)
         assert len(cleanup_called) == 1
+
+
+# ---------------------------------------------------------------------------
+# Restart policy after resource kill
+# ---------------------------------------------------------------------------
+
+class TestRestartPolicyAfterKill:
+
+    @pytest.mark.asyncio
+    async def test_restart_invoked_after_memory_kill(self, monitor, server_manager):
+        """_check_auto_restart_on_crash must be called after a memory-triggered kill."""
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+            "memory_warn_pct": 90,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
+
+        restart_checked = []
+
+        async def mock_cleanup(id, exit_code, intentional=False):
+            pass
+
+        async def mock_restart_check(server_id, instance):
+            restart_checked.append(server_id)
+
+        server_manager._cleanup_server = mock_cleanup
+        server_manager._check_auto_restart_on_crash = mock_restart_check
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert restart_checked == ["srv"], "restart policy was not invoked after memory kill"
+
+    @pytest.mark.asyncio
+    async def test_restart_invoked_after_cpu_kill(self, monitor, server_manager):
+        """_check_auto_restart_on_crash must be called after a CPU-stuck kill."""
+        server_manager.configs["srv"] = {
+            "cpu_warn_pct": 80,
+            "cpu_kill_cycles": 1,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", cpu_percent=85.0)
+
+        restart_checked = []
+
+        async def mock_cleanup(id, exit_code, intentional=False):
+            pass
+
+        async def mock_restart_check(server_id, instance):
+            restart_checked.append(server_id)
+
+        server_manager._cleanup_server = mock_cleanup
+        server_manager._check_auto_restart_on_crash = mock_restart_check
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert restart_checked == ["srv"], "restart policy was not invoked after CPU kill"
+
+    @pytest.mark.asyncio
+    async def test_restart_not_invoked_when_cooldown_active(self, monitor, server_manager):
+        """When cooldown guard skips the kill, restart must not be called either."""
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
+
+        # Set a recent kill so cooldown is active
+        monitor._last_kill_time["srv"] = time.monotonic()
+
+        restart_checked = []
+
+        async def mock_restart_check(server_id, instance):
+            restart_checked.append(server_id)
+
+        server_manager._check_auto_restart_on_crash = mock_restart_check
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert restart_checked == [], "restart should not be called when cooldown skipped the kill"

--- a/tests/test_resource_kill_policy.py
+++ b/tests/test_resource_kill_policy.py
@@ -70,7 +70,10 @@ class TestMemoryKillPolicy:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append((id, exit_code))
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
 
@@ -151,7 +154,10 @@ class TestCpuStuckPolicy:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append((id, exit_code))
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         # First two cycles: warning only
         await monitor._check_resource_thresholds("srv", process)
@@ -222,8 +228,10 @@ class TestKillCooldown:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append(id)
-            # After kill, remove from processes so second check sees a different process
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         # First kill fires
         await monitor._check_resource_thresholds("srv", process)
@@ -247,7 +255,10 @@ class TestKillCooldown:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append(id)
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         # First kill
         await monitor._check_resource_thresholds("srv", process)
@@ -283,7 +294,10 @@ class TestConfigOverrides:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append(id)
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
         assert len(cleanup_called) == 1
@@ -302,7 +316,10 @@ class TestConfigOverrides:
         cleanup_called = []
         async def mock_cleanup(id, exit_code, intentional=False):
             cleanup_called.append(id)
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
+            pass
         server_manager._cleanup_server = mock_cleanup
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
         assert len(cleanup_called) == 1
@@ -316,7 +333,7 @@ class TestRestartPolicyAfterKill:
 
     @pytest.mark.asyncio
     async def test_restart_invoked_after_memory_kill(self, monitor, server_manager):
-        """_check_auto_restart_on_crash must be called after a memory-triggered kill."""
+        """_restart_under_policy must be called after a memory-triggered kill."""
         server_manager.configs["srv"] = {
             "memory_limit_mb": 100,
             "memory_kill_pct": 98,
@@ -331,11 +348,11 @@ class TestRestartPolicyAfterKill:
         async def mock_cleanup(id, exit_code, intentional=False):
             pass
 
-        async def mock_restart_check(server_id, instance):
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
             restart_checked.append(server_id)
 
         server_manager._cleanup_server = mock_cleanup
-        server_manager._check_auto_restart_on_crash = mock_restart_check
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
 
@@ -343,7 +360,7 @@ class TestRestartPolicyAfterKill:
 
     @pytest.mark.asyncio
     async def test_restart_invoked_after_cpu_kill(self, monitor, server_manager):
-        """_check_auto_restart_on_crash must be called after a CPU-stuck kill."""
+        """_restart_under_policy must be called after a CPU-stuck kill."""
         server_manager.configs["srv"] = {
             "cpu_warn_pct": 80,
             "cpu_kill_cycles": 1,
@@ -357,11 +374,11 @@ class TestRestartPolicyAfterKill:
         async def mock_cleanup(id, exit_code, intentional=False):
             pass
 
-        async def mock_restart_check(server_id, instance):
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
             restart_checked.append(server_id)
 
         server_manager._cleanup_server = mock_cleanup
-        server_manager._check_auto_restart_on_crash = mock_restart_check
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
 
@@ -383,10 +400,10 @@ class TestRestartPolicyAfterKill:
 
         restart_checked = []
 
-        async def mock_restart_check(server_id, instance):
+        async def mock_restart_under_policy(server_id, proc, exit_code, config):
             restart_checked.append(server_id)
 
-        server_manager._check_auto_restart_on_crash = mock_restart_check
+        monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
 

--- a/tests/test_resource_kill_policy.py
+++ b/tests/test_resource_kill_policy.py
@@ -67,18 +67,15 @@ class TestMemoryKillPolicy:
         # 99MB / 100MB = 99% > 98% kill threshold
         _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append((id, exit_code))
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append((server_id, exit_code))
         monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
 
-        assert len(cleanup_called) == 1
-        assert cleanup_called[0] == ("srv", -1)
+        assert len(restart_called) == 1
+        assert restart_called[0] == ("srv", -1)
 
     @pytest.mark.asyncio
     async def test_warns_but_no_kill_at_warn_threshold(self, monitor, server_manager):
@@ -151,27 +148,24 @@ class TestCpuStuckPolicy:
         server_manager.processes["srv"] = process
         _set_snapshot(monitor, "srv", cpu_percent=95.0)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append((id, exit_code))
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append((server_id, exit_code))
         monitor._restart_under_policy = mock_restart_under_policy
 
         # First two cycles: warning only
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 0
+        assert len(restart_called) == 0
         assert monitor._high_cpu_cycles["srv"] == 1
 
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 0
+        assert len(restart_called) == 0
         assert monitor._high_cpu_cycles["srv"] == 2
 
         # Third cycle: kill fires
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1
-        assert cleanup_called[0] == ("srv", -1)
+        assert len(restart_called) == 1
+        assert restart_called[0] == ("srv", -1)
 
     @pytest.mark.asyncio
     async def test_cpu_counter_resets_on_healthy_cycle(self, monitor, server_manager):
@@ -225,21 +219,18 @@ class TestKillCooldown:
         server_manager.processes["srv"] = process
         _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append(id)
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append(server_id)
         monitor._restart_under_policy = mock_restart_under_policy
 
         # First kill fires
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1
+        assert len(restart_called) == 1
 
         # Immediately try again — should be blocked by 60s cooldown
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1  # still 1, not 2
+        assert len(restart_called) == 1  # still 1, not 2
 
     @pytest.mark.asyncio
     async def test_kill_allowed_after_cooldown_expires(self, monitor, server_manager):
@@ -252,24 +243,21 @@ class TestKillCooldown:
         server_manager.processes["srv"] = process
         _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append(id)
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append(server_id)
         monitor._restart_under_policy = mock_restart_under_policy
 
         # First kill
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1
+        assert len(restart_called) == 1
 
         # Simulate cooldown expiry by backdating the last kill time
         monitor._last_kill_time["srv"] = time.monotonic() - 61
 
         # Second kill allowed
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 2
+        assert len(restart_called) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -291,16 +279,13 @@ class TestConfigOverrides:
         # 85MB / 100MB = 85% > 80% kill threshold
         _set_snapshot(monitor, "srv", memory_rss_bytes=85 * 1024 * 1024)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append(id)
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append(server_id)
         monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1
+        assert len(restart_called) == 1
 
     @pytest.mark.asyncio
     async def test_per_server_cpu_kill_cycles_respected(self, monitor, server_manager):
@@ -313,16 +298,13 @@ class TestConfigOverrides:
         server_manager.processes["srv"] = process
         _set_snapshot(monitor, "srv", cpu_percent=85.0)
 
-        cleanup_called = []
-        async def mock_cleanup(id, exit_code, intentional=False):
-            cleanup_called.append(id)
+        restart_called = []
         async def mock_restart_under_policy(server_id, proc, exit_code, config):
-            pass
-        server_manager._cleanup_server = mock_cleanup
+            restart_called.append(server_id)
         monitor._restart_under_policy = mock_restart_under_policy
 
         await monitor._check_resource_thresholds("srv", process)
-        assert len(cleanup_called) == 1
+        assert len(restart_called) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_resource_kill_policy.py
+++ b/tests/test_resource_kill_policy.py
@@ -1,0 +1,308 @@
+"""
+Tests for P4 - soft resource throttling and kill policy in MCPHealthMonitor.
+
+Covers:
+- Memory kill at >= memory_kill_pct
+- Memory warn at >= memory_warn_pct (no kill)
+- CPU stuck kill after N consecutive high cycles
+- CPU counter resets on healthy cycle
+- Kill loop cooldown (60s guard)
+- No action when memory limit not configured
+- Config-level threshold overrides
+"""
+import time
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from fluidmcp.cli.services.server_manager import ServerManager, MCPHealthMonitor
+from fluidmcp.cli.repositories import InMemoryBackend
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def monitor(server_manager):
+    return MCPHealthMonitor(server_manager, check_interval=30)
+
+
+def _make_process(pid=1234, alive=True):
+    p = Mock()
+    p.pid = pid
+    p.poll = Mock(return_value=None if alive else 1)
+    return p
+
+
+def _set_snapshot(monitor, server_id, memory_rss_bytes=None, cpu_percent=0.0):
+    monitor._last_resource_snapshot[server_id] = {
+        "memory_rss_bytes": memory_rss_bytes,
+        "cpu_percent": cpu_percent,
+        "active_requests": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Memory kill policy
+# ---------------------------------------------------------------------------
+
+class TestMemoryKillPolicy:
+
+    @pytest.mark.asyncio
+    async def test_kills_when_memory_exceeds_kill_pct(self, monitor, server_manager):
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+            "memory_warn_pct": 90,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        # 99MB / 100MB = 99% > 98% kill threshold
+        _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append((id, exit_code))
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert len(cleanup_called) == 1
+        assert cleanup_called[0] == ("srv", -1)
+
+    @pytest.mark.asyncio
+    async def test_warns_but_no_kill_at_warn_threshold(self, monitor, server_manager):
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+            "memory_warn_pct": 90,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        # 92MB / 100MB = 92% — above warn (90%) but below kill (98%)
+        _set_snapshot(monitor, "srv", memory_rss_bytes=92 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append((id, exit_code))
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert len(cleanup_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_kill_when_memory_limit_not_configured(self, monitor, server_manager):
+        server_manager.configs["srv"] = {"memory_limit_mb": 0}
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        # Even with enormous RSS, no kill without a limit to compare against
+        _set_snapshot(monitor, "srv", memory_rss_bytes=999 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert len(cleanup_called) == 0
+
+    @pytest.mark.asyncio
+    async def test_no_kill_when_no_snapshot(self, monitor, server_manager):
+        server_manager.configs["srv"] = {"memory_limit_mb": 100}
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        # No snapshot yet
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+
+        assert len(cleanup_called) == 0
+
+
+# ---------------------------------------------------------------------------
+# CPU stuck policy
+# ---------------------------------------------------------------------------
+
+class TestCpuStuckPolicy:
+
+    @pytest.mark.asyncio
+    async def test_kills_after_n_consecutive_high_cpu_cycles(self, monitor, server_manager):
+        server_manager.configs["srv"] = {
+            "cpu_warn_pct": 90,
+            "cpu_kill_cycles": 3,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", cpu_percent=95.0)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append((id, exit_code))
+        server_manager._cleanup_server = mock_cleanup
+
+        # First two cycles: warning only
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 0
+        assert monitor._high_cpu_cycles["srv"] == 1
+
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 0
+        assert monitor._high_cpu_cycles["srv"] == 2
+
+        # Third cycle: kill fires
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1
+        assert cleanup_called[0] == ("srv", -1)
+
+    @pytest.mark.asyncio
+    async def test_cpu_counter_resets_on_healthy_cycle(self, monitor, server_manager):
+        server_manager.configs["srv"] = {"cpu_warn_pct": 90, "cpu_kill_cycles": 3}
+        process = _make_process()
+        server_manager.processes["srv"] = process
+
+        # Two high-CPU cycles
+        _set_snapshot(monitor, "srv", cpu_percent=95.0)
+        await monitor._check_resource_thresholds("srv", process)
+        await monitor._check_resource_thresholds("srv", process)
+        assert monitor._high_cpu_cycles.get("srv") == 2
+
+        # One healthy cycle resets the counter
+        _set_snapshot(monitor, "srv", cpu_percent=10.0)
+        await monitor._check_resource_thresholds("srv", process)
+        assert "srv" not in monitor._high_cpu_cycles
+
+    @pytest.mark.asyncio
+    async def test_no_kill_below_cpu_warn_threshold(self, monitor, server_manager):
+        server_manager.configs["srv"] = {"cpu_warn_pct": 90, "cpu_kill_cycles": 3}
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", cpu_percent=50.0)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        for _ in range(5):
+            await monitor._check_resource_thresholds("srv", process)
+
+        assert len(cleanup_called) == 0
+
+
+# ---------------------------------------------------------------------------
+# Kill cooldown guard
+# ---------------------------------------------------------------------------
+
+class TestKillCooldown:
+
+    @pytest.mark.asyncio
+    async def test_second_kill_skipped_within_cooldown(self, monitor, server_manager):
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+            "memory_warn_pct": 90,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+            # After kill, remove from processes so second check sees a different process
+        server_manager._cleanup_server = mock_cleanup
+
+        # First kill fires
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1
+
+        # Immediately try again — should be blocked by 60s cooldown
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1  # still 1, not 2
+
+    @pytest.mark.asyncio
+    async def test_kill_allowed_after_cooldown_expires(self, monitor, server_manager):
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 98,
+            "memory_warn_pct": 90,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", memory_rss_bytes=99 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        # First kill
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1
+
+        # Simulate cooldown expiry by backdating the last kill time
+        monitor._last_kill_time["srv"] = time.monotonic() - 61
+
+        # Second kill allowed
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 2
+
+
+# ---------------------------------------------------------------------------
+# Config overrides via server config
+# ---------------------------------------------------------------------------
+
+class TestConfigOverrides:
+
+    @pytest.mark.asyncio
+    async def test_per_server_memory_thresholds_respected(self, monitor, server_manager):
+        # Lower kill threshold (80%) via per-server config
+        server_manager.configs["srv"] = {
+            "memory_limit_mb": 100,
+            "memory_kill_pct": 80,
+            "memory_warn_pct": 70,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        # 85MB / 100MB = 85% > 80% kill threshold
+        _set_snapshot(monitor, "srv", memory_rss_bytes=85 * 1024 * 1024)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1
+
+    @pytest.mark.asyncio
+    async def test_per_server_cpu_kill_cycles_respected(self, monitor, server_manager):
+        # Kill after just 1 cycle via per-server config
+        server_manager.configs["srv"] = {
+            "cpu_warn_pct": 80,
+            "cpu_kill_cycles": 1,
+        }
+        process = _make_process()
+        server_manager.processes["srv"] = process
+        _set_snapshot(monitor, "srv", cpu_percent=85.0)
+
+        cleanup_called = []
+        async def mock_cleanup(id, exit_code, intentional=False):
+            cleanup_called.append(id)
+        server_manager._cleanup_server = mock_cleanup
+
+        await monitor._check_resource_thresholds("srv", process)
+        assert len(cleanup_called) == 1

--- a/tests/test_stability_alerts.py
+++ b/tests/test_stability_alerts.py
@@ -1,0 +1,231 @@
+"""
+Tests for P5 - stability tracking and log-based alerts in MCPHealthMonitor.
+
+Covers:
+- Restart timestamps accumulate per server
+- Storm threshold triggers "unstable" flag in DB
+- Old timestamps outside 10-min window are pruned
+- Counter resets on sustained health (>5 min uptime)
+- _clear_stability clears "unstable" flag after healthy operation
+- _clear_stability is a no-op when already "stable"
+- stability field present in all get_server_status() return paths
+- Per-env FMCP_RESTART_STORM_THRESHOLD override
+"""
+import time
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
+
+from fluidmcp.cli.services.server_manager import ServerManager, MCPHealthMonitor
+from fluidmcp.cli.repositories import InMemoryBackend
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def monitor(server_manager):
+    return MCPHealthMonitor(server_manager, check_interval=30)
+
+
+# ---------------------------------------------------------------------------
+# _check_stability — restart timestamp accumulation
+# ---------------------------------------------------------------------------
+
+class TestCheckStability:
+
+    @pytest.mark.asyncio
+    async def test_timestamps_accumulate(self, monitor):
+        await monitor._check_stability("srv")
+        await monitor._check_stability("srv")
+        assert len(monitor._restart_timestamps.get("srv", [])) == 2
+
+    @pytest.mark.asyncio
+    async def test_old_timestamps_pruned(self, monitor):
+        # Inject 3 old timestamps outside the 10-min window
+        old = time.monotonic() - 700
+        monitor._restart_timestamps["srv"] = [old, old, old]
+
+        # A fresh restart should prune the old ones
+        await monitor._check_stability("srv")
+        assert len(monitor._restart_timestamps["srv"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_flag_below_threshold(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "5"}):
+            for _ in range(4):
+                await monitor._check_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        # Either no instance yet or stability not set to "unstable"
+        if instance:
+            assert instance.get("stability", "stable") != "unstable"
+
+    @pytest.mark.asyncio
+    async def test_marks_unstable_at_threshold(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "3"}):
+            for _ in range(3):
+                await monitor._check_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance is not None
+        assert instance.get("stability") == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_env_threshold_override_respected(self, monitor, server_manager):
+        # With threshold=2, second call should trigger unstable
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "2"}):
+            await monitor._check_stability("srv2")
+            instance = await server_manager.db.get_instance_state("srv2")
+            if instance:
+                assert instance.get("stability", "stable") != "unstable"  # only 1 so far
+
+            await monitor._check_stability("srv2")
+
+        instance = await server_manager.db.get_instance_state("srv2")
+        assert instance is not None
+        assert instance.get("stability") == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_multiple_servers_tracked_independently(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "3"}):
+            for _ in range(3):
+                await monitor._check_stability("alpha")
+            for _ in range(2):
+                await monitor._check_stability("beta")
+
+        alpha_instance = await server_manager.db.get_instance_state("alpha")
+        beta_instance = await server_manager.db.get_instance_state("beta")
+
+        assert alpha_instance is not None
+        assert alpha_instance.get("stability") == "unstable"
+
+        if beta_instance:
+            assert beta_instance.get("stability", "stable") != "unstable"
+
+
+# ---------------------------------------------------------------------------
+# _clear_stability
+# ---------------------------------------------------------------------------
+
+class TestClearStability:
+
+    @pytest.mark.asyncio
+    async def test_clears_unstable_flag(self, monitor, server_manager):
+        # Seed an unstable instance directly
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "stability": "unstable",
+        })
+
+        await monitor._clear_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_already_stable(self, monitor, server_manager):
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "stability": "stable",
+        })
+
+        # Should not raise, should not change anything
+        await monitor._clear_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_instance(self, monitor, server_manager):
+        # No instance in DB — should not raise
+        await monitor._clear_stability("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_restart_timestamps_cleared_before_stability_clear(self, monitor, server_manager):
+        # Simulate the reset path that removes timestamps then schedules _clear_stability
+        monitor._restart_timestamps["srv"] = [time.monotonic()]
+
+        # The health monitor removes timestamps before calling _clear_stability
+        monitor._restart_timestamps.pop("srv", None)
+        await monitor._clear_stability("srv")
+
+        assert "srv" not in monitor._restart_timestamps
+
+
+# ---------------------------------------------------------------------------
+# stability field in get_server_status()
+# ---------------------------------------------------------------------------
+
+class TestStabilityInGetServerStatus:
+
+    @pytest.mark.asyncio
+    async def test_stability_present_when_running(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            "stability": "stable",
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert "stability" in status
+        assert status["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_stability_unstable_surfaced(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            "stability": "unstable",
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert status["stability"] == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_stability_defaults_to_stable_when_not_in_db(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            # no "stability" key
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert status.get("stability") == "stable"
+
+    @pytest.mark.asyncio
+    async def test_stability_present_for_not_found_server(self, server_manager):
+        status = await server_manager.get_server_status("ghost")
+        assert "stability" in status
+        assert status["stability"] == "stable"


### PR DESCRIPTION
## Summary
Adds proactive resource protection to `MCPHealthMonitor` — prevents one heavy MCP from consuming all container memory/CPU and degrading others on Railway.

**Depends on:** #723 (P1), #735 (P2), #740 (P3)

## What's implemented

### Memory kill policy
- Warns at `>= memory_warn_pct` (default 90%) of configured memory limit
- Kills at `>= memory_kill_pct` (default 98%) — uses `_cleanup_server(exit_code=-1)` so MCPHealthMonitor restart policy kicks in automatically
- Skipped silently when no `memory_limit_mb` is configured (can't compute % without a limit)

### CPU stuck policy
- Tracks consecutive cycles where `cpu_percent >= cpu_warn_pct` (default 90%)
- Kills after `cpu_kill_cycles` (default 3) consecutive high-CPU cycles (~90s with 30s interval)
- Counter resets on any healthy cycle — one-off spikes don't trigger a kill

### Kill loop cooldown
- 60s cooldown per server after any resource-triggered kill
- Prevents kill → restart → kill infinite loops on misconfigured servers
- Both memory and CPU kills share the same cooldown timer

### Configuration (all optional, env var fallbacks)
| Field | Default | Env var |
|---|---|---|
| `memory_warn_pct` | 90 | `FMCP_MEMORY_WARN_PCT` |
| `memory_kill_pct` | 98 | `FMCP_MEMORY_KILL_PCT` |
| `cpu_warn_pct` | 90 | `FMCP_CPU_WARN_PCT` |
| `cpu_kill_cycles` | 3 | `FMCP_CPU_KILL_CYCLES` |

## Tests
11 tests in `tests/test_resource_kill_policy.py` — memory kill, memory warn, no limit configured, no snapshot, CPU kill after N cycles, CPU reset on healthy, cooldown guard, cooldown expiry, per-server config overrides.

Generated with Claude Code