### PR TITLE
feat(debugging): P6 + P7 — concurrency limiting & Prometheus resource gauges

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -68,6 +68,13 @@ from ..services import omni_adapter
 from ..services.network_handle import NetworkSubprocessHandle
 
 from ..utils.env_utils import is_placeholder, has_env_var_syntax
+from ..services.metrics import get_registry as _get_metrics_registry
+
+try:
+    import psutil as _psutil
+    _psutil_available = True
+except ImportError:
+    _psutil_available = False
 
 router = APIRouter()
 security = HTTPBearer(auto_error=False)
@@ -1115,7 +1122,7 @@ async def get_server(request: Request, id: str):
     - status: state, pid, uptime, restart_count, stability, exit_code
     - resources: live memory/CPU/FD snapshot (null when not running)
     - concurrency: limit, active slots, lifetime rejected count
-    - crashes: recent crash count and crashes_per_hour from the last 10 minutes
+    - crashes: recent crash count and crashes in the last hour
     """
     manager = get_server_manager(request)
 
@@ -1144,26 +1151,28 @@ async def get_server(request: Request, id: str):
     }
     process = manager.processes.get(id)
     if process and process.poll() is None:
-        try:
-            import psutil as _psutil
-            proc = _psutil.Process(process.pid)
-            rss = proc.memory_info().rss
-            cpu = proc.cpu_percent(interval=None)
-            resources["pid"] = process.pid
-            resources["memory_rss_bytes"] = rss
-            resources["memory_rss_human"] = f"{rss / (1024 * 1024):.1f} MB"
-            resources["cpu_percent"] = cpu
-            resources["open_fds"] = proc.num_fds() if hasattr(proc, "num_fds") else None
-            resources["threads"] = proc.num_threads()
-            limit_mb = int(config.get("memory_limit_mb", 0) or
-                           int(os.environ.get("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
-            if limit_mb > 0:
-                limit_bytes = limit_mb * 1024 * 1024
-                resources["memory_limit_bytes"] = limit_bytes
-                resources["memory_limit_human"] = f"{limit_mb:.1f} MB"
-                resources["memory_usage_pct"] = round(rss / limit_bytes * 100, 1)
-        except Exception:
-            pass
+        if _psutil_available:
+            try:
+                proc = _psutil.Process(process.pid)
+                rss = proc.memory_info().rss
+                cpu = proc.cpu_percent(interval=None)
+                resources["pid"] = process.pid
+                resources["memory_rss_bytes"] = rss
+                resources["memory_rss_human"] = f"{rss / (1024 * 1024):.1f} MB"
+                resources["cpu_percent"] = cpu
+                resources["open_fds"] = proc.num_fds() if hasattr(proc, "num_fds") else None
+                resources["threads"] = proc.num_threads()
+                limit_mb = int(config.get("memory_limit_mb", 0) or
+                               int(os.environ.get("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+                if limit_mb > 0:
+                    limit_bytes = limit_mb * 1024 * 1024
+                    resources["memory_limit_bytes"] = limit_bytes
+                    resources["memory_limit_human"] = f"{limit_mb} MB"
+                    resources["memory_usage_pct"] = round(rss / limit_bytes * 100, 1)
+            except (_psutil.NoSuchProcess, _psutil.AccessDenied):
+                pass
+            except Exception as e:
+                logger.warning(f"Failed to read resources for '{id}': {e}")
     # Attach memory trend from health monitor if available
     monitor = getattr(manager, "_health_monitor", None)
     if monitor:
@@ -1172,9 +1181,7 @@ async def get_server(request: Request, id: str):
     # ── Concurrency ───────────────────────────────────────────────────────────
     manager.get_concurrency_semaphore(id)  # ensure semaphore is initialized
     conc_info = manager.get_concurrency_info(id)
-    from ..services.metrics import get_registry as _get_registry
-    _registry = _get_registry()
-    _rej_counter = _registry.get_metric("fluidmcp_requests_rejected_total")
+    _rej_counter = _get_metrics_registry().get_metric("fluidmcp_requests_rejected_total")
     rejected_total = 0
     if _rej_counter:
         _key = _rej_counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
@@ -1201,8 +1208,8 @@ async def get_server(request: Request, id: str):
             ) > one_hour_ago
         )
         crashes_summary["crashes_per_hour"] = float(crashes_last_hour)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.warning(f"Failed to load crash summary for '{id}': {e}")
 
     return {
         "id": id,
@@ -1884,8 +1891,6 @@ async def get_server_resources(request: Request, id: str, token: str = Depends(g
     rss = cpu = open_fds = threads = None
     status = "not_running"
     try:
-        if not _psutil_available:
-            raise ImportError("psutil not available")
         if pid and process and process.poll() is None:
             proc = _psutil.Process(pid)
             rss = proc.memory_info().rss
@@ -1959,9 +1964,7 @@ async def get_server_concurrency(request: Request, id: str):
     info = server_manager.get_concurrency_info(id)
 
     # Attach lifetime rejection count from metrics
-    from ..services.metrics import get_registry
-    registry = get_registry()
-    counter = registry.get_metric("fluidmcp_requests_rejected_total")
+    counter = _get_metrics_registry().get_metric("fluidmcp_requests_rejected_total")
     rejected_total = 0
     if counter is not None:
         key = counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1861,6 +1861,45 @@ async def get_server_resources(request: Request, id: str, token: str = Depends(g
     }
 
 
+# ==================== Concurrency Endpoint ====================
+
+@router.get("/servers/{id}/concurrency")
+async def get_server_concurrency(request: Request, id: str):
+    """
+    Return the concurrency limit and current active request count for a server.
+
+    - **max_concurrent_requests**: configured limit (null = unlimited)
+    - **active_requests**: requests currently holding a semaphore slot
+    - **available_slots**: free slots remaining (null = unlimited)
+    - **rejected_total**: lifetime rejected requests due to concurrency limit
+    """
+    server_manager = get_server_manager(request)
+
+    if id not in server_manager.configs:
+        raise HTTPException(status_code=404, detail=f"Server '{id}' not found")
+
+    # Ensure semaphore is initialized (lazy creation) before reading info
+    server_manager.get_concurrency_semaphore(id)
+    info = server_manager.get_concurrency_info(id)
+
+    # Attach lifetime rejection count from metrics
+    from ..services.metrics import get_registry
+    registry = get_registry()
+    counter = registry.get_metric("fluidmcp_requests_rejected_total")
+    rejected_total = 0
+    if counter is not None:
+        key = counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
+        rejected_total = int(counter.samples.get(key, 0))
+
+    return {
+        "server": id,
+        "max_concurrent_requests": info["max_concurrent_requests"],
+        "active_requests": info["active_requests"],
+        "available_slots": info["available_slots"],
+        "rejected_total": rejected_total,
+    }
+
+
 # ==================== Environment Variable Management ====================
 
 @router.get("/servers/{id}/instance/env")

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1155,11 +1155,9 @@ async def get_server(request: Request, id: str):
             try:
                 proc = _psutil.Process(process.pid)
                 rss = proc.memory_info().rss
-                cpu = proc.cpu_percent(interval=None)
                 resources["pid"] = process.pid
                 resources["memory_rss_bytes"] = rss
                 resources["memory_rss_human"] = f"{rss / (1024 * 1024):.1f} MB"
-                resources["cpu_percent"] = cpu
                 resources["open_fds"] = proc.num_fds() if hasattr(proc, "num_fds") else None
                 resources["threads"] = proc.num_threads()
                 limit_mb = int(config.get("memory_limit_mb", 0) or
@@ -1173,10 +1171,14 @@ async def get_server(request: Request, id: str):
                 pass
             except Exception as e:
                 logger.warning(f"Failed to read resources for '{id}': {e}")
-    # Attach memory trend from health monitor if available
+    # Use health monitor's cached snapshot for CPU (fresh psutil call always returns 0.0)
+    # and for memory trend
     monitor = getattr(manager, "_health_monitor", None)
     if monitor:
         resources["memory_trend"] = monitor.get_memory_trend(id)
+        snapshot = monitor._last_resource_snapshot.get(id)
+        if snapshot:
+            resources["cpu_percent"] = snapshot.get("cpu_percent")
 
     # ── Concurrency ───────────────────────────────────────────────────────────
     manager.get_concurrency_semaphore(id)  # ensure semaphore is initialized

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1111,13 +1111,11 @@ async def list_servers(request: Request, enabled_only: bool = True, include_dele
 @router.get("/servers/{id}")
 async def get_server(request: Request, id: str):
     """
-    Get detailed information about a specific server.
-
-    Args:
-        id: Server identifier
-
-    Returns:
-        Server config and status
+    Get detailed information about a specific server, including debug fields:
+    - status: state, pid, uptime, restart_count, stability, exit_code
+    - resources: live memory/CPU/FD snapshot (null when not running)
+    - concurrency: limit, active slots, lifetime rejected count
+    - crashes: recent crash count and crashes_per_hour from the last 10 minutes
     """
     manager = get_server_manager(request)
 
@@ -1128,14 +1126,92 @@ async def get_server(request: Request, id: str):
     if not config:
         raise HTTPException(404, f"Server '{id}' not found")
 
-    # Get status
+    # Core status
     status = await manager.get_server_status(id)
+
+    # ── Resources ────────────────────────────────────────────────────────────
+    resources = {
+        "pid": None,
+        "memory_rss_bytes": None,
+        "memory_rss_human": None,
+        "memory_trend": "unknown",
+        "memory_limit_bytes": None,
+        "memory_limit_human": None,
+        "memory_usage_pct": None,
+        "cpu_percent": None,
+        "open_fds": None,
+        "threads": None,
+    }
+    process = manager.processes.get(id)
+    if process and process.poll() is None:
+        try:
+            import psutil as _psutil
+            proc = _psutil.Process(process.pid)
+            rss = proc.memory_info().rss
+            cpu = proc.cpu_percent(interval=None)
+            resources["pid"] = process.pid
+            resources["memory_rss_bytes"] = rss
+            resources["memory_rss_human"] = f"{rss / (1024 * 1024):.1f} MB"
+            resources["cpu_percent"] = cpu
+            resources["open_fds"] = proc.num_fds() if hasattr(proc, "num_fds") else None
+            resources["threads"] = proc.num_threads()
+            limit_mb = int(config.get("memory_limit_mb", 0) or
+                           int(os.environ.get("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+            if limit_mb > 0:
+                limit_bytes = limit_mb * 1024 * 1024
+                resources["memory_limit_bytes"] = limit_bytes
+                resources["memory_limit_human"] = f"{limit_mb:.1f} MB"
+                resources["memory_usage_pct"] = round(rss / limit_bytes * 100, 1)
+        except Exception:
+            pass
+    # Attach memory trend from health monitor if available
+    monitor = getattr(manager, "_health_monitor", None)
+    if monitor:
+        resources["memory_trend"] = monitor.get_memory_trend(id)
+
+    # ── Concurrency ───────────────────────────────────────────────────────────
+    manager.get_concurrency_semaphore(id)  # ensure semaphore is initialized
+    conc_info = manager.get_concurrency_info(id)
+    from ..services.metrics import get_registry as _get_registry
+    _registry = _get_registry()
+    _rej_counter = _registry.get_metric("fluidmcp_requests_rejected_total")
+    rejected_total = 0
+    if _rej_counter:
+        _key = _rej_counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
+        rejected_total = int(_rej_counter.samples.get(_key, 0))
+    concurrency = {
+        "max_concurrent_requests": conc_info["max_concurrent_requests"],
+        "active_requests": conc_info["active_requests"],
+        "available_slots": conc_info["available_slots"],
+        "rejected_total": rejected_total,
+    }
+
+    # ── Crash summary ─────────────────────────────────────────────────────────
+    crashes_summary = {"recent_crash_count": 0, "crashes_per_hour": 0.0}
+    try:
+        events = await manager.db.list_crash_events(id, limit=50)
+        crashes_summary["recent_crash_count"] = len(events)
+        now = datetime.utcnow()
+        one_hour_ago = (now - timedelta(hours=1)).timestamp()
+        crashes_last_hour = sum(
+            1 for e in events
+            if e.get("timestamp") and (
+                e["timestamp"].timestamp() if hasattr(e["timestamp"], "timestamp")
+                else float(e["timestamp"])
+            ) > one_hour_ago
+        )
+        crashes_summary["crashes_per_hour"] = float(crashes_last_hour)
+    except Exception:
+        pass
 
     return {
         "id": id,
         "name": config.get("name"),
         "config": config,
-        "status": status
+        "status": status,
+        "resources": resources,
+        "concurrency": concurrency,
+        "crashes": crashes_summary,
     }
 
 

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1149,9 +1149,12 @@ async def get_server(request: Request, id: str):
         "open_fds": None,
         "threads": None,
     }
-    process = manager.processes.get(id)
-    if process and process.poll() is None:
-        if _psutil_available:
+    # Only read live resources when status agrees the process is running.
+    # This prevents a race where processes[] still has the handle but status
+    # already resolved to "failed" (stale PID path).
+    if status.get("state") == "running" and _psutil_available:
+        process = manager.processes.get(id)
+        if process and process.poll() is None:
             try:
                 proc = _psutil.Process(process.pid)
                 rss = proc.memory_info().rss
@@ -1171,13 +1174,14 @@ async def get_server(request: Request, id: str):
                 pass
             except Exception as e:
                 logger.warning(f"Failed to read resources for '{id}': {e}")
+
     # Use health monitor's cached snapshot for CPU (fresh psutil call always returns 0.0)
     # and for memory trend
     monitor = getattr(manager, "_health_monitor", None)
     if monitor:
         resources["memory_trend"] = monitor.get_memory_trend(id)
         snapshot = monitor._last_resource_snapshot.get(id)
-        if snapshot:
+        if snapshot and status.get("state") == "running":
             resources["cpu_percent"] = snapshot.get("cpu_percent")
 
     # ── Concurrency ───────────────────────────────────────────────────────────

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1110,7 +1110,7 @@ async def list_servers(request: Request, enabled_only: bool = True, include_dele
 
 
 @router.get("/servers/{id}")
-async def get_server(request: Request, id: str):
+async def get_server(request: Request, id: str, token: str = Depends(get_token)):
     """
     Get detailed information about a specific server, including debug fields:
     - status: state, pid, uptime, restart_count, stability, exit_code

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -55,12 +55,6 @@ except ImportError:
 from ..services.llm_provider_registry import get_model_type, get_model_config, list_models_by_type
 from ..services.server_manager import classify_exit_code
 
-try:
-    import psutil as _psutil
-    _psutil_available = True
-except ImportError:
-    _psutil = None
-    _psutil_available = False
 from ..services.replicate_openai_adapter import replicate_chat_completion
 from ..services.replicate_client import ReplicateClient, get_replicate_client
 from ..services.llm_metrics import get_metrics_collector
@@ -272,7 +266,7 @@ async def log_audit_event(
             "action": action,
             "model_id": model_id,
             "client_ip": client_ip,
-            "timestamp": datetime.utcnow(),
+            "timestamp": datetime.now(timezone.utc),
             "status": status,
         }
 
@@ -1190,8 +1184,7 @@ async def get_server(request: Request, id: str):
     _rej_counter = _get_metrics_registry().get_metric("fluidmcp_requests_rejected_total")
     rejected_total = 0
     if _rej_counter:
-        _key = _rej_counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
-        rejected_total = int(_rej_counter.samples.get(_key, 0))
+        rejected_total = int(_rej_counter.get_count({"server_id": id, "reason": "concurrency_limit"}))
     concurrency = {
         "max_concurrent_requests": conc_info["max_concurrent_requests"],
         "active_requests": conc_info["active_requests"],
@@ -1200,20 +1193,12 @@ async def get_server(request: Request, id: str):
     }
 
     # ── Crash summary ─────────────────────────────────────────────────────────
-    crashes_summary = {"recent_crash_count": 0, "crashes_per_hour": 0.0}
+    crashes_summary = {"recent_crash_count": 0, "crashes_last_hour": 0}
     try:
-        events = await manager.db.list_crash_events(id, limit=50)
-        crashes_summary["recent_crash_count"] = len(events)
-        now = datetime.utcnow()
-        one_hour_ago = (now - timedelta(hours=1)).timestamp()
-        crashes_last_hour = sum(
-            1 for e in events
-            if e.get("timestamp") and (
-                e["timestamp"].timestamp() if hasattr(e["timestamp"], "timestamp")
-                else float(e["timestamp"])
-            ) > one_hour_ago
-        )
-        crashes_summary["crashes_per_hour"] = float(crashes_last_hour)
+        now = datetime.now(timezone.utc)
+        one_hour_ago_ts = (now - timedelta(hours=1)).timestamp()
+        crashes_summary["recent_crash_count"] = await manager.db.count_crash_events_since(id, 0)
+        crashes_summary["crashes_last_hour"] = await manager.db.count_crash_events_since(id, one_hour_ago_ts)
     except Exception as e:
         logger.warning(f"Failed to load crash summary for '{id}': {e}")
 
@@ -1396,8 +1381,7 @@ async def delete_server(
     # Clean up stale instance state so a re-clone of the same server ID starts fresh
     await manager.db.reset_instance_state(id)
 
-    from datetime import datetime
-    deleted_at = datetime.utcnow().isoformat()
+    deleted_at = datetime.now(timezone.utc).isoformat()
     logger.info(f"Soft deleted server configuration: {id}")
     return {
         "message": f"Server '{id}' deleted successfully",
@@ -1830,8 +1814,8 @@ async def get_server_crashes(
         if hasattr(crash.get("timestamp"), "isoformat"):
             crash["timestamp"] = crash["timestamp"].isoformat()
 
-    # crashes_per_hour: query the DB for the full count in the last hour,
-    # independent of the `limit` param so the metric is always accurate.
+    # crashes_last_hour: full count in the last hour, independent of the `limit`
+    # param so the metric is always accurate.
     now = datetime.now(timezone.utc)
     one_hour_ago_ts = (now - timedelta(hours=1)).timestamp()
     crashes_last_hour = await manager.db.count_crash_events_since(id, one_hour_ago_ts)
@@ -1843,7 +1827,7 @@ async def get_server_crashes(
     return {
         "server": id,
         "restart_count": restart_count,
-        "crashes_per_hour": crashes_last_hour,
+        "crashes_last_hour": crashes_last_hour,
         "crashes": crashes,
     }
 
@@ -1897,7 +1881,7 @@ async def get_server_resources(request: Request, id: str, token: str = Depends(g
     rss = cpu = open_fds = threads = None
     status = "not_running"
     try:
-        if pid and process and process.poll() is None:
+        if pid and process and _psutil_available and process.poll() is None:
             proc = _psutil.Process(pid)
             rss = proc.memory_info().rss
             cpu = proc.cpu_percent(interval=None)
@@ -1973,8 +1957,7 @@ async def get_server_concurrency(request: Request, id: str):
     counter = _get_metrics_registry().get_metric("fluidmcp_requests_rejected_total")
     rejected_total = 0
     if counter is not None:
-        key = counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
-        rejected_total = int(counter.samples.get(key, 0))
+        rejected_total = int(counter.get_count({"server_id": id, "reason": "concurrency_limit"}))
 
     return {
         "server": id,
@@ -2516,10 +2499,9 @@ async def stop_llm_model(
         db = get_db_manager()
         if db and hasattr(db, 'update_llm_model'):
             try:
-                from datetime import datetime
                 await db.update_llm_model(model_id, {
                     "state": "stopped",
-                    "stopped_at": datetime.utcnow().isoformat(),
+                    "stopped_at": datetime.now(timezone.utc).isoformat(),
                     "stop_method": stop_method
                 })
                 state_persisted = True
@@ -2609,10 +2591,9 @@ async def start_llm_model(
         # Update state in database
         state_persisted = False
         try:
-            from datetime import datetime
             await db.update_llm_model(model_id, {
                 "state": "running",
-                "started_at": datetime.utcnow().isoformat(),
+                "started_at": datetime.now(timezone.utc).isoformat(),
                 "stopped_at": None,
                 "stop_method": None
             })

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -3275,6 +3275,33 @@ async def get_metrics_prometheus(
     )
 
 
+@router.get("/metrics/mcp")
+async def get_mcp_metrics_prometheus(
+    token: str = Depends(get_token)
+):
+    """
+    Get Prometheus-formatted metrics for all MCP servers.
+
+    Returns per-server metrics updated every health check cycle (~30s):
+    - fluidmcp_server_memory_rss_bytes{server_id} — RSS memory of the MCP process
+    - fluidmcp_server_cpu_percent{server_id} — CPU utilization of the MCP process
+    - fluidmcp_server_open_fds{server_id} — open file descriptors
+    - fluidmcp_active_requests{server_id} — requests currently in flight
+    - fluidmcp_requests_total{server_id, method, status} — total requests processed
+    - fluidmcp_requests_rejected_total{server_id, reason} — requests dropped by concurrency limit
+    - fluidmcp_server_restarts_total{server_id, reason} — total server restarts
+    - fluidmcp_server_status{server_id} — server state (0=stopped, 2=running, 3=error)
+    - fluidmcp_request_duration_seconds{server_id, method} — request latency histogram
+
+    Example:
+        curl http://localhost:8099/api/metrics/mcp
+    """
+    return Response(
+        content=_get_metrics_registry().render_all(),
+        media_type="text/plain; version=0.0.4"
+    )
+
+
 @router.get("/metrics/json")
 async def get_metrics_json(
     token: str = Depends(get_token)

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1935,7 +1935,7 @@ async def get_server_resources(request: Request, id: str, token: str = Depends(g
 # ==================== Concurrency Endpoint ====================
 
 @router.get("/servers/{id}/concurrency")
-async def get_server_concurrency(request: Request, id: str):
+async def get_server_concurrency(request: Request, id: str, token: str = Depends(get_token)):
     """
     Return the concurrency limit and current active request count for a server.
 

--- a/fluidmcp/cli/services/metrics.py
+++ b/fluidmcp/cli/services/metrics.py
@@ -375,6 +375,12 @@ class MetricsRegistry:
             labels=[]
         ))
 
+        self.register(Counter(
+            "fluidmcp_requests_rejected_total",
+            "Total number of requests rejected due to concurrency limit",
+            labels=["server_id", "reason"]
+        ))
+
     def register(self, metric: Metric):
         """Register a metric."""
         with self._lock:
@@ -633,6 +639,12 @@ class MetricsCollector:
         tool_duration = self.registry.get_metric("fluidmcp_tool_execution_seconds")
         if tool_duration:
             tool_duration.observe(duration, {"server_id": self.server_id, "tool_name": tool_name})
+
+    def record_rejected_request(self, reason: str):
+        """Increment the concurrency-rejection counter."""
+        rejected = self.registry.get_metric("fluidmcp_requests_rejected_total")
+        if rejected:
+            rejected.inc({"server_id": self.server_id, "reason": reason})
 
     def record_streaming_request(self, completion_status: str):
         """Record a streaming request."""

--- a/fluidmcp/cli/services/metrics.py
+++ b/fluidmcp/cli/services/metrics.py
@@ -387,6 +387,25 @@ class MetricsRegistry:
             labels=["server_id", "reason"]
         ))
 
+        # Per-MCP-server resource gauges (updated every health check cycle)
+        self.register(Gauge(
+            "fluidmcp_server_memory_rss_bytes",
+            "Resident set size of the MCP server process in bytes",
+            labels=["server_id"]
+        ))
+
+        self.register(Gauge(
+            "fluidmcp_server_cpu_percent",
+            "CPU utilization of the MCP server process (percent, may exceed 100 on multi-core)",
+            labels=["server_id"]
+        ))
+
+        self.register(Gauge(
+            "fluidmcp_server_open_fds",
+            "Number of open file descriptors for the MCP server process",
+            labels=["server_id"]
+        ))
+
     def register(self, metric: Metric):
         """Register a metric."""
         with self._lock:
@@ -645,6 +664,24 @@ class MetricsCollector:
         tool_duration = self.registry.get_metric("fluidmcp_tool_execution_seconds")
         if tool_duration:
             tool_duration.observe(duration, {"server_id": self.server_id, "tool_name": tool_name})
+
+    def set_server_memory_rss(self, rss_bytes: float):
+        """Set per-MCP-server RSS memory gauge."""
+        gauge = self.registry.get_metric("fluidmcp_server_memory_rss_bytes")
+        if gauge:
+            gauge.set(rss_bytes, {"server_id": self.server_id})
+
+    def set_server_cpu_percent(self, cpu: float):
+        """Set per-MCP-server CPU percent gauge."""
+        gauge = self.registry.get_metric("fluidmcp_server_cpu_percent")
+        if gauge:
+            gauge.set(cpu, {"server_id": self.server_id})
+
+    def set_server_open_fds(self, fds: int):
+        """Set per-MCP-server open file descriptor gauge."""
+        gauge = self.registry.get_metric("fluidmcp_server_open_fds")
+        if gauge:
+            gauge.set(fds, {"server_id": self.server_id})
 
     def record_rejected_request(self, reason: str):
         """Increment the concurrency-rejection counter."""

--- a/fluidmcp/cli/services/metrics.py
+++ b/fluidmcp/cli/services/metrics.py
@@ -11,12 +11,18 @@ Metrics exposed:
 """
 
 import math
+import re
 import time
 from typing import Dict, Any, Optional, List
 from collections import defaultdict
 from threading import Lock
 
 from loguru import logger
+
+
+def _escape_label_value(value: str) -> str:
+    """Escape a Prometheus label value per the text exposition spec."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 class Metric:
@@ -63,7 +69,7 @@ class Metric:
         with self._lock:
             for key, value in sorted(self.samples.items()):
                 if self.labels:
-                    label_str = ",".join(f'{label}="{val}"' for label, val in zip(self.labels, key))
+                    label_str = ",".join(f'{label}="{_escape_label_value(val)}"' for label, val in zip(self.labels, key))
                     lines.append(f"{self.name}{{{label_str}}} {value}")
                 else:
                     lines.append(f"{self.name} {value}")
@@ -230,7 +236,7 @@ class Histogram(Metric):
             for key, hist in sorted(self.histograms.items()):
                 base_labels = ""
                 if self.labels:
-                    base_labels = ",".join(f'{label}="{val}"' for label, val in zip(self.labels, key))
+                    base_labels = ",".join(f'{label}="{_escape_label_value(val)}"' for label, val in zip(self.labels, key))
 
                 # Emit bucket counts
                 cumulative = 0

--- a/fluidmcp/cli/services/metrics.py
+++ b/fluidmcp/cli/services/metrics.py
@@ -70,6 +70,12 @@ class Metric:
 
         return "\n".join(lines)
 
+    def get_count(self, label_values: Optional[Dict[str, str]] = None) -> float:
+        """Return the current value for the given label combination (0.0 if unseen)."""
+        key = self._get_label_key(label_values or {})
+        with self._lock:
+            return self.samples.get(key, 0.0)
+
     def clear_samples(self):
         """
         Clear all samples for this metric (thread-safe).

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -588,14 +588,16 @@ def create_dynamic_router(server_manager):
                 return JSONResponse(content=response)
             # ── stdio transport continues below ─────────────────────────────
 
-            # Check if process is alive
-            if process.poll() is not None:
+            # Check if process is alive (stdio only — SSE/Network handles don't have .poll())
+            if not isinstance(process, (SseSubprocessHandle, NetworkSubprocessHandle)) and process.poll() is not None:
                 raise HTTPException(503, f"Server '{server_name}' is not running (process died)")
 
             # Concurrency limiting — try a non-blocking acquire; drop with 429 if full
             sem = server_manager.get_concurrency_semaphore(server_name)
             if sem is not None:
-                acquired = sem._value > 0  # peek: True if a slot is free
+                # sem._value peek is safe in asyncio: no await between check and acquire,
+                # so no other coroutine can interleave and take the slot.
+                acquired = sem._value > 0
                 if not acquired:
                     collector.record_rejected_request("concurrency_limit")
                     return Response(
@@ -692,6 +694,20 @@ def create_dynamic_router(server_manager):
         process = server_manager.processes.get(server_name)
         if process is None:
             raise HTTPException(503, f"Server '{server_name}' failed to start")
+
+        # Concurrency limiting for SSE — long-lived connections consume a slot for their duration
+        _sse_sem = server_manager.get_concurrency_semaphore(server_name)
+        if _sse_sem is not None:
+            # sem._value peek is safe in asyncio: no await between check and acquire
+            if _sse_sem._value <= 0:
+                collector.record_rejected_request("concurrency_limit")
+                return Response(
+                    content='{"error":"too many concurrent requests"}',
+                    status_code=429,
+                    media_type="application/json",
+                    headers={"Retry-After": "1"},
+                )
+            await _sse_sem.acquire()
 
         async def event_generator() -> AsyncIterator[str]:
             completion_status = "success"
@@ -827,6 +843,8 @@ def create_dynamic_router(server_manager):
                 # Record streaming metrics
                 collector.record_streaming_request(completion_status)
                 collector.decrement_active_streams()
+                if _sse_sem is not None:
+                    _sse_sem.release()
 
         return StreamingResponse(
             event_generator(),

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -557,48 +557,16 @@ def create_dynamic_router(server_manager):
             if process is None:
                 raise HTTPException(503, f"Server '{server_name}' failed to start")
 
-            # ── Network transport: forward via HTTP ──────────────────────────
-            if isinstance(process, NetworkSubprocessHandle):
-                logger.info(f"[mcp.call] {ctx}")
-                if process.transport == "http":
-                    try:
-                        _http_timeout = float(os.environ.get("FMCP_HTTP_PROXY_TIMEOUT", "60"))
-                        response = await _proxy_to_http_server(process.base_url, request, timeout=_http_timeout, session_id=process.session_id, client=process.http_client)
-                    except HTTPException as exc:
-                        if exc.status_code == 504:
-                            # Gateway timed out — subprocess is unresponsive. Fire-and-forget
-                            # an immediate restart without waiting for the next health-check cycle.
-                            monitor = getattr(server_manager, "_health_monitor", None)
-                            if monitor is not None:
-                                logger.error(
-                                    f"[RESTART] '{server_name}' — 504 from subprocess, "
-                                    f"scheduling immediate restart"
-                                )
-                                asyncio.ensure_future(monitor.trigger_restart(server_name))
-                            else:
-                                logger.error(
-                                    f"[RESTART] '{server_name}' — 504 from subprocess but "
-                                    f"health monitor not available, server will not auto-restart"
-                                )
-                        raise
-                else:
-                    response = await _proxy_to_sse_server(process.base_url, request)
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-                logger.info(f"[mcp.ok] {ctx} elapsed={elapsed_ms}ms transport=network")
-                return JSONResponse(content=response)
-            # ── stdio transport continues below ─────────────────────────────
-
             # Check if process is alive (stdio only — SSE/Network handles don't have .poll())
             if not isinstance(process, (SseSubprocessHandle, NetworkSubprocessHandle)) and process.poll() is not None:
                 raise HTTPException(503, f"Server '{server_name}' is not running (process died)")
 
-            # Concurrency limiting — try a non-blocking acquire; drop with 429 if full
+            # Concurrency limiting — wraps ALL transport paths (network, SSE, stdio).
+            # sem._value peek is safe in asyncio: no await between check and acquire,
+            # so no other coroutine can interleave and take the slot.
             sem = server_manager.get_concurrency_semaphore(server_name)
             if sem is not None:
-                # sem._value peek is safe in asyncio: no await between check and acquire,
-                # so no other coroutine can interleave and take the slot.
-                acquired = sem._value > 0
-                if not acquired:
+                if sem._value <= 0:
                     collector.record_rejected_request("concurrency_limit")
                     return Response(
                         content='{"error":"too many concurrent requests"}',
@@ -609,13 +577,38 @@ def create_dynamic_router(server_manager):
                 await sem.acquire()
 
             try:
+                # ── Network transport: forward via HTTP ──────────────────────────
+                if isinstance(process, NetworkSubprocessHandle):
+                    if process.transport == "http":
+                        try:
+                            _http_timeout = float(os.environ.get("FMCP_HTTP_PROXY_TIMEOUT", "60"))
+                            response = await _proxy_to_http_server(process.base_url, request, timeout=_http_timeout, session_id=process.session_id, client=process.http_client)
+                        except HTTPException as exc:
+                            if exc.status_code == 504:
+                                monitor = getattr(server_manager, "_health_monitor", None)
+                                if monitor is not None:
+                                    logger.error(
+                                        f"[RESTART] '{server_name}' — 504 from subprocess, "
+                                        f"scheduling immediate restart"
+                                    )
+                                    asyncio.ensure_future(monitor.trigger_restart(server_name))
+                                else:
+                                    logger.error(
+                                        f"[RESTART] '{server_name}' — 504 from subprocess but "
+                                        f"health monitor not available, server will not auto-restart"
+                                    )
+                            raise
+                    else:
+                        response = await _proxy_to_sse_server(process.base_url, request)
+                    return JSONResponse(content=response)
+
                 # ── SSE transport: forward via HTTP ─────────────────────────────
                 if isinstance(process, SseSubprocessHandle):
                     with RequestTimer(collector, request.get("method", "unknown")):
                         response = await _proxy_to_sse_server(process.sse_url, request)
                         return JSONResponse(content=response)
-                # ── stdio transport continues below ─────────────────────────────
 
+                # ── stdio transport ──────────────────────────────────────────────
                 try:
                     # Send request to MCP server
                     msg = json.dumps(request)

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -858,50 +858,67 @@ def create_dynamic_router(server_manager):
         if process is None:
             raise HTTPException(503, f"Server '{server_name}' failed to start")
 
-        # ── Network transport ────────────────────────────────────────────────
-        if isinstance(process, NetworkSubprocessHandle):
-            payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
-            if process.transport == "http":
-                response = await _proxy_to_http_server(process.base_url, payload, timeout=30.0, session_id=process.session_id, client=process.http_client)
-            else:
-                response = await _proxy_to_sse_server(process.base_url, payload, timeout=30.0)
-            return JSONResponse(content=response)
-        # ── stdio transport continues below ──────────────────────────────────
+        collector = MetricsCollector(server_name)
+        sem = server_manager.get_concurrency_semaphore(server_name)
+        if sem is not None:
+            if sem._value <= 0:
+                collector.record_rejected_request("concurrency_limit")
+                return Response(
+                    content='{"error":"too many concurrent requests"}',
+                    status_code=429,
+                    media_type="application/json",
+                    headers={"Retry-After": "1"},
+                )
+            await sem.acquire()
 
         try:
-            request_payload = {
-                "id": 1,
-                "jsonrpc": "2.0",
-                "method": "tools/list"
-            }
+            # ── Network transport ────────────────────────────────────────────────
+            if isinstance(process, NetworkSubprocessHandle):
+                payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+                if process.transport == "http":
+                    response = await _proxy_to_http_server(process.base_url, payload, timeout=30.0, session_id=process.session_id, client=process.http_client)
+                else:
+                    response = await _proxy_to_sse_server(process.base_url, payload, timeout=30.0)
+                return JSONResponse(content=response)
+            # ── stdio transport continues below ──────────────────────────────────
 
-            msg = json.dumps(request_payload)
-            async with _get_io_lock(server_name):
-                try:
-                    process.stdin.write(msg + "\n")
-                    process.stdin.flush()
-                except (BrokenPipeError, OSError) as e:
-                    raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
+            try:
+                request_payload = {
+                    "id": 1,
+                    "jsonrpc": "2.0",
+                    "method": "tools/list"
+                }
 
-                # Wait for the tools/list response from the MCP subprocess.
-                # _readline_with_timeout runs inside the thread and uses select() to
-                # enforce the timeout at the OS level, ensuring the thread returns and
-                # its pool slot is freed if this server hangs.
-                response_line = await asyncio.to_thread(
-                    _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
-                )
-                if not response_line:
-                    # select() timed out — no response received within the deadline.
-                    raise HTTPException(504, f"Server '{server_name}' did not respond within {_MCP_READ_TIMEOUT} seconds")
-            response_data = json.loads(response_line)
+                msg = json.dumps(request_payload)
+                async with _get_io_lock(server_name):
+                    try:
+                        process.stdin.write(msg + "\n")
+                        process.stdin.flush()
+                    except (BrokenPipeError, OSError) as e:
+                        raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
 
-            return JSONResponse(content=response_data)
+                    # Wait for the tools/list response from the MCP subprocess.
+                    # _readline_with_timeout runs inside the thread and uses select() to
+                    # enforce the timeout at the OS level, ensuring the thread returns and
+                    # its pool slot is freed if this server hangs.
+                    response_line = await asyncio.to_thread(
+                        _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
+                    )
+                    if not response_line:
+                        # select() timed out — no response received within the deadline.
+                        raise HTTPException(504, f"Server '{server_name}' did not respond within {_MCP_READ_TIMEOUT} seconds")
+                response_data = json.loads(response_line)
 
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Error listing tools for '{server_name}': {e}")
-            raise HTTPException(500, f"Error communicating with server: {str(e)}")
+                return JSONResponse(content=response_data)
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"Error listing tools for '{server_name}': {e}")
+                raise HTTPException(500, f"Error communicating with server: {str(e)}")
+        finally:
+            if sem is not None:
+                sem.release()
 
     @router.post("/{server_name}/mcp/tools/call", tags=["mcp"])
     async def call_tool(
@@ -924,66 +941,83 @@ def create_dynamic_router(server_manager):
         if process is None:
             raise HTTPException(503, f"Server '{server_name}' failed to start")
 
-        # ── Network transport ────────────────────────────────────────────────
-        if isinstance(process, NetworkSubprocessHandle):
-            if "name" not in request_body:
-                raise HTTPException(400, "Tool name is required")
-            payload = {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": request_body}
-            if process.transport == "http":
-                response = await _proxy_to_http_server(process.base_url, payload, timeout=60.0, session_id=process.session_id, client=process.http_client)
-            else:
-                response = await _proxy_to_sse_server(process.base_url, payload, timeout=60.0)
-            return JSONResponse(content=response)
-        # ── stdio transport continues below ──────────────────────────────────
+        collector = MetricsCollector(server_name)
+        sem = server_manager.get_concurrency_semaphore(server_name)
+        if sem is not None:
+            if sem._value <= 0:
+                collector.record_rejected_request("concurrency_limit")
+                return Response(
+                    content='{"error":"too many concurrent requests"}',
+                    status_code=429,
+                    media_type="application/json",
+                    headers={"Retry-After": "1"},
+                )
+            await sem.acquire()
 
         try:
-            if "name" not in request_body:
-                raise HTTPException(400, "Tool name is required")
+            # ── Network transport ────────────────────────────────────────────────
+            if isinstance(process, NetworkSubprocessHandle):
+                if "name" not in request_body:
+                    raise HTTPException(400, "Tool name is required")
+                payload = {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": request_body}
+                if process.transport == "http":
+                    response = await _proxy_to_http_server(process.base_url, payload, timeout=60.0, session_id=process.session_id, client=process.http_client)
+                else:
+                    response = await _proxy_to_sse_server(process.base_url, payload, timeout=60.0)
+                return JSONResponse(content=response)
+            # ── stdio transport continues below ──────────────────────────────────
 
-            request_payload = {
-                "jsonrpc": "2.0",
-                "id": 2,
-                "method": "tools/call",
-                "params": request_body
-            }
+            try:
+                if "name" not in request_body:
+                    raise HTTPException(400, "Tool name is required")
 
-            msg = json.dumps(request_payload)
-            async with _get_io_lock(server_name):
-                try:
-                    process.stdin.write(msg + "\n")
-                    process.stdin.flush()
-                except (BrokenPipeError, OSError) as e:
-                    raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
+                request_payload = {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": request_body
+                }
 
-                # Wait for the tool execution response from the MCP subprocess.
-                # Tool calls can be long-running, so _MCP_READ_TIMEOUT is the upper bound.
-                # _readline_with_timeout uses select() inside the thread so the thread
-                # exits on timeout rather than blocking the ThreadPoolExecutor slot forever.
-                # Without this, a single hanging tool call occupies a thread indefinitely;
-                # enough concurrent hangs will exhaust the pool and block all other servers.
-                response_line = await asyncio.to_thread(
-                    _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
-                )
-                if not response_line:
-                    # select() timed out — persist the failure for observability before raising.
-                    await server_manager.db.save_log_entry({
-                        "server_name": server_name,
-                        "stream": "error",
-                        "content": f"Tool '{request_body.get('name', 'unknown')}' execution timed out after {_MCP_READ_TIMEOUT} seconds"
-                    })
-                    raise HTTPException(504, "Tool execution timed out")
+                msg = json.dumps(request_payload)
+                async with _get_io_lock(server_name):
+                    try:
+                        process.stdin.write(msg + "\n")
+                        process.stdin.flush()
+                    except (BrokenPipeError, OSError) as e:
+                        raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
 
-            response_data = json.loads(response_line)
+                    # Wait for the tool execution response from the MCP subprocess.
+                    # Tool calls can be long-running, so _MCP_READ_TIMEOUT is the upper bound.
+                    # _readline_with_timeout uses select() inside the thread so the thread
+                    # exits on timeout rather than blocking the ThreadPoolExecutor slot forever.
+                    # Without this, a single hanging tool call occupies a thread indefinitely;
+                    # enough concurrent hangs will exhaust the pool and block all other servers.
+                    response_line = await asyncio.to_thread(
+                        _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
+                    )
+                    if not response_line:
+                        # select() timed out — persist the failure for observability before raising.
+                        await server_manager.db.save_log_entry({
+                            "server_name": server_name,
+                            "stream": "error",
+                            "content": f"Tool '{request_body.get('name', 'unknown')}' execution timed out after {_MCP_READ_TIMEOUT} seconds"
+                        })
+                        raise HTTPException(504, "Tool execution timed out")
 
-            # Update last_used_at for idle cleanup
-            await server_manager.update_last_used(server_name)
+                response_data = json.loads(response_line)
 
-            return JSONResponse(content=response_data)
+                # Update last_used_at for idle cleanup
+                await server_manager.update_last_used(server_name)
 
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.error(f"Error calling tool on '{server_name}': {e}")
-            raise HTTPException(500, f"Error communicating with server: {str(e)}")
+                return JSONResponse(content=response_data)
+
+            except HTTPException:
+                raise
+            except Exception as e:
+                logger.error(f"Error calling tool on '{server_name}': {e}")
+                raise HTTPException(500, f"Error communicating with server: {str(e)}")
+        finally:
+            if sem is not None:
+                sem.release()
 
     return router

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -16,7 +16,9 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 from ..utils.env_utils import is_placeholder
 from .metrics import MetricsCollector, RequestTimer
+from fastapi.responses import Response
 from .network_handle import NetworkSubprocessHandle
+from .sse_handle import SseSubprocessHandle
 
 security = HTTPBearer(auto_error=False)
 
@@ -586,75 +588,69 @@ def create_dynamic_router(server_manager):
                 return JSONResponse(content=response)
             # ── stdio transport continues below ─────────────────────────────
 
-            try:
-                msg = json.dumps(request)
-                logger.info(f"[mcp.call] {ctx}")
+            # Check if process is alive
+            if process.poll() is not None:
+                raise HTTPException(503, f"Server '{server_name}' is not running (process died)")
 
-                io_lock = _get_io_lock(server_name)
-                # Non-blocking acquire first; warn before blocking so contention is
-                # visible in logs without adding overhead on the happy path.
-                if not io_lock.locked():
-                    await io_lock.acquire()
-                else:
-                    logger.warning(f"[mcp.lock_wait] {ctx} — another request holds the I/O lock, queuing")
-                    await io_lock.acquire()
-                try:
-                    try:
-                        process.stdin.write(msg + "\n")
-                        process.stdin.flush()
-                    except (BrokenPipeError, OSError) as e:
-                        elapsed_ms = int((time.monotonic() - t0) * 1000)
-                        logger.error(f"[mcp.process_died] {ctx} elapsed={elapsed_ms}ms — broken pipe: {e}")
-                        raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
-
-                    # Wait for the MCP subprocess to write its JSON-RPC response.
-                    # _readline_with_timeout runs in a thread (via to_thread) and uses
-                    # select() internally, so the thread itself exits after _MCP_READ_TIMEOUT
-                    # seconds if the server hangs — freeing the ThreadPoolExecutor slot.
-                    # A plain readline() here would block the thread forever on a hung server,
-                    # eventually exhausting the pool and making all healthy servers unreachable.
-                    response_line = await asyncio.to_thread(
-                        _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
+            # Concurrency limiting — try a non-blocking acquire; drop with 429 if full
+            sem = server_manager.get_concurrency_semaphore(server_name)
+            if sem is not None:
+                acquired = sem._value > 0  # peek: True if a slot is free
+                if not acquired:
+                    collector.record_rejected_request("concurrency_limit")
+                    return Response(
+                        content='{"error":"too many concurrent requests"}',
+                        status_code=429,
+                        media_type="application/json",
+                        headers={"Retry-After": "1"},
                     )
-                finally:
-                    io_lock.release()
+                await sem.acquire()
 
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-
-                if not response_line:
-                    # Empty string means select() timed out — server did not respond.
-                    logger.warning(f"[mcp.timeout] {ctx} elapsed={elapsed_ms}ms — server did not respond within {_MCP_READ_TIMEOUT}s")
-                    raise HTTPException(504, f"Server '{server_name}' did not respond within {_MCP_READ_TIMEOUT} seconds")
-
-                _slow_ms = int(os.getenv("FMCP_SLOW_REQUEST_MS", "5000"))
-                if elapsed_ms > _slow_ms:
-                    logger.warning(f"[mcp.slow] {ctx} elapsed={elapsed_ms}ms — response was slow")
+            try:
+                # ── SSE transport: forward via HTTP ─────────────────────────────
+                if isinstance(process, SseSubprocessHandle):
+                    with RequestTimer(collector, request.get("method", "unknown")):
+                        response = await _proxy_to_sse_server(process.sse_url, request)
+                        return JSONResponse(content=response)
+                # ── stdio transport continues below ─────────────────────────────
 
                 try:
+                    # Send request to MCP server
+                    msg = json.dumps(request)
+                    async with _get_io_lock(server_name):
+                        try:
+                            process.stdin.write(msg + "\n")
+                            process.stdin.flush()
+                        except (BrokenPipeError, OSError) as e:
+                            raise HTTPException(503, f"Server '{server_name}' process pipe broken: {str(e)}")
+
+                        # Wait for the MCP subprocess to write its JSON-RPC response.
+                        # _readline_with_timeout runs in a thread (via to_thread) and uses
+                        # select() internally, so the thread itself exits after _MCP_READ_TIMEOUT
+                        # seconds if the server hangs — freeing the ThreadPoolExecutor slot.
+                        # A plain readline() here would block the thread forever on a hung server,
+                        # eventually exhausting the pool and making all healthy servers unreachable.
+                        response_line = await asyncio.to_thread(
+                            _readline_with_timeout, process.stdout, _MCP_READ_TIMEOUT
+                        )
+                        if not response_line:
+                            # Empty string means select() timed out — server did not respond.
+                            raise HTTPException(504, f"Server '{server_name}' did not respond within {_MCP_READ_TIMEOUT} seconds")
                     response_data = json.loads(response_line)
-                except json.JSONDecodeError as e:
-                    logger.error(f"[mcp.bad_response] {ctx} elapsed={elapsed_ms}ms — invalid JSON: {e} raw={response_line[:300]}")
-                    raise HTTPException(502, "MCP server returned invalid JSON")
 
-                if "error" in response_data:
-                    err = response_data["error"]
-                    err_code = err.get("code") if isinstance(err, dict) else None
-                    err_msg = _sanitize_log_field(err.get("message") if isinstance(err, dict) else str(err))
-                    logger.warning(f"[mcp.error_response] {ctx} elapsed={elapsed_ms}ms — code={err_code} message={err_msg}")
-                else:
-                    logger.info(f"[mcp.ok] {ctx} elapsed={elapsed_ms}ms")
+                    # Update last_used_at for idle cleanup
+                    await server_manager.update_last_used(server_name)
 
-                # Update last_used_at for idle cleanup
-                await server_manager.update_last_used(server_name)
+                    return JSONResponse(content=response_data)
 
-                return JSONResponse(content=response_data)
-
-            except HTTPException:
-                raise
-            except Exception as e:
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-                logger.error(f"[mcp.error] {ctx} elapsed={elapsed_ms}ms — {type(e).__name__}: {e}", exc_info=True)
-                raise HTTPException(500, f"Error communicating with server: {str(e)}")
+                except HTTPException:
+                    raise
+                except Exception as e:
+                    logger.error(f"Error proxying request to '{server_name}': {e}")
+                    raise HTTPException(500, f"Error communicating with server: {str(e)}")
+            finally:
+                if sem is not None:
+                    sem.release()
 
     @router.post("/{server_name}/sse", tags=["mcp"])
     async def sse_stream(

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2213,6 +2213,9 @@ class MCPHealthMonitor:
             collector.set_server_cpu_percent(cpu)
             if open_fds is not None:
                 collector.set_server_open_fds(open_fds)
+            uptime = self._sm.get_uptime(server_id)
+            if uptime is not None:
+                collector.set_uptime(uptime)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -445,7 +445,7 @@ class ServerManager:
     def get_concurrency_semaphore(self, server_id: str) -> Optional[asyncio.Semaphore]:
         """Return the semaphore for server_id, or None if no limit is configured."""
         config = self.configs.get(server_id, {})
-        limit = int(config.get("max_concurrent_requests", 0))
+        limit = int(config.get("max_concurrent_requests") or 0)
         if limit <= 0:
             return None
         if server_id not in self._concurrency_semaphores:
@@ -455,7 +455,7 @@ class ServerManager:
     def get_concurrency_info(self, server_id: str) -> Dict[str, Any]:
         """Return concurrency limit and current active count for a server."""
         config = self.configs.get(server_id, {})
-        limit = int(config.get("max_concurrent_requests", 0))
+        limit = int(config.get("max_concurrent_requests") or 0)
         sem = self._concurrency_semaphores.get(server_id)
         active = (limit - sem._value) if sem and limit > 0 else None
         return {
@@ -2217,8 +2217,7 @@ class MCPHealthMonitor:
             gauge = registry.get_metric("fluidmcp_active_requests")
             if gauge is None:
                 return 0
-            key = gauge._get_label_key({"server_id": server_id})
-            return int(gauge.samples.get(key, 0))
+            return int(gauge.get_count({"server_id": server_id}))
         except Exception:
             return 0
 

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -85,9 +85,10 @@ class ServerManager:
         # Operation locks to prevent concurrent operations on same server
         self._operation_locks: Dict[str, asyncio.Lock] = {}
 
-        # Concurrency semaphores: server_id -> asyncio.Semaphore
-        # Created lazily when max_concurrent_requests is set in the server config.
-        self._concurrency_semaphores: Dict[str, asyncio.Semaphore] = {}
+        # Concurrency semaphores: server_id -> (configured_limit, asyncio.Semaphore)
+        # Stored as a tuple so we can detect when the configured limit changes and
+        # recreate the semaphore with the new value instead of keeping a stale one.
+        self._concurrency_semaphores: Dict[str, tuple] = {}
 
         # Event loop for async operations
         self._loop = None
@@ -443,20 +444,35 @@ class ServerManager:
             return await self._stop_server_unlocked(id, force)
 
     def get_concurrency_semaphore(self, server_id: str) -> Optional[asyncio.Semaphore]:
-        """Return the semaphore for server_id, or None if no limit is configured."""
+        """Return the semaphore for server_id, or None if no limit is configured.
+
+        The cache stores (configured_limit, semaphore) tuples so that a config
+        change (e.g. raising or lowering max_concurrent_requests) automatically
+        produces a fresh semaphore rather than continuing to enforce the stale
+        value for the lifetime of the process.
+        """
         config = self.configs.get(server_id, {})
         limit = int(config.get("max_concurrent_requests") or 0)
         if limit <= 0:
+            # Remove any stale semaphore if the limit was removed from config.
+            self._concurrency_semaphores.pop(server_id, None)
             return None
-        if server_id not in self._concurrency_semaphores:
-            self._concurrency_semaphores[server_id] = asyncio.Semaphore(limit)
-        return self._concurrency_semaphores[server_id]
+        cached = self._concurrency_semaphores.get(server_id)
+        if cached is None or cached[0] != limit:
+            # No cached semaphore, or the cached one was built for a different
+            # limit.  Recreate it.  Any coroutines already holding the old
+            # semaphore will release it normally; new requests use the fresh one.
+            sem = asyncio.Semaphore(limit)
+            self._concurrency_semaphores[server_id] = (limit, sem)
+            return sem
+        return cached[1]
 
     def get_concurrency_info(self, server_id: str) -> Dict[str, Any]:
         """Return concurrency limit and current active count for a server."""
         config = self.configs.get(server_id, {})
         limit = int(config.get("max_concurrent_requests") or 0)
-        sem = self._concurrency_semaphores.get(server_id)
+        cached = self._concurrency_semaphores.get(server_id)
+        sem = cached[1] if cached else None
         active = (limit - sem._value) if sem and limit > 0 else None
         return {
             "server_id": server_id,

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -586,6 +586,8 @@ class ServerManager:
                 return {
                     "id": id,
                     "state": "failed",
+                    "transport": None,
+                    "url": None,
                     "pid": None,
                     "uptime": None,
                     "restart_count": 0,
@@ -613,6 +615,8 @@ class ServerManager:
                         return {
                             "id": id,
                             "state": "failed",
+                            "transport": None,
+                            "url": None,
                             "pid": None,
                             "uptime": None,
                             "restart_count": instance.get("restart_count", 0),
@@ -646,6 +650,8 @@ class ServerManager:
                     return {
                         "id": id,
                         "state": "failed",
+                        "transport": None,
+                        "url": None,
                         "pid": None,
                         "uptime": None,
                         "restart_count": instance.get("restart_count", 0),
@@ -657,6 +663,8 @@ class ServerManager:
             return {
                 "id": id,
                 "state": state,
+                "transport": None,
+                "url": None,
                 "pid": pid,
                 "uptime": None,
                 "restart_count": instance.get("restart_count", 0),
@@ -668,6 +676,8 @@ class ServerManager:
         return {
             "id": id,
             "state": "not_found",
+            "transport": None,
+            "url": None,
             "pid": None,
             "uptime": None,
             "restart_count": 0,

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -2195,6 +2195,7 @@ class MCPHealthMonitor:
                 return  # skip this cycle; next cycle will have a real reading
             rss = proc.memory_info().rss
             cpu = proc.cpu_percent(interval=None)
+            open_fds = proc.num_fds() if hasattr(proc, "num_fds") else None
             # Update ring buffer for memory trend
             if server_id not in self._memory_history:
                 self._memory_history[server_id] = deque(maxlen=3)
@@ -2202,9 +2203,16 @@ class MCPHealthMonitor:
             snapshot = {
                 "memory_rss_bytes": rss,
                 "cpu_percent": cpu,
+                "open_fds": open_fds,
                 "active_requests": self._get_active_requests(server_id),
             }
             self._last_resource_snapshot[server_id] = snapshot
+            # Emit per-server Prometheus gauges
+            collector = MetricsCollector(server_id)
+            collector.set_server_memory_rss(rss)
+            collector.set_server_cpu_percent(cpu)
+            if open_fds is not None:
+                collector.set_server_open_fds(open_fds)
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 

--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -85,6 +85,10 @@ class ServerManager:
         # Operation locks to prevent concurrent operations on same server
         self._operation_locks: Dict[str, asyncio.Lock] = {}
 
+        # Concurrency semaphores: server_id -> asyncio.Semaphore
+        # Created lazily when max_concurrent_requests is set in the server config.
+        self._concurrency_semaphores: Dict[str, asyncio.Semaphore] = {}
+
         # Event loop for async operations
         self._loop = None
 
@@ -437,6 +441,29 @@ class ServerManager:
         # Acquire lock for this operation
         async with lock:
             return await self._stop_server_unlocked(id, force)
+
+    def get_concurrency_semaphore(self, server_id: str) -> Optional[asyncio.Semaphore]:
+        """Return the semaphore for server_id, or None if no limit is configured."""
+        config = self.configs.get(server_id, {})
+        limit = int(config.get("max_concurrent_requests", 0))
+        if limit <= 0:
+            return None
+        if server_id not in self._concurrency_semaphores:
+            self._concurrency_semaphores[server_id] = asyncio.Semaphore(limit)
+        return self._concurrency_semaphores[server_id]
+
+    def get_concurrency_info(self, server_id: str) -> Dict[str, Any]:
+        """Return concurrency limit and current active count for a server."""
+        config = self.configs.get(server_id, {})
+        limit = int(config.get("max_concurrent_requests", 0))
+        sem = self._concurrency_semaphores.get(server_id)
+        active = (limit - sem._value) if sem and limit > 0 else None
+        return {
+            "server_id": server_id,
+            "max_concurrent_requests": limit if limit > 0 else None,
+            "active_requests": active,
+            "available_slots": sem._value if sem and limit > 0 else None,
+        }
 
     def _get_operation_lock(self, server_id: str) -> asyncio.Lock:
         """

--- a/fluidmcp/cli/services/sse_handle.py
+++ b/fluidmcp/cli/services/sse_handle.py
@@ -1,0 +1,48 @@
+"""
+SSE transport handle for MCP servers.
+
+Kept in its own module to avoid circular imports between
+package_launcher.py and server_manager.py.
+"""
+import subprocess
+from loguru import logger
+
+
+class SseSubprocessHandle:
+    """
+    Wraps a subprocess.Popen for an SSE-transport MCP server.
+
+    We still OWN the process (spawned via uv/python/etc.) so we keep the
+    real Popen for lifecycle management (kill/terminate/poll).
+    Communication happens over HTTP instead of stdin/stdout.
+
+    Attributes:
+        _process:  The real subprocess.Popen — used for kill/terminate/poll.
+        sse_url:   Base HTTP URL, e.g. "http://127.0.0.1:8000".
+        pid:       Delegated to the underlying process.
+        returncode: Delegated to the underlying process.
+    """
+
+    def __init__(self, process: subprocess.Popen, sse_url: str):
+        self._process = process
+        self.sse_url = sse_url
+
+    @property
+    def pid(self):
+        return self._process.pid
+
+    @property
+    def returncode(self):
+        return self._process.returncode
+
+    def poll(self):
+        return self._process.poll()
+
+    def terminate(self):
+        self._process.terminate()
+
+    def kill(self):
+        self._process.kill()
+
+    def wait(self, timeout=None):
+        return self._process.wait(timeout=timeout)

--- a/tests/test_concurrency_limiting.py
+++ b/tests/test_concurrency_limiting.py
@@ -1,0 +1,174 @@
+"""
+Tests for P6 - concurrency limiting.
+
+Covers:
+- GET /api/servers/{id}/concurrency: 404, unlimited, limited with no active, correct slot math
+- rejected_total increments in Prometheus counter
+- Semaphore: no limit when config absent / zero
+- Semaphore: created once and reused (singleton per server)
+- Semaphore: acquire/release under the limit
+- Semaphore slots: correct _value before and after acquire
+"""
+import asyncio
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fluidmcp.cli.api.management import router
+from fluidmcp.cli.repositories import InMemoryBackend
+from fluidmcp.cli.services.server_manager import ServerManager
+from fluidmcp.cli.services.metrics import get_registry, MetricsCollector
+
+
+def make_app(server_manager, db_manager):
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.state.server_manager = server_manager
+    app.state.db_manager = db_manager
+    return app
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def client(server_manager, backend):
+    return TestClient(make_app(server_manager, backend))
+
+
+def _register(server_manager, server_id, max_concurrent_requests=0):
+    server_manager.configs[server_id] = {
+        "id": server_id,
+        "name": "Test",
+        "max_concurrent_requests": max_concurrent_requests,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /api/servers/{id}/concurrency endpoint
+# ---------------------------------------------------------------------------
+
+class TestGetConcurrencyEndpoint:
+
+    def test_404_for_unknown_server(self, client):
+        resp = client.get("/api/servers/ghost/concurrency")
+        assert resp.status_code == 404
+
+    def test_unlimited_when_not_configured(self, client, server_manager):
+        _register(server_manager, "srv")
+        resp = client.get("/api/servers/srv/concurrency")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["max_concurrent_requests"] is None
+        assert data["active_requests"] is None
+        assert data["available_slots"] is None
+
+    def test_limited_shows_correct_info(self, client, server_manager):
+        _register(server_manager, "srv", max_concurrent_requests=5)
+        resp = client.get("/api/servers/srv/concurrency")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["max_concurrent_requests"] == 5
+        assert data["active_requests"] == 0
+        assert data["available_slots"] == 5
+
+    def test_response_has_all_expected_keys(self, client, server_manager):
+        _register(server_manager, "srv")
+        resp = client.get("/api/servers/srv/concurrency")
+        assert resp.status_code == 200
+        keys = resp.json().keys()
+        for expected in ["server", "max_concurrent_requests", "active_requests",
+                         "available_slots", "rejected_total"]:
+            assert expected in keys, f"missing key: {expected}"
+
+    def test_rejected_total_reflects_counter(self, client, server_manager):
+        _register(server_manager, "srv")
+        # Manually increment the rejection counter
+        registry = get_registry()
+        counter = registry.get_metric("fluidmcp_requests_rejected_total")
+        counter.inc({"server_id": "srv", "reason": "concurrency_limit"}, amount=3)
+
+        resp = client.get("/api/servers/srv/concurrency")
+        assert resp.json()["rejected_total"] == 3
+
+
+# ---------------------------------------------------------------------------
+# ServerManager.get_concurrency_semaphore()
+# ---------------------------------------------------------------------------
+
+class TestGetConcurrencySemaphore:
+
+    def test_returns_none_when_not_configured(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv"}
+        assert server_manager.get_concurrency_semaphore("srv") is None
+
+    def test_returns_none_when_limit_is_zero(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 0}
+        assert server_manager.get_concurrency_semaphore("srv") is None
+
+    def test_returns_semaphore_when_limit_set(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 3}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        assert sem is not None
+        assert sem._value == 3
+
+    def test_semaphore_is_singleton(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 3}
+        sem1 = server_manager.get_concurrency_semaphore("srv")
+        sem2 = server_manager.get_concurrency_semaphore("srv")
+        assert sem1 is sem2
+
+    @pytest.mark.asyncio
+    async def test_semaphore_slots_decrement_on_acquire(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 2}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        assert sem._value == 2
+        await sem.acquire()
+        assert sem._value == 1
+        sem.release()
+        assert sem._value == 2
+
+    @pytest.mark.asyncio
+    async def test_semaphore_full_when_all_slots_taken(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 1}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+        assert sem._value == 0  # exhausted — next acquire would block
+        sem.release()
+
+
+# ---------------------------------------------------------------------------
+# ServerManager.get_concurrency_info()
+# ---------------------------------------------------------------------------
+
+class TestGetConcurrencyInfo:
+
+    def test_unlimited_server(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv"}
+        info = server_manager.get_concurrency_info("srv")
+        assert info["max_concurrent_requests"] is None
+        assert info["active_requests"] is None
+        assert info["available_slots"] is None
+
+    @pytest.mark.asyncio
+    async def test_limited_server_shows_slot_math(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 4}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+        await sem.acquire()
+
+        info = server_manager.get_concurrency_info("srv")
+        assert info["max_concurrent_requests"] == 4
+        assert info["active_requests"] == 2
+        assert info["available_slots"] == 2
+
+        sem.release()
+        sem.release()

--- a/tests/test_concurrency_limiting.py
+++ b/tests/test_concurrency_limiting.py
@@ -236,6 +236,46 @@ class TestConcurrencyLimiting429:
         sem.release()
         await handle.aclose()
 
+    @pytest.mark.asyncio
+    async def test_429_tools_list_when_semaphore_full(self, server_manager):
+        """GET /{server}/mcp/tools/list must return 429 when the semaphore is full."""
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 1}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        server_manager.processes["srv"] = fake_process
+
+        app = self._make_mcp_app(server_manager)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/srv/mcp/tools/list")
+
+        assert resp.status_code == 429
+        assert resp.headers.get("Retry-After") == "1"
+
+        sem.release()
+
+    @pytest.mark.asyncio
+    async def test_429_tools_call_when_semaphore_full(self, server_manager):
+        """POST /{server}/mcp/tools/call must return 429 when the semaphore is full."""
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 1}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None
+        server_manager.processes["srv"] = fake_process
+
+        app = self._make_mcp_app(server_manager)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/srv/mcp/tools/call", json={"name": "read_file", "arguments": {}})
+
+        assert resp.status_code == 429
+        assert resp.headers.get("Retry-After") == "1"
+
+        sem.release()
+
 
 # ---------------------------------------------------------------------------
 # null / invalid max_concurrent_requests config values
@@ -299,18 +339,29 @@ class TestEnrichedServerGetShape:
         assert "crashes_last_hour" in crashes, "field renamed from crashes_per_hour"
         assert "crashes_per_hour" not in crashes, "old field name must not be present"
 
+    def _make_unauthed_client(self, server_manager, backend):
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.state.server_manager = server_manager
+        app.state.db_manager = backend
+        return TestClient(app, raise_server_exceptions=False)
+
     def test_unauthenticated_request_is_rejected(self, server_manager, backend, monkeypatch):
         """GET /api/servers/{id} must require auth in secure mode — it returns protected debug telemetry."""
         monkeypatch.setenv("FMCP_SECURE_MODE", "true")
         monkeypatch.setenv("FMCP_BEARER_TOKEN", "test-secret")
         _register(server_manager, "srv")
-        # Build a client with no Authorization header
-        app = FastAPI()
-        app.include_router(router, prefix="/api")
-        app.state.server_manager = server_manager
-        app.state.db_manager = backend
-        unauthed_client = TestClient(app, raise_server_exceptions=False)
-        resp = unauthed_client.get("/api/servers/srv")
+        resp = self._make_unauthed_client(server_manager, backend).get("/api/servers/srv")
         assert resp.status_code in (401, 403), (
             f"Expected 401/403 for unauthenticated request, got {resp.status_code}"
+        )
+
+    def test_concurrency_endpoint_unauthenticated_is_rejected(self, server_manager, backend, monkeypatch):
+        """GET /api/servers/{id}/concurrency must require auth in secure mode."""
+        monkeypatch.setenv("FMCP_SECURE_MODE", "true")
+        monkeypatch.setenv("FMCP_BEARER_TOKEN", "test-secret")
+        _register(server_manager, "srv")
+        resp = self._make_unauthed_client(server_manager, backend).get("/api/servers/srv/concurrency")
+        assert resp.status_code in (401, 403), (
+            f"Expected 401/403 for unauthenticated concurrency request, got {resp.status_code}"
         )

--- a/tests/test_concurrency_limiting.py
+++ b/tests/test_concurrency_limiting.py
@@ -12,7 +12,6 @@ Covers:
 - null/invalid max_concurrent_requests values
 - Enriched GET /api/servers/{id} response shape
 """
-import asyncio
 import pytest
 from unittest.mock import MagicMock
 from fastapi import FastAPI
@@ -23,6 +22,7 @@ from fluidmcp.cli.repositories import InMemoryBackend
 from fluidmcp.cli.services.server_manager import ServerManager
 from fluidmcp.cli.services.metrics import get_registry
 from fluidmcp.cli.services.package_launcher import create_dynamic_router
+from fluidmcp.cli.services.network_handle import NetworkSubprocessHandle
 
 
 def make_app(server_manager, db_manager):
@@ -213,6 +213,29 @@ class TestConcurrencyLimiting429:
 
         sem.release()
 
+    @pytest.mark.asyncio
+    async def test_429_network_transport_when_semaphore_full(self, server_manager):
+        """Network/SSE-backed servers must also be blocked when the semaphore is full."""
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 1}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+
+        # Build a real NetworkSubprocessHandle with a mock subprocess so isinstance() passes
+        fake_proc = MagicMock()
+        fake_proc.poll.return_value = None  # looks alive for the fast-path check
+        handle = NetworkSubprocessHandle(fake_proc, base_url="http://127.0.0.1:9999", transport="sse")
+        server_manager.processes["srv"] = handle
+
+        app = self._make_mcp_app(server_manager)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/srv/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+        assert resp.status_code == 429
+        assert resp.headers.get("Retry-After") == "1"
+
+        sem.release()
+        await handle.aclose()
+
 
 # ---------------------------------------------------------------------------
 # null / invalid max_concurrent_requests config values
@@ -275,3 +298,19 @@ class TestEnrichedServerGetShape:
         crashes = data["crashes"]
         assert "crashes_last_hour" in crashes, "field renamed from crashes_per_hour"
         assert "crashes_per_hour" not in crashes, "old field name must not be present"
+
+    def test_unauthenticated_request_is_rejected(self, server_manager, backend, monkeypatch):
+        """GET /api/servers/{id} must require auth in secure mode — it returns protected debug telemetry."""
+        monkeypatch.setenv("FMCP_SECURE_MODE", "true")
+        monkeypatch.setenv("FMCP_BEARER_TOKEN", "test-secret")
+        _register(server_manager, "srv")
+        # Build a client with no Authorization header
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.state.server_manager = server_manager
+        app.state.db_manager = backend
+        unauthed_client = TestClient(app, raise_server_exceptions=False)
+        resp = unauthed_client.get("/api/servers/srv")
+        assert resp.status_code in (401, 403), (
+            f"Expected 401/403 for unauthenticated request, got {resp.status_code}"
+        )

--- a/tests/test_concurrency_limiting.py
+++ b/tests/test_concurrency_limiting.py
@@ -8,17 +8,21 @@ Covers:
 - Semaphore: created once and reused (singleton per server)
 - Semaphore: acquire/release under the limit
 - Semaphore slots: correct _value before and after acquire
+- 429 response when semaphore is full (most important behavior)
+- null/invalid max_concurrent_requests values
+- Enriched GET /api/servers/{id} response shape
 """
 import asyncio
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import MagicMock
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from fluidmcp.cli.api.management import router
 from fluidmcp.cli.repositories import InMemoryBackend
 from fluidmcp.cli.services.server_manager import ServerManager
-from fluidmcp.cli.services.metrics import get_registry, MetricsCollector
+from fluidmcp.cli.services.metrics import get_registry
+from fluidmcp.cli.services.package_launcher import create_dynamic_router
 
 
 def make_app(server_manager, db_manager):
@@ -172,3 +176,102 @@ class TestGetConcurrencyInfo:
 
         sem.release()
         sem.release()
+
+
+# ---------------------------------------------------------------------------
+# 429 when semaphore is full
+# ---------------------------------------------------------------------------
+
+class TestConcurrencyLimiting429:
+    """The most important behavior: 429 + Retry-After when all slots are occupied."""
+
+    def _make_mcp_app(self, server_manager):
+        app = FastAPI()
+        mcp_router = create_dynamic_router(server_manager)
+        app.include_router(mcp_router)
+        return app
+
+    @pytest.mark.asyncio
+    async def test_429_when_semaphore_full(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": 1}
+        # Exhaust the one available slot manually
+        sem = server_manager.get_concurrency_semaphore("srv")
+        await sem.acquire()
+
+        # Use a mock so the 503 "process is None" guard doesn't fire before the semaphore check.
+        fake_process = MagicMock()
+        fake_process.poll.return_value = None  # pretend process is alive
+        server_manager.processes["srv"] = fake_process
+
+        app = self._make_mcp_app(server_manager)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post("/srv/mcp", json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+        assert resp.status_code == 429
+        assert resp.headers.get("Retry-After") == "1"
+        assert "too many concurrent requests" in resp.text
+
+        sem.release()
+
+
+# ---------------------------------------------------------------------------
+# null / invalid max_concurrent_requests config values
+# ---------------------------------------------------------------------------
+
+class TestNullMaxConcurrentRequests:
+
+    def test_null_value_returns_none_semaphore(self, server_manager):
+        """'max_concurrent_requests': null must not crash with TypeError."""
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": None}
+        sem = server_manager.get_concurrency_semaphore("srv")
+        assert sem is None
+
+    def test_null_value_concurrency_info_unlimited(self, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": None}
+        info = server_manager.get_concurrency_info("srv")
+        assert info["max_concurrent_requests"] is None
+        assert info["active_requests"] is None
+        assert info["available_slots"] is None
+
+    def test_null_via_endpoint(self, client, server_manager):
+        server_manager.configs["srv"] = {"id": "srv", "max_concurrent_requests": None}
+        resp = client.get("/api/servers/srv/concurrency")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["max_concurrent_requests"] is None
+
+
+# ---------------------------------------------------------------------------
+# Enriched GET /api/servers/{id} response shape
+# ---------------------------------------------------------------------------
+
+class TestEnrichedServerGetShape:
+
+    def test_response_includes_debug_sections(self, client, server_manager):
+        """GET /api/servers/{id} must include resources, concurrency, and crashes sections."""
+        _register(server_manager, "srv", max_concurrent_requests=3)
+
+        resp = client.get("/api/servers/srv")
+        assert resp.status_code == 200
+        data = resp.json()
+
+        assert "resources" in data, "missing 'resources' section"
+        assert "concurrency" in data, "missing 'concurrency' section"
+        assert "crashes" in data, "missing 'crashes' section"
+
+    def test_concurrency_section_shape(self, client, server_manager):
+        _register(server_manager, "srv", max_concurrent_requests=5)
+        data = client.get("/api/servers/srv").json()
+        conc = data["concurrency"]
+        assert conc["max_concurrent_requests"] == 5
+        assert conc["active_requests"] == 0
+        assert conc["available_slots"] == 5
+        assert "rejected_total" in conc
+
+    def test_crashes_section_uses_correct_field_name(self, client, server_manager):
+        """Field must be crashes_last_hour, not the old crashes_per_hour."""
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv").json()
+        crashes = data["crashes"]
+        assert "crashes_last_hour" in crashes, "field renamed from crashes_per_hour"
+        assert "crashes_per_hour" not in crashes, "old field name must not be present"

--- a/tests/test_per_server_resource_gauges.py
+++ b/tests/test_per_server_resource_gauges.py
@@ -1,0 +1,137 @@
+"""
+Tests for P7 - per-server Prometheus resource gauges.
+
+Covers:
+- fluidmcp_server_memory_rss_bytes updated after snapshot cycle
+- fluidmcp_server_cpu_percent updated after snapshot cycle
+- fluidmcp_server_open_fds updated after snapshot cycle
+- Gauges not set on warm-up cycle (first call)
+- Gauges not set when psutil unavailable
+- MetricsCollector helpers write to correct label keys
+- Multiple servers tracked independently
+"""
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+
+from fluidmcp.cli.services.server_manager import ServerManager, MCPHealthMonitor
+from fluidmcp.cli.services.metrics import get_registry, MetricsCollector
+from fluidmcp.cli.repositories import InMemoryBackend
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def monitor(server_manager):
+    return MCPHealthMonitor(server_manager, check_interval=30)
+
+
+def _make_process(pid=1234):
+    p = Mock()
+    p.pid = pid
+    p.poll = Mock(return_value=None)
+    return p
+
+
+def _make_psutil_proc(rss=50 * 1024 * 1024, cpu=12.5, fds=20):
+    proc = Mock()
+    proc.memory_info = Mock(return_value=Mock(rss=rss))
+    proc.cpu_percent = Mock(return_value=cpu)
+    proc.num_fds = Mock(return_value=fds)
+    proc.num_threads = Mock(return_value=4)
+    return proc
+
+
+def _get_gauge(name, server_id):
+    registry = get_registry()
+    gauge = registry.get_metric(name)
+    if gauge is None:
+        return None
+    key = gauge._get_label_key({"server_id": server_id})
+    return gauge.samples.get(key)
+
+
+# ---------------------------------------------------------------------------
+# MetricsCollector helpers
+# ---------------------------------------------------------------------------
+
+class TestMetricsCollectorHelpers:
+
+    def test_set_server_memory_rss(self):
+        collector = MetricsCollector("test_srv_rss")
+        collector.set_server_memory_rss(104857600)
+        assert _get_gauge("fluidmcp_server_memory_rss_bytes", "test_srv_rss") == 104857600
+
+    def test_set_server_cpu_percent(self):
+        collector = MetricsCollector("test_srv_cpu")
+        collector.set_server_cpu_percent(23.4)
+        assert _get_gauge("fluidmcp_server_cpu_percent", "test_srv_cpu") == 23.4
+
+    def test_set_server_open_fds(self):
+        collector = MetricsCollector("test_srv_fds")
+        collector.set_server_open_fds(42)
+        assert _get_gauge("fluidmcp_server_open_fds", "test_srv_fds") == 42
+
+    def test_multiple_servers_tracked_independently(self):
+        MetricsCollector("alpha").set_server_memory_rss(10 * 1024 * 1024)
+        MetricsCollector("beta").set_server_memory_rss(20 * 1024 * 1024)
+        assert _get_gauge("fluidmcp_server_memory_rss_bytes", "alpha") == 10 * 1024 * 1024
+        assert _get_gauge("fluidmcp_server_memory_rss_bytes", "beta") == 20 * 1024 * 1024
+
+
+# ---------------------------------------------------------------------------
+# _update_resource_snapshot emits gauges
+# ---------------------------------------------------------------------------
+
+class TestSnapshotEmitsGauges:
+
+    def test_gauges_set_after_warm_up(self, monitor):
+        process = _make_process(pid=9901)
+        psutil_proc = _make_psutil_proc(rss=67108864, cpu=5.0, fds=15)
+
+        with patch("psutil.Process", return_value=psutil_proc):
+            # First call: warm-up, no gauges yet
+            monitor._update_resource_snapshot("srv_gauge", process)
+            assert _get_gauge("fluidmcp_server_memory_rss_bytes", "srv_gauge") is None
+
+            # Second call: real reading, gauges emitted
+            monitor._update_resource_snapshot("srv_gauge", process)
+
+        assert _get_gauge("fluidmcp_server_memory_rss_bytes", "srv_gauge") == 67108864
+        assert _get_gauge("fluidmcp_server_cpu_percent", "srv_gauge") == 5.0
+        assert _get_gauge("fluidmcp_server_open_fds", "srv_gauge") == 15
+
+    def test_snapshot_also_cached(self, monitor):
+        process = _make_process(pid=9902)
+        psutil_proc = _make_psutil_proc(rss=33554432, cpu=1.5, fds=8)
+
+        with patch("psutil.Process", return_value=psutil_proc):
+            monitor._update_resource_snapshot("srv_cache", process)
+            monitor._update_resource_snapshot("srv_cache", process)
+
+        snapshot = monitor._last_resource_snapshot.get("srv_cache")
+        assert snapshot is not None
+        assert snapshot["memory_rss_bytes"] == 33554432
+        assert snapshot["cpu_percent"] == 1.5
+        assert snapshot["open_fds"] == 8
+
+    def test_no_gauge_on_no_such_process(self, monitor):
+        process = _make_process(pid=9903)
+        import psutil
+        with patch("psutil.Process", side_effect=psutil.NoSuchProcess(pid=9903)):
+            monitor._update_resource_snapshot("srv_dead", process)
+
+        assert _get_gauge("fluidmcp_server_memory_rss_bytes", "srv_dead") is None
+
+    def test_gauges_registered_in_registry(self):
+        registry = get_registry()
+        assert registry.get_metric("fluidmcp_server_memory_rss_bytes") is not None
+        assert registry.get_metric("fluidmcp_server_cpu_percent") is not None
+        assert registry.get_metric("fluidmcp_server_open_fds") is not None


### PR DESCRIPTION
## Summary

Combines P6 and P7 into a single PR on top of `development`.

### P6 — Concurrency limiting per MCP server
- `asyncio.Semaphore` per-server request cap (`max_concurrent_requests` config field)
- 429 + `Retry-After: 1` when all slots are occupied — no queuing, instant rejection
- Semaphore wraps **all** transport paths: stdio, SSE subprocess, network (HTTP/SSE)
- `poll()` / dead-process guard placed before semaphore acquire (stdio only)
- New endpoint: `GET /api/servers/{id}/concurrency` — live slot counts + rejection total
- Enriched `GET /api/servers/{id}` with `resources`, `concurrency`, `crashes` sections
- All enriched endpoints require auth (`Depends(get_token)`) in secure mode
- `crashes_last_hour` field (replaces old `crashes_per_hour`)
- Public `Metric.get_count()` replaces private `counter.samples` / `_get_label_key()` access
- `datetime.now(timezone.utc)` throughout (replaces deprecated `utcnow()`)
- 25 tests in `tests/test_concurrency_limiting.py`

### P7 — Per-server Prometheus resource gauges
- `fluidmcp_server_cpu_percent`, `fluidmcp_server_memory_bytes`, `fluidmcp_server_uptime_seconds` gauges updated every health cycle
- `GET /api/metrics/mcp` — Prometheus text-format scrape endpoint for all MCP server metrics
- Uptime gauge updated on every health monitor tick (not just on start)
- Prometheus label values escaped (replace `"` → `_`, truncate at 200 chars)
- Semaphore staleness fix: peek `sem._value` instead of stale local copy

## Test plan
- [ ] `pytest tests/test_concurrency_limiting.py` — 25 tests pass
- [ ] `GET /api/servers/{srv}/concurrency` returns slot info when limit is set, nulls when unlimited
- [ ] POST to a server with semaphore full returns 429 + `Retry-After: 1`
- [ ] `GET /api/metrics/mcp` returns Prometheus text with cpu/memory/uptime gauges
- [ ] Unauthenticated requests to enriched endpoints return 401/403 in secure mode

Supersedes PR #746 (P6) — that PR can be closed.