### PR TITLE
MCP-524: feat: implement on-demand (lazy) start for stopped/idle-cleaned MCP servers

### DIFF
--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1936,7 +1936,8 @@ async def run_tool(
             raise HTTPException(400, f"Server '{id}' is not running")
         safe_id = id.replace('\n', '\\n').replace('\r', '\\r')
         logger.info(f"Auto-starting server '{safe_id}' on demand")
-        started = await manager.start_server(id)
+        # Pass config so start_server skips a redundant DB fetch
+        started = await manager.start_server(id, config=config)
         if not started:
             raise HTTPException(400, f"Server '{id}' failed to auto-start")
 

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1934,12 +1934,15 @@ async def run_tool(
         config = await manager.db.get_server_config(id)
         if not config or config.get("deleted_at") or not config.get("enabled", True):
             raise HTTPException(400, f"Server '{id}' is not running")
-        logger.info(f"Auto-starting server '{id}' on demand")
+        safe_id = id.replace('\n', '\\n').replace('\r', '\\r')
+        logger.info(f"Auto-starting server '{safe_id}' on demand")
         started = await manager.start_server(id)
         if not started:
             raise HTTPException(400, f"Server '{id}' failed to auto-start")
 
-    process = manager.processes[id]
+    process = manager.processes.get(id)
+    if process is None:
+        raise HTTPException(503, f"Server '{id}' failed to start")
 
     # Send tools/call request
     try:

--- a/fluidmcp/cli/api/management.py
+++ b/fluidmcp/cli/api/management.py
@@ -1927,13 +1927,19 @@ async def run_tool(
     """
     manager = get_server_manager(request)
 
-    # Check if server is running
-    if id not in manager.processes:
-        raise HTTPException(400, f"Server '{id}' is not running")
+    # Auto-start the server if it's stopped but has a valid, enabled config
+    if id not in manager.processes or manager.processes[id].poll() is not None:
+        if manager.db is None:
+            raise HTTPException(400, f"Server '{id}' is not running")
+        config = await manager.db.get_server_config(id)
+        if not config or config.get("deleted_at") or not config.get("enabled", True):
+            raise HTTPException(400, f"Server '{id}' is not running")
+        logger.info(f"Auto-starting server '{id}' on demand")
+        started = await manager.start_server(id)
+        if not started:
+            raise HTTPException(400, f"Server '{id}' failed to auto-start")
 
     process = manager.processes[id]
-    if process.poll() is not None:
-        raise HTTPException(400, f"Server '{id}' has stopped")
 
     # Send tools/call request
     try:

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -379,7 +379,8 @@ def create_dynamic_router(server_manager):
         if not config.get("enabled", True):
             raise HTTPException(404, f"Server '{server_name}' is disabled")
 
-        logger.info(f"Auto-starting server '{server_name}' on demand")
+        safe_name = server_name.replace('\n', '\\n').replace('\r', '\\r')
+        logger.info(f"Auto-starting server '{safe_name}' on demand")
         started = await server_manager.start_server(server_name)
         if not started:
             raise HTTPException(503, f"Server '{server_name}' failed to auto-start")
@@ -415,7 +416,9 @@ def create_dynamic_router(server_manager):
         with RequestTimer(collector, method):
             await _ensure_server_running(server_name)
 
-            process = server_manager.processes[server_name]
+            process = server_manager.processes.get(server_name)
+            if process is None:
+                raise HTTPException(503, f"Server '{server_name}' failed to start")
 
             # ── SSE transport: forward via HTTP ─────────────────────────────
             if isinstance(process, SseSubprocessHandle):
@@ -486,7 +489,9 @@ def create_dynamic_router(server_manager):
         # Update last_used_at for idle cleanup when SSE connection is opened
         await server_manager.update_last_used(server_name)
 
-        process = server_manager.processes[server_name]
+        process = server_manager.processes.get(server_name)
+        if process is None:
+            raise HTTPException(503, f"Server '{server_name}' failed to start")
 
         async def event_generator() -> AsyncIterator[str]:
             completion_status = "success"
@@ -590,7 +595,9 @@ def create_dynamic_router(server_manager):
         """
         await _ensure_server_running(server_name)
 
-        process = server_manager.processes[server_name]
+        process = server_manager.processes.get(server_name)
+        if process is None:
+            raise HTTPException(503, f"Server '{server_name}' failed to start")
 
         # ── SSE transport ────────────────────────────────────────────────────
         if isinstance(process, SseSubprocessHandle):
@@ -646,7 +653,9 @@ def create_dynamic_router(server_manager):
         """
         await _ensure_server_running(server_name)
 
-        process = server_manager.processes[server_name]
+        process = server_manager.processes.get(server_name)
+        if process is None:
+            raise HTTPException(503, f"Server '{server_name}' failed to start")
 
         # ── SSE transport ────────────────────────────────────────────────────
         if isinstance(process, SseSubprocessHandle):

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -357,6 +357,33 @@ def create_dynamic_router(server_manager):
             _io_locks[name] = asyncio.Lock()
         return _io_locks[name]
 
+    async def _ensure_server_running(server_name: str) -> None:
+        """
+        Auto-start a stopped/idle-cleaned server if it has a valid, enabled config in the DB.
+
+        Raises HTTPException 404 if no config exists or server is disabled.
+        Raises HTTPException 503 if auto-start fails.
+        Does nothing if the server is already running.
+        """
+        process = server_manager.processes.get(server_name)
+        if process is not None and process.poll() is None:
+            return  # already running
+
+        # No running process — check DB for a valid, enabled config
+        if server_manager.db is None:
+            raise HTTPException(404, f"Server '{server_name}' not found or not running")
+
+        config = await server_manager.db.get_server_config(server_name)
+        if not config or config.get("deleted_at"):
+            raise HTTPException(404, f"Server '{server_name}' not found or not running")
+        if not config.get("enabled", True):
+            raise HTTPException(404, f"Server '{server_name}' is disabled")
+
+        logger.info(f"Auto-starting server '{server_name}' on demand")
+        started = await server_manager.start_server(server_name)
+        if not started:
+            raise HTTPException(503, f"Server '{server_name}' failed to auto-start")
+
     @router.post("/{server_name}/mcp", tags=["mcp"])
     async def proxy_jsonrpc(
         server_name: str,
@@ -386,15 +413,9 @@ def create_dynamic_router(server_manager):
         # HTTPExceptions raised within this context are tracked as error_type="network_error"
         # via RequestTimer.__exit__ → _categorize_error() → name-based matching
         with RequestTimer(collector, method):
-            # Check if server exists
-            if server_name not in server_manager.processes:
-                raise HTTPException(404, f"Server '{server_name}' not found or not running")
+            await _ensure_server_running(server_name)
 
             process = server_manager.processes[server_name]
-
-            # Check if process is alive
-            if process.poll() is not None:
-                raise HTTPException(503, f"Server '{server_name}' is not running (process died)")
 
             # ── SSE transport: forward via HTTP ─────────────────────────────
             if isinstance(process, SseSubprocessHandle):
@@ -437,9 +458,6 @@ def create_dynamic_router(server_manager):
         """
         Server-Sent Events streaming endpoint for long-running MCP operations.
         """
-        # Update last_used_at for idle cleanup when SSE connection is opened
-        await server_manager.update_last_used(server_name)
-
         # Initialize metrics collector
         collector = MetricsCollector(server_name)
 
@@ -448,6 +466,8 @@ def create_dynamic_router(server_manager):
         # Design Decision: These HTTPExceptions (404/503) are intentionally NOT wrapped
         # in RequestTimer because they represent pre-flight validation failures that occur
         # before any MCP protocol interaction begins. They are pure HTTP-layer errors.
+        # _ensure_server_running may auto-start a stopped server here; if it raises,
+        # the error is still a pre-flight failure before any streaming begins.
         #
         # These errors are observable through:
         # 1. FastAPI's built-in HTTP error logs
@@ -461,13 +481,12 @@ def create_dynamic_router(server_manager):
         #
         # Current implementation prioritizes clarity by separating HTTP validation from
         # MCP protocol errors tracked via RequestTimer.
-        if server_name not in server_manager.processes:
-            raise HTTPException(404, f"Server '{server_name}' not found or not running")
+        await _ensure_server_running(server_name)
+
+        # Update last_used_at for idle cleanup when SSE connection is opened
+        await server_manager.update_last_used(server_name)
 
         process = server_manager.processes[server_name]
-
-        if process.poll() is not None:
-            raise HTTPException(503, f"Server '{server_name}' is not running")
 
         async def event_generator() -> AsyncIterator[str]:
             completion_status = "success"
@@ -569,13 +588,9 @@ def create_dynamic_router(server_manager):
         """
         List available tools for a server.
         """
-        if server_name not in server_manager.processes:
-            raise HTTPException(404, f"Server '{server_name}' not found or not running")
+        await _ensure_server_running(server_name)
 
         process = server_manager.processes[server_name]
-
-        if process.poll() is not None:
-            raise HTTPException(503, f"Server '{server_name}' is not running")
 
         # ── SSE transport ────────────────────────────────────────────────────
         if isinstance(process, SseSubprocessHandle):
@@ -629,13 +644,9 @@ def create_dynamic_router(server_manager):
         """
         Call a specific tool on the MCP server.
         """
-        if server_name not in server_manager.processes:
-            raise HTTPException(404, f"Server '{server_name}' not found or not running")
+        await _ensure_server_running(server_name)
 
         process = server_manager.processes[server_name]
-
-        if process.poll() is not None:
-            raise HTTPException(503, f"Server '{server_name}' is not running")
 
         # ── SSE transport ────────────────────────────────────────────────────
         if isinstance(process, SseSubprocessHandle):

--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -357,7 +357,7 @@ def create_dynamic_router(server_manager):
             _io_locks[name] = asyncio.Lock()
         return _io_locks[name]
 
-    async def _ensure_server_running(server_name: str) -> None:
+    async def auto_start_stopped_server(server_name: str) -> None:
         """
         Auto-start a stopped/idle-cleaned server if it has a valid, enabled config in the DB.
 
@@ -365,9 +365,10 @@ def create_dynamic_router(server_manager):
         Raises HTTPException 503 if auto-start fails.
         Does nothing if the server is already running.
         """
+        # Fast path: process is alive, nothing to do
         process = server_manager.processes.get(server_name)
         if process is not None and process.poll() is None:
-            return  # already running
+            return
 
         # No running process — check DB for a valid, enabled config
         if server_manager.db is None:
@@ -381,7 +382,8 @@ def create_dynamic_router(server_manager):
 
         safe_name = server_name.replace('\n', '\\n').replace('\r', '\\r')
         logger.info(f"Auto-starting server '{safe_name}' on demand")
-        started = await server_manager.start_server(server_name)
+        # Pass config so start_server skips a redundant DB fetch
+        started = await server_manager.start_server(server_name, config=config)
         if not started:
             raise HTTPException(503, f"Server '{server_name}' failed to auto-start")
 
@@ -414,7 +416,7 @@ def create_dynamic_router(server_manager):
         # HTTPExceptions raised within this context are tracked as error_type="network_error"
         # via RequestTimer.__exit__ → _categorize_error() → name-based matching
         with RequestTimer(collector, method):
-            await _ensure_server_running(server_name)
+            await auto_start_stopped_server(server_name)
 
             process = server_manager.processes.get(server_name)
             if process is None:
@@ -469,7 +471,7 @@ def create_dynamic_router(server_manager):
         # Design Decision: These HTTPExceptions (404/503) are intentionally NOT wrapped
         # in RequestTimer because they represent pre-flight validation failures that occur
         # before any MCP protocol interaction begins. They are pure HTTP-layer errors.
-        # _ensure_server_running may auto-start a stopped server here; if it raises,
+        # auto_start_stopped_server may auto-start a stopped server here; if it raises,
         # the error is still a pre-flight failure before any streaming begins.
         #
         # These errors are observable through:
@@ -484,7 +486,7 @@ def create_dynamic_router(server_manager):
         #
         # Current implementation prioritizes clarity by separating HTTP validation from
         # MCP protocol errors tracked via RequestTimer.
-        await _ensure_server_running(server_name)
+        await auto_start_stopped_server(server_name)
 
         # Update last_used_at for idle cleanup when SSE connection is opened
         await server_manager.update_last_used(server_name)
@@ -593,7 +595,7 @@ def create_dynamic_router(server_manager):
         """
         List available tools for a server.
         """
-        await _ensure_server_running(server_name)
+        await auto_start_stopped_server(server_name)
 
         process = server_manager.processes.get(server_name)
         if process is None:
@@ -651,7 +653,7 @@ def create_dynamic_router(server_manager):
         """
         Call a specific tool on the MCP server.
         """
-        await _ensure_server_running(server_name)
+        await auto_start_stopped_server(server_name)
 
         process = server_manager.processes.get(server_name)
         if process is None:

--- a/fluidmcp/frontend/src/hooks/useToolRunner.ts
+++ b/fluidmcp/frontend/src/hooks/useToolRunner.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '../services/api';
 import { toolHistoryService } from '../services/toolHistory';
+import { showLoading, showError, dismissToast } from '../services/toast';
 import type { ToolExecution } from '../services/toolHistory';
 
 interface UseToolRunnerResult {
@@ -57,11 +58,21 @@ export function useToolRunner(
         setExecutionTime(null);
       }
 
+      const toastId = `tool-run-${serverId}-${toolName}`;
       const startTime = performance.now();
 
       try {
+        // Check if server is stopped before running — show a loading toast since
+        // the backend may auto-start it, which takes several seconds
+        const serverStatus = await apiClient.getServerStatus(serverId);
+        if (serverStatus.state !== 'running') {
+          showLoading(`Starting server "${serverName}"...`, toastId);
+        }
+
         const response = await apiClient.runTool(serverId, toolName, args);
         const endTime = performance.now();
+
+        dismissToast(toastId);
         const duration = (endTime - startTime) / 1000; // Convert to seconds
 
         if (isMountedRef.current) {
@@ -89,6 +100,8 @@ export function useToolRunner(
         const duration = (endTime - startTime) / 1000;
 
         const errorMessage = err.message || 'Failed to execute tool';
+
+        showError(errorMessage, toastId);
 
         if (isMountedRef.current) {
           setError(errorMessage);

--- a/fluidmcp/frontend/src/pages/ToolRunner.tsx
+++ b/fluidmcp/frontend/src/pages/ToolRunner.tsx
@@ -91,6 +91,13 @@ export const ToolRunner: React.FC = () => {
 
   const handleSubmit = async (values: Record<string, any>) => {
     await execute(values);
+    // Refresh server status so the auto-start banner clears after the server starts
+    try {
+      const updated = await apiClient.getServerDetails(serverId!);
+      setServer(updated as Server);
+    } catch {
+      // ignore — banner will just stay until next navigation
+    }
   };
 
   const handleLoadFromHistory = (executionId: string) => {
@@ -231,6 +238,27 @@ export const ToolRunner: React.FC = () => {
               </button>
             )}
           </div>
+
+      {/* Auto-start notice when server is stopped */}
+      {server.status?.state && server.status.state !== 'running' && server.status.state !== 'starting' && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.75rem',
+          padding: '0.875rem 1.25rem',
+          marginBottom: '1.5rem',
+          background: 'rgba(234, 179, 8, 0.08)',
+          border: '1px solid rgba(234, 179, 8, 0.25)',
+          borderRadius: '0.5rem',
+          fontSize: '0.875rem',
+          color: 'rgba(255, 255, 255, 0.8)',
+        }}>
+          <span style={{ fontSize: '1rem' }}>⚡</span>
+          <span>
+            Server is currently <strong style={{ color: '#fbbf24' }}>{server.status.state}</strong> — it will auto-start when you run a tool.
+          </span>
+        </div>
+      )}
 
       {/* Main Content */}
       <ErrorBoundary fallback={


### PR DESCRIPTION
## Summary
- Added `_ensure_server_running` helper in `package_launcher.py` that checks the DB for a valid, enabled config and auto-starts stopped/idle-cleaned servers before proxying any request
- Applied the same lazy-start logic to the `POST /api/servers/{id}/tools/{tool_name}/run` endpoint in `management.py`
- Frontend: added an auto-start banner on the ToolRunner page when the server is stopped, and a loading toast while the server is starting up — both clear automatically after the server comes online

## Test plan
- [x] Run a tool on a stopped server — server should auto-start and tool should succeed
- [x] Run a tool on a server that was idle-cleaned — same as above
- [ ] Run a tool on a disabled server — should return 404, no auto-start
- [ ] Run a tool on a non-existent server — should return 404
- [x] Verify the "Server is currently stopped" banner appears on ToolRunner for a stopped server and disappears after the tool runs
- [x] Verify the loading toast appears while the server is starting and dismisses on completion
- [x] Verify error toast appears if auto-start fails
