### PR TITLE
[MCP-568]: feat(debugging): P8 - GET /api/servers/{id}/debug aggregator endpoint

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1975,6 +1975,7 @@ async def get_server_debug(
     request: Request,
     id: str,
     stderr_lines: int = Query(default=20, ge=1, le=200),
+    token: str = Depends(get_token),
 ):
     """
     Full debug snapshot for a server in a single request.

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1968,6 +1968,157 @@ async def get_server_concurrency(request: Request, id: str, token: str = Depends
     }
 
 
+# ==================== Debug Aggregator ====================
+
+@router.get("/servers/{id}/debug")
+async def get_server_debug(
+    request: Request,
+    id: str,
+    stderr_lines: int = Query(default=20, ge=1, le=200),
+):
+    """
+    Full debug snapshot for a server in a single request.
+
+    Combines:
+    - **status**: state, pid, uptime, restart_count, stability, exit_code, transport
+    - **resources**: live memory/CPU/FDs, memory trend, limit info
+    - **concurrency**: max limit, active slots, lifetime rejections
+    - **crashes**: recent history with exit classification, crashes_per_hour
+    - **stderr**: last N lines from the process log (default 20, max 200)
+    """
+    manager = get_server_manager(request)
+
+    config = manager.configs.get(id)
+    if not config:
+        config = await manager.db.get_server_config(id)
+    if not config:
+        raise HTTPException(404, f"Server '{id}' not found")
+
+    # ── Status ────────────────────────────────────────────────────────────────
+    status = await manager.get_server_status(id)
+
+    # ── Resources ─────────────────────────────────────────────────────────────
+    resources = {
+        "pid": None,
+        "memory_rss_bytes": None,
+        "memory_rss_human": None,
+        "memory_trend": "unknown",
+        "memory_limit_bytes": None,
+        "memory_limit_human": None,
+        "memory_usage_pct": None,
+        "cpu_percent": None,
+        "open_fds": None,
+        "threads": None,
+    }
+    if status.get("state") == "running" and _psutil_available:
+        process = manager.processes.get(id)
+        if process and process.poll() is None:
+            try:
+                proc = _psutil.Process(process.pid)
+                rss = proc.memory_info().rss
+                resources["pid"] = process.pid
+                resources["memory_rss_bytes"] = rss
+                resources["memory_rss_human"] = f"{rss / (1024 * 1024):.1f} MB"
+                resources["open_fds"] = proc.num_fds() if hasattr(proc, "num_fds") else None
+                resources["threads"] = proc.num_threads()
+                limit_mb = int(config.get("memory_limit_mb", 0) or
+                               int(os.environ.get("FMCP_DEFAULT_MEMORY_LIMIT_MB", "0")))
+                if limit_mb > 0:
+                    limit_bytes = limit_mb * 1024 * 1024
+                    resources["memory_limit_bytes"] = limit_bytes
+                    resources["memory_limit_human"] = f"{limit_mb} MB"
+                    resources["memory_usage_pct"] = round(rss / limit_bytes * 100, 1)
+            except (_psutil.NoSuchProcess, _psutil.AccessDenied):
+                pass
+            except Exception as e:
+                logger.warning(f"[debug] Failed to read resources for '{id}': {e}")
+    monitor = getattr(manager, "_health_monitor", None)
+    if monitor:
+        resources["memory_trend"] = monitor.get_memory_trend(id)
+        snapshot = monitor._last_resource_snapshot.get(id)
+        if snapshot and status.get("state") == "running":
+            resources["cpu_percent"] = snapshot.get("cpu_percent")
+
+    # ── Concurrency ───────────────────────────────────────────────────────────
+    manager.get_concurrency_semaphore(id)
+    conc_info = manager.get_concurrency_info(id)
+    _rej_counter = _get_metrics_registry().get_metric("fluidmcp_requests_rejected_total")
+    rejected_total = 0
+    if _rej_counter:
+        _key = _rej_counter._get_label_key({"server_id": id, "reason": "concurrency_limit"})
+        rejected_total = int(_rej_counter.samples.get(_key, 0))
+    concurrency = {
+        "max_concurrent_requests": conc_info["max_concurrent_requests"],
+        "active_requests": conc_info["active_requests"],
+        "available_slots": conc_info["available_slots"],
+        "rejected_total": rejected_total,
+    }
+
+    # ── Crashes ───────────────────────────────────────────────────────────────
+    crashes = []
+    crashes_per_hour = 0.0
+    recent_crash_count = 0
+    try:
+        from ..services.server_manager import classify_exit_code
+        raw_crashes = await manager.db.list_crash_events(id, limit=20)
+        now = datetime.utcnow()
+        one_hour_ago = (now - timedelta(hours=1)).timestamp()
+        for c in raw_crashes:
+            if "exit_category" not in c and "exit_code" in c:
+                info = classify_exit_code(c["exit_code"])
+                c["exit_category"] = info["category"]
+                c["exit_label"] = info["label"]
+                c["exit_description"] = info["description"]
+            crashes.append(c)
+        recent_crash_count = len(crashes)
+        crashes_per_hour = float(sum(
+            1 for c in crashes
+            if c.get("timestamp") and (
+                c["timestamp"].timestamp() if hasattr(c["timestamp"], "timestamp")
+                else float(c["timestamp"])
+            ) > one_hour_ago
+        ))
+    except Exception as e:
+        logger.warning(f"[debug] Failed to load crashes for '{id}': {e}")
+
+    # ── Stderr ────────────────────────────────────────────────────────────────
+    stderr = {"lines": [], "line_count": 0, "truncated": False, "file": None}
+    try:
+        log_path = manager._get_stderr_log_path(id)
+        stderr["file"] = log_path
+        if os.path.exists(log_path):
+            read_bytes = stderr_lines * 240
+            file_size = os.path.getsize(log_path)
+            truncated = file_size > read_bytes
+            with open(log_path, "rb") as f:
+                if truncated:
+                    f.seek(-read_bytes, os.SEEK_END)
+                data = f.read()
+            text = data.decode("utf-8", errors="replace")
+            all_lines = text.splitlines()
+            if truncated and len(all_lines) > 1:
+                all_lines = all_lines[1:]
+            tail = all_lines[-stderr_lines:]
+            stderr["lines"] = tail
+            stderr["line_count"] = len(tail)
+            stderr["truncated"] = truncated
+    except Exception as e:
+        logger.warning(f"[debug] Failed to read stderr for '{id}': {e}")
+
+    return {
+        "server": id,
+        "status": status,
+        "resources": resources,
+        "concurrency": concurrency,
+        "crashes": {
+            "recent_crash_count": recent_crash_count,
+            "crashes_per_hour": crashes_per_hour,
+            "events": crashes,
+        },
+        "stderr": stderr,
+    }
+
+
 # ==================== Environment Variable Management ====================
 
 @router.get("/servers/{id}/instance/env")

--- a/tests/test_debug_aggregator.py
+++ b/tests/test_debug_aggregator.py
@@ -1,0 +1,225 @@
+"""
+Tests for GET /api/servers/{id}/debug aggregator endpoint.
+
+Covers:
+- 404 for unknown server
+- All top-level keys present
+- status section present and correct
+- resources null when not running
+- resources populated when running
+- concurrency section present
+- crashes section present with events list
+- stderr section present (empty when no log file)
+- stderr_lines query param respected
+- crashes annotated with exit classification
+"""
+import os
+import pytest
+import tempfile
+from unittest.mock import Mock, patch
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fluidmcp.cli.api.management import router
+from fluidmcp.cli.repositories import InMemoryBackend
+from fluidmcp.cli.services.server_manager import ServerManager
+
+
+def make_app(server_manager, db_manager):
+    app = FastAPI()
+    app.include_router(router, prefix="/api")
+    app.state.server_manager = server_manager
+    app.state.db_manager = db_manager
+    return app
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+@pytest.fixture
+def client(server_manager, backend):
+    return TestClient(make_app(server_manager, backend))
+
+
+def _register(server_manager, server_id, name="Test"):
+    server_manager.configs[server_id] = {"id": server_id, "name": name}
+
+
+# ---------------------------------------------------------------------------
+# Basic shape
+# ---------------------------------------------------------------------------
+
+class TestDebugAggregatorShape:
+
+    def test_404_for_unknown_server(self, client):
+        resp = client.get("/api/servers/ghost/debug")
+        assert resp.status_code == 404
+
+    def test_all_top_level_keys_present(self, client, server_manager):
+        _register(server_manager, "srv")
+        resp = client.get("/api/servers/srv/debug")
+        assert resp.status_code == 200
+        keys = resp.json().keys()
+        for expected in ["server", "status", "resources", "concurrency", "crashes", "stderr"]:
+            assert expected in keys, f"missing top-level key: {expected}"
+
+    def test_server_field_matches_id(self, client, server_manager):
+        _register(server_manager, "srv")
+        assert client.get("/api/servers/srv/debug").json()["server"] == "srv"
+
+    def test_status_section_has_state(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        assert "state" in data["status"]
+
+    def test_resources_null_when_not_running(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        assert data["resources"]["memory_rss_bytes"] is None
+        assert data["resources"]["cpu_percent"] is None
+
+    def test_concurrency_section_present(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        conc = data["concurrency"]
+        for key in ["max_concurrent_requests", "active_requests", "available_slots", "rejected_total"]:
+            assert key in conc, f"missing concurrency key: {key}"
+
+    def test_crashes_section_present(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        crashes = data["crashes"]
+        for key in ["recent_crash_count", "crashes_per_hour", "events"]:
+            assert key in crashes, f"missing crashes key: {key}"
+        assert isinstance(crashes["events"], list)
+
+    def test_stderr_section_present(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        stderr = data["stderr"]
+        for key in ["lines", "line_count", "truncated", "file"]:
+            assert key in stderr, f"missing stderr key: {key}"
+
+    def test_stderr_empty_when_no_log_file(self, client, server_manager):
+        _register(server_manager, "srv")
+        data = client.get("/api/servers/srv/debug").json()
+        assert data["stderr"]["lines"] == []
+        assert data["stderr"]["line_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Running server resources
+# ---------------------------------------------------------------------------
+
+class TestDebugAggregatorRunning:
+
+    def test_resources_populated_when_running(self, client, server_manager):
+        _register(server_manager, "srv")
+        mock_process = Mock()
+        mock_process.pid = 1234
+        mock_process.poll = Mock(return_value=None)
+        server_manager.processes["srv"] = mock_process
+
+        import asyncio
+        from fluidmcp.cli.repositories import InMemoryBackend
+        asyncio.get_event_loop().run_until_complete(
+            server_manager.db.save_instance_state({
+                "server_id": "srv", "state": "running", "pid": 1234
+            })
+        )
+
+        mock_proc = Mock()
+        mock_proc.memory_info = Mock(return_value=Mock(rss=52428800))
+        mock_proc.num_fds = Mock(return_value=15)
+        mock_proc.num_threads = Mock(return_value=4)
+
+        with patch("psutil.Process", return_value=mock_proc):
+            data = client.get("/api/servers/srv/debug").json()
+
+        assert data["resources"]["memory_rss_bytes"] == 52428800
+        assert data["resources"]["pid"] == 1234
+        assert data["resources"]["open_fds"] == 15
+        assert data["resources"]["threads"] == 4
+
+
+# ---------------------------------------------------------------------------
+# Stderr
+# ---------------------------------------------------------------------------
+
+class TestDebugAggregatorStderr:
+
+    def test_stderr_lines_returned_from_log_file(self, client, server_manager):
+        _register(server_manager, "srv")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            for i in range(30):
+                f.write(f"log line {i}\n")
+            log_path = f.name
+
+        try:
+            server_manager._get_stderr_log_path = Mock(return_value=log_path)
+            data = client.get("/api/servers/srv/debug").json()
+            # Default is 20 lines
+            assert data["stderr"]["line_count"] == 20
+            assert "log line 29" in data["stderr"]["lines"][-1]
+        finally:
+            os.unlink(log_path)
+
+    def test_stderr_lines_param_respected(self, client, server_manager):
+        _register(server_manager, "srv")
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
+            for i in range(30):
+                f.write(f"log line {i}\n")
+            log_path = f.name
+
+        try:
+            server_manager._get_stderr_log_path = Mock(return_value=log_path)
+            data = client.get("/api/servers/srv/debug?stderr_lines=5").json()
+            assert data["stderr"]["line_count"] == 5
+        finally:
+            os.unlink(log_path)
+
+
+# ---------------------------------------------------------------------------
+# Crash annotation
+# ---------------------------------------------------------------------------
+
+class TestDebugAggregatorCrashes:
+
+    def test_crashes_annotated_with_exit_classification(self, client, server_manager, backend):
+        import asyncio
+        _register(server_manager, "srv")
+        asyncio.get_event_loop().run_until_complete(
+            backend.save_crash_event({
+                "server_id": "srv",
+                "exit_code": 137,
+                "timestamp": __import__("datetime").datetime.utcnow(),
+            })
+        )
+
+        data = client.get("/api/servers/srv/debug").json()
+        events = data["crashes"]["events"]
+        assert len(events) == 1
+        assert events[0]["exit_label"] == "oom_killed"
+        assert events[0]["exit_category"] == "resource"
+
+    def test_crashes_per_hour_computed(self, client, server_manager, backend):
+        import asyncio
+        _register(server_manager, "srv")
+        asyncio.get_event_loop().run_until_complete(
+            backend.save_crash_event({
+                "server_id": "srv",
+                "exit_code": 1,
+                "timestamp": __import__("datetime").datetime.utcnow(),
+            })
+        )
+
+        data = client.get("/api/servers/srv/debug").json()
+        assert data["crashes"]["crashes_per_hour"] == 1.0
+        assert data["crashes"]["recent_crash_count"] == 1

--- a/tests/test_debug_aggregator.py
+++ b/tests/test_debug_aggregator.py
@@ -223,3 +223,27 @@ class TestDebugAggregatorCrashes:
         data = client.get("/api/servers/srv/debug").json()
         assert data["crashes"]["crashes_per_hour"] == 1.0
         assert data["crashes"]["recent_crash_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement
+# ---------------------------------------------------------------------------
+
+class TestDebugAggregatorAuth:
+
+    def _make_unauthed_client(self, server_manager, backend):
+        app = FastAPI()
+        app.include_router(router, prefix="/api")
+        app.state.server_manager = server_manager
+        app.state.db_manager = backend
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_unauthenticated_request_is_rejected(self, server_manager, backend, monkeypatch):
+        """GET /api/servers/{id}/debug must require auth in secure mode — it returns sensitive diagnostics."""
+        monkeypatch.setenv("FMCP_SECURE_MODE", "true")
+        monkeypatch.setenv("FMCP_BEARER_TOKEN", "test-secret")
+        _register(server_manager, "srv")
+        resp = self._make_unauthed_client(server_manager, backend).get("/api/servers/srv/debug")
+        assert resp.status_code in (401, 403), (
+            f"Expected 401/403 for unauthenticated debug request, got {resp.status_code}"
+        )


### PR DESCRIPTION
## Summary
Single endpoint that combines all debug data for a server in one request — replaces having to call `/status`, `/resources`, `/concurrency`, `/crashes`, and `/stderr` separately.

```
GET /api/servers/{id}/debug?stderr_lines=20
```

Returns:
- **status** — state, pid, uptime, restart_count, stability, exit_code, transport
- **resources** — live memory RSS/human, CPU%, open FDs, threads, memory trend, limit info (all null when not running)
- **concurrency** — max_concurrent_requests, active_requests, available_slots, rejected_total
- **crashes** — last 20 events with exit classification (category/label/description), recent_crash_count, crashes_per_hour
- **stderr** — last N lines from process log file (default 20, max 200 via `?stderr_lines=N`)

## Test plan
- [x] 404 for unknown server
- [x] All top-level keys present (server, status, resources, concurrency, crashes, stderr)
- [x] `server` field matches request id
- [x] `status.state` present
- [x] Resources all null when server not running
- [x] Resources populated with live psutil data when running
- [x] Concurrency keys all present
- [x] Crashes keys present with `events` as list
- [x] Stderr section present with all keys
- [x] Stderr empty when no log file exists
- [x] Stderr returns last 20 lines from log file by default
- [x] `?stderr_lines=N` param respected
- [x] Crash events annotated with exit classification (label, category, description)
- [x] `crashes_per_hour` computed correctly

All 14 tests pass. No regressions in existing debugging tests.

Generated with Claude Code