### PR TITLE
MCP-574: fix: Routing Issues, UI deep-link routing behind reverse proxies

### DIFF
--- a/fluidmcp/cli/cli.py
+++ b/fluidmcp/cli/cli.py
@@ -582,7 +582,7 @@ def github_command(args, secure_mode: bool = False, token: str = None) -> None:
             logger.info(f"Starting FastAPI server for {package_name}")
             logger.info(f"Swagger UI available at: http://localhost:{client_server_port}/docs")
 
-            uvicorn.run(app, host="0.0.0.0", port=client_server_port)
+            uvicorn.run(app, host="0.0.0.0", port=client_server_port, proxy_headers=True, forwarded_allow_ips="*")
 
     except ValueError:
         logger.exception("Configuration error")

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -697,7 +697,9 @@ async def main(args):
         host=args.host,
         port=args.port,
         loop="asyncio",
-        log_level="info"
+        log_level="info",
+        proxy_headers=True,
+        forwarded_allow_ips="*",
         # Note: Uvicorn doesn't provide a direct body size limit parameter
         # For production, configure limits at reverse proxy level (Nginx, Cloudflare, etc.)
     )

--- a/fluidmcp/cli/services/frontend_utils.py
+++ b/fluidmcp/cli/services/frontend_utils.py
@@ -10,7 +10,8 @@ This module provides functionality to:
 from pathlib import Path
 from typing import Optional
 from loguru import logger
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import FileResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 
@@ -134,18 +135,54 @@ def setup_frontend_routes(
 
         return False
 
+    # Known SPA routes that should redirect /route → /ui/route when hit bare
+    _SPA_ROUTES = {
+        "status", "servers", "documentation", "inspector",
+        "llm",
+    }
+
     try:
-        # Mount StaticFiles for serving built assets (JS, CSS, images)
-        # The html=True parameter enables SPA mode:
-        # - Serves static files normally (app.js, styles.css, etc.)
-        # - Falls back to index.html for non-file paths (SPA routing)
-        # This eliminates the need for separate route handlers
-        app.mount("/ui", StaticFiles(directory=str(frontend_dist), html=True), name="ui")
+        index_html = frontend_dist / "index.html"
+        assets_dir = frontend_dist / "assets"
+
+        # Mount /ui/assets separately so static asset requests are served directly
+        # without going through the SPA fallback handler.
+        if assets_dir.exists():
+            app.mount("/ui/assets", StaticFiles(directory=str(assets_dir)), name="ui-assets")
+
+        # Explicit /ui and /ui/ routes — Starlette's StaticFiles mount redirects
+        # /ui → /ui/ via an absolute Location header built from the raw Host header.
+        # Behind GitHub Codespaces / Railway that points at localhost:port instead of
+        # the public hostname. Serving index.html directly avoids the redirect entirely.
+        @app.get("/ui", include_in_schema=False)
+        @app.get("/ui/", include_in_schema=False)
+        async def ui_root():
+            return FileResponse(str(index_html))
+
+        # SPA catch-all: any /ui/{path} that isn't a real file gets index.html.
+        # Starlette's StaticFiles(html=True) falls back to 404.html (not index.html)
+        # when a path doesn't match a file, so deep-links like /ui/status would 404.
+        @app.get("/ui/{path:path}", include_in_schema=False)
+        async def ui_spa(path: str):
+            candidate = frontend_dist / path
+            if candidate.exists() and candidate.is_file():
+                return FileResponse(str(candidate))
+            return FileResponse(str(index_html))
+
+        # Redirect bare SPA routes (/status, /servers, etc.) → /ui/<route> so that
+        # copy-pasting a deep-link without the /ui prefix still works.
+        def _make_redirect_handler():
+            async def handler(request: Request):
+                return RedirectResponse(url="/ui" + str(request.url.path), status_code=302)
+            return handler
+
+        for _route in _SPA_ROUTES:
+            _handler = _make_redirect_handler()
+            app.add_api_route(f"/{_route}", _handler, include_in_schema=False)
+            app.add_api_route(f"/{_route}/{{rest:path}}", _handler, include_in_schema=False)
 
         logger.info("✓ Frontend UI routes registered")
 
-        # Log the URL with the correct host
-        # Use localhost for better UX if host is 0.0.0.0
         display_host = "localhost" if host == "0.0.0.0" else host
         logger.info(f"✓ Frontend UI available at http://{display_host}:{port}/ui")
 

--- a/fluidmcp/cli/services/frontend_utils.py
+++ b/fluidmcp/cli/services/frontend_utils.py
@@ -162,9 +162,26 @@ def setup_frontend_routes(
         # SPA catch-all: any /ui/{path} that isn't a real file gets index.html.
         # Starlette's StaticFiles(html=True) falls back to 404.html (not index.html)
         # when a path doesn't match a file, so deep-links like /ui/status would 404.
+        #
+        # SECURITY: Path traversal protection
+        # User-controlled path segments like "../../../etc/passwd" are resolved and
+        # checked to ensure they stay within frontend_dist before serving.
         @app.get("/ui/{path:path}", include_in_schema=False)
         async def ui_spa(path: str):
-            candidate = frontend_dist / path
+            # Build candidate path and resolve it to absolute form
+            candidate = (frontend_dist / path).resolve()
+            frontend_dist_resolved = frontend_dist.resolve()
+
+            # Containment check: ensure resolved path is under frontend_dist
+            # This prevents path traversal attacks (e.g., /ui/../../../etc/passwd)
+            try:
+                candidate.relative_to(frontend_dist_resolved)
+            except ValueError:
+                # Path escaped frontend_dist - serve index.html instead of error
+                # (error would leak information about server filesystem structure)
+                return FileResponse(str(index_html))
+
+            # Safe to serve: path is contained within frontend_dist
             if candidate.exists() and candidate.is_file():
                 return FileResponse(str(candidate))
             return FileResponse(str(index_html))

--- a/fluidmcp/frontend/src/main.tsx
+++ b/fluidmcp/frontend/src/main.tsx
@@ -11,7 +11,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
       <div className="min-h-screen bg-background font-sans antialiased" style={{ fontFamily: 'Inter, sans-serif' }}>
-        <BrowserRouter>
+        <BrowserRouter basename="/ui">
           <App />
         </BrowserRouter>
       </div>


### PR DESCRIPTION
## Summary

- **`BrowserRouter basename=\"/ui\"`** — React Router was matching routes as `/status` while the app is served at `/ui/`, so `/ui/status` never matched any route. Adding `basename` fixes all deep links.
- **Replaced `StaticFiles` mount with explicit route handlers** — `StaticFiles(html=True)` falls back to `404.html` (not `index.html`) for unknown sub-paths, breaking direct navigation to `/ui/status` etc. New handlers serve `index.html` as the SPA fallback for any unmatched `/ui/*` path.
- **Eliminated absolute-URL redirect** — Starlette redirects `/ui` → `/ui/` using the raw `Host` header, which resolves to `localhost:port` behind GitHub Codespaces. Serving `index.html` directly from `GET /ui` removes the redirect entirely.
- **Bare route redirects** — `/status`, `/servers`, `/inspector` etc. now 302 to `/ui/<route>` so copy-pasted links without the `/ui` prefix work.
- **`proxy_headers=True` on uvicorn** — trusts `X-Forwarded-Host`/`X-Forwarded-Proto` from Railway/Codespaces for correct URL construction elsewhere (OpenAPI docs, etc.).

## Test plan

- [x] `/ui` loads landing page (no redirect to localhost)
- [x] `/ui/` loads landing page
- [x] `/ui/status` loads status page directly (deep link)
- [x] `/ui/servers` loads servers page directly
- [x] `/ui/inspector` loads inspector page directly
- [x] `/status` redirects to `/ui/status` and loads correctly
- [x] `/inspector` redirects to `/ui/inspector` and loads correctly
- [x] `/ui/nonexistent` falls back to landing page (SPA catch-all)
- [x] Static assets (`/ui/assets/*.js`, `*.css`) still served correctly