### PR TITLE
[MCP-622] : Fix: fmcp run servers not registered in server_manager.processes (invisible to dynamic router)

### DIFF
--- a/fluidmcp/cli/services/run_servers.py
+++ b/fluidmcp/cli/services/run_servers.py
@@ -322,8 +322,9 @@ def run_servers(
                 process = await server_manager._spawn_mcp_process(server_name, spawn_cfg)
 
                 if process:
-                    # _spawn_mcp_process already registers the process in server_manager.
-                    # Just wire up the module-level tracking used by health/tools endpoints.
+                    # Register in server_manager.processes so the dynamic router can find it.
+                    server_manager.processes[server_name] = process
+                    # Wire up module-level tracking used by health/tools endpoints.
                     _register_server_process(server_name, process)
                     _initialize_server_metrics(server_name)
 


### PR DESCRIPTION
Type : BugFix