### PR TITLE
MCP-564: WIP : feat(debugging): P5 - stability tracking and log-based alerts

### DIFF
--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -550,6 +550,7 @@ class ServerManager:
                     "pid": process.pid,
                     "uptime": uptime,
                     "restart_count": instance.get("restart_count", 0) if instance else 0,
+                    "stability": instance.get("stability", "stable") if instance else "stable",
                     "exit_code": None
                 }
             else:
@@ -560,6 +561,7 @@ class ServerManager:
                     "pid": None,
                     "uptime": None,
                     "restart_count": 0,
+                    "stability": "stable",
                     "exit_code": process.returncode
                 }
 
@@ -586,6 +588,7 @@ class ServerManager:
                             "pid": None,
                             "uptime": None,
                             "restart_count": instance.get("restart_count", 0),
+                            "stability": instance.get("stability", "stable"),
                             "exit_code": -1
                         }
 
@@ -618,6 +621,7 @@ class ServerManager:
                         "pid": None,
                         "uptime": None,
                         "restart_count": instance.get("restart_count", 0),
+                        "stability": instance.get("stability", "stable"),
                         "exit_code": -1
                     }
 
@@ -628,6 +632,7 @@ class ServerManager:
                 "pid": pid,
                 "uptime": None,
                 "restart_count": instance.get("restart_count", 0),
+                "stability": instance.get("stability", "stable"),
                 "exit_code": instance.get("exit_code")
             }
 
@@ -638,6 +643,7 @@ class ServerManager:
             "pid": None,
             "uptime": None,
             "restart_count": 0,
+            "stability": "stable",
             "exit_code": None
         }
 
@@ -1809,6 +1815,9 @@ class MCPHealthMonitor:
         # Timestamp of last resource-triggered kill per server (cooldown guard)
         self._last_kill_time: Dict[str, float] = {}
 
+        # Stability tracking: sliding window of restart timestamps (10 min)
+        self._restart_timestamps: Dict[str, List[float]] = {}
+
     def start(self) -> None:
         """Start the background health monitor."""
         if self._running:
@@ -1891,6 +1900,8 @@ class MCPHealthMonitor:
                 uptime = self._sm.get_uptime(server_id)
                 if uptime and uptime > 300:
                     self._restart_counts.pop(server_id, None)
+                    self._restart_timestamps.pop(server_id, None)
+                    asyncio.ensure_future(self._clear_stability(server_id))
             # Update resource snapshot while process is alive
             self._update_resource_snapshot(server_id, process)
             # Check resource thresholds and kill/restart if exceeded
@@ -1986,6 +1997,7 @@ class MCPHealthMonitor:
                     )
                     success = False
             self._restart_counts[server_id] = count + 1
+            await self._check_stability(server_id)
             if success:
                 logger.info(f"MCP server '{server_id}' restarted successfully")
             else:
@@ -2176,3 +2188,39 @@ class MCPHealthMonitor:
         else:
             # Reset counter on any healthy cycle
             self._high_cpu_cycles.pop(server_id, None)
+
+    async def _check_stability(self, server_id: str) -> None:
+        """Record a restart timestamp and flag server as unstable if flapping."""
+        now = time.monotonic()
+        window = 600  # 10 minutes
+        storm_threshold = int(os.getenv("FMCP_RESTART_STORM_THRESHOLD", "5"))
+
+        timestamps = self._restart_timestamps.get(server_id, [])
+        timestamps.append(now)
+        # Keep only timestamps within the sliding window
+        timestamps = [t for t in timestamps if now - t <= window]
+        self._restart_timestamps[server_id] = timestamps
+
+        if len(timestamps) >= storm_threshold:
+            logger.warning(
+                f"[ALERT] {server_id} has restarted {len(timestamps)} times "
+                f"in the last 10 minutes — marking unstable"
+            )
+            try:
+                instance = await self._sm.db.get_instance_state(server_id) or {}
+                instance["server_id"] = server_id
+                instance["stability"] = "unstable"
+                await self._sm.db.save_instance_state(instance)
+            except Exception as e:
+                logger.error(f"Failed to update stability flag for '{server_id}': {e}")
+
+    async def _clear_stability(self, server_id: str) -> None:
+        """Clear the unstable flag after sustained healthy operation."""
+        try:
+            instance = await self._sm.db.get_instance_state(server_id)
+            if instance and instance.get("stability") == "unstable":
+                instance["stability"] = "stable"
+                await self._sm.db.save_instance_state(instance)
+                logger.info(f"[ALERT] {server_id} stability cleared after 5 minutes of healthy operation")
+        except Exception as e:
+            logger.error(f"Failed to clear stability flag for '{server_id}': {e}")

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2193,7 +2193,11 @@ class MCPHealthMonitor:
         """Record a restart timestamp and flag server as unstable if flapping."""
         now = time.monotonic()
         window = 600  # 10 minutes
-        storm_threshold = int(os.getenv("FMCP_RESTART_STORM_THRESHOLD", "5"))
+        try:
+            storm_threshold = int(os.getenv("FMCP_RESTART_STORM_THRESHOLD", "5"))
+        except (ValueError, TypeError):
+            logger.warning("Invalid FMCP_RESTART_STORM_THRESHOLD value, using default 5")
+            storm_threshold = 5
 
         timestamps = self._restart_timestamps.get(server_id, [])
         timestamps.append(now)

--- a/tests/test_stability_alerts.py
+++ b/tests/test_stability_alerts.py
@@ -1,0 +1,231 @@
+"""
+Tests for P5 - stability tracking and log-based alerts in MCPHealthMonitor.
+
+Covers:
+- Restart timestamps accumulate per server
+- Storm threshold triggers "unstable" flag in DB
+- Old timestamps outside 10-min window are pruned
+- Counter resets on sustained health (>5 min uptime)
+- _clear_stability clears "unstable" flag after healthy operation
+- _clear_stability is a no-op when already "stable"
+- stability field present in all get_server_status() return paths
+- Per-env FMCP_RESTART_STORM_THRESHOLD override
+"""
+import time
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
+
+from fluidmcp.cli.services.server_manager import ServerManager, MCPHealthMonitor
+from fluidmcp.cli.repositories import InMemoryBackend
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def monitor(server_manager):
+    return MCPHealthMonitor(server_manager, check_interval=30)
+
+
+# ---------------------------------------------------------------------------
+# _check_stability — restart timestamp accumulation
+# ---------------------------------------------------------------------------
+
+class TestCheckStability:
+
+    @pytest.mark.asyncio
+    async def test_timestamps_accumulate(self, monitor):
+        await monitor._check_stability("srv")
+        await monitor._check_stability("srv")
+        assert len(monitor._restart_timestamps.get("srv", [])) == 2
+
+    @pytest.mark.asyncio
+    async def test_old_timestamps_pruned(self, monitor):
+        # Inject 3 old timestamps outside the 10-min window
+        old = time.monotonic() - 700
+        monitor._restart_timestamps["srv"] = [old, old, old]
+
+        # A fresh restart should prune the old ones
+        await monitor._check_stability("srv")
+        assert len(monitor._restart_timestamps["srv"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_flag_below_threshold(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "5"}):
+            for _ in range(4):
+                await monitor._check_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        # Either no instance yet or stability not set to "unstable"
+        if instance:
+            assert instance.get("stability", "stable") != "unstable"
+
+    @pytest.mark.asyncio
+    async def test_marks_unstable_at_threshold(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "3"}):
+            for _ in range(3):
+                await monitor._check_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance is not None
+        assert instance.get("stability") == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_env_threshold_override_respected(self, monitor, server_manager):
+        # With threshold=2, second call should trigger unstable
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "2"}):
+            await monitor._check_stability("srv2")
+            instance = await server_manager.db.get_instance_state("srv2")
+            if instance:
+                assert instance.get("stability", "stable") != "unstable"  # only 1 so far
+
+            await monitor._check_stability("srv2")
+
+        instance = await server_manager.db.get_instance_state("srv2")
+        assert instance is not None
+        assert instance.get("stability") == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_multiple_servers_tracked_independently(self, monitor, server_manager):
+        with patch.dict("os.environ", {"FMCP_RESTART_STORM_THRESHOLD": "3"}):
+            for _ in range(3):
+                await monitor._check_stability("alpha")
+            for _ in range(2):
+                await monitor._check_stability("beta")
+
+        alpha_instance = await server_manager.db.get_instance_state("alpha")
+        beta_instance = await server_manager.db.get_instance_state("beta")
+
+        assert alpha_instance is not None
+        assert alpha_instance.get("stability") == "unstable"
+
+        if beta_instance:
+            assert beta_instance.get("stability", "stable") != "unstable"
+
+
+# ---------------------------------------------------------------------------
+# _clear_stability
+# ---------------------------------------------------------------------------
+
+class TestClearStability:
+
+    @pytest.mark.asyncio
+    async def test_clears_unstable_flag(self, monitor, server_manager):
+        # Seed an unstable instance directly
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "stability": "unstable",
+        })
+
+        await monitor._clear_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_already_stable(self, monitor, server_manager):
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "stability": "stable",
+        })
+
+        # Should not raise, should not change anything
+        await monitor._clear_stability("srv")
+
+        instance = await server_manager.db.get_instance_state("srv")
+        assert instance["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_instance(self, monitor, server_manager):
+        # No instance in DB — should not raise
+        await monitor._clear_stability("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_restart_timestamps_cleared_before_stability_clear(self, monitor, server_manager):
+        # Simulate the reset path that removes timestamps then schedules _clear_stability
+        monitor._restart_timestamps["srv"] = [time.monotonic()]
+
+        # The health monitor removes timestamps before calling _clear_stability
+        monitor._restart_timestamps.pop("srv", None)
+        await monitor._clear_stability("srv")
+
+        assert "srv" not in monitor._restart_timestamps
+
+
+# ---------------------------------------------------------------------------
+# stability field in get_server_status()
+# ---------------------------------------------------------------------------
+
+class TestStabilityInGetServerStatus:
+
+    @pytest.mark.asyncio
+    async def test_stability_present_when_running(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            "stability": "stable",
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert "stability" in status
+        assert status["stability"] == "stable"
+
+    @pytest.mark.asyncio
+    async def test_stability_unstable_surfaced(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            "stability": "unstable",
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert status["stability"] == "unstable"
+
+    @pytest.mark.asyncio
+    async def test_stability_defaults_to_stable_when_not_in_db(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "name": "Test"}
+
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        await server_manager.db.save_instance_state({
+            "server_id": "srv",
+            "state": "running",
+            "pid": 1234,
+            # no "stability" key
+        })
+
+        status = await server_manager.get_server_status("srv")
+        assert status.get("stability") == "stable"
+
+    @pytest.mark.asyncio
+    async def test_stability_present_for_not_found_server(self, server_manager):
+        status = await server_manager.get_server_status("ghost")
+        assert "stability" in status
+        assert status["stability"] == "stable"


### PR DESCRIPTION
## Summary
- `_check_stability()`: sliding 10-min window counts restart timestamps; marks server `stability = "unstable"` in DB when restarts ≥ `FMCP_RESTART_STORM_THRESHOLD` (env override, default 5) and logs `[ALERT]`
- `_clear_stability()`: clears `"unstable"` flag after 5 minutes of sustained healthy operation
- `stability` field added to **all** `get_server_status()` return paths — defaults to `"stable"` when not in DB
- `_check_stability()` called after every auto-restart; `_clear_stability()` scheduled when restart counter resets on sustained uptime

## Test plan
- [x] `test_timestamps_accumulate` — restart timestamps grow per server
- [x] `test_old_timestamps_pruned` — timestamps outside 10-min window are discarded
- [x] `test_no_flag_below_threshold` — no DB write before storm threshold
- [x] `test_marks_unstable_at_threshold` — DB flag set to `"unstable"` at threshold
- [x] `test_env_threshold_override_respected` — `FMCP_RESTART_STORM_THRESHOLD` env var works
- [x] `test_multiple_servers_tracked_independently` — no cross-contamination between server IDs
- [x] `test_clears_unstable_flag` — `_clear_stability` flips flag back to `"stable"`
- [x] `test_noop_when_already_stable` — no error/change when already stable
- [x] `test_noop_when_no_instance` — no crash on missing DB entry
- [x] `test_stability_present_when_running` — field present in running-process status
- [x] `test_stability_unstable_surfaced` — `"unstable"` propagates from DB to status response
- [x] `test_stability_defaults_to_stable_when_not_in_db` — missing field defaults correctly
- [x] `test_stability_present_for_not_found_server` — not-found path always returns `"stable"`

All 14 tests pass.

Generated with Claude Code