### PR TITLE
MCP-276 : feat: Full observability stack — OTEL traces + Loki logs + Prometheus metrics + Grafana

### DIFF
--- a/.env.observability.example
+++ b/.env.observability.example
@@ -1,0 +1,21 @@
+# Copy this file to .env.observability and fill in values before starting the stack.
+# Never commit .env.observability to version control.
+#
+# Usage:
+#   cp .env.observability.example .env.observability
+#   # Edit .env.observability
+#   docker compose -f docker-compose.observability.yml --env-file .env.observability up --build
+
+# ── Grafana credentials (REQUIRED) ────────────────────────────────────────────
+# The compose file has no default for GF_SECURITY_ADMIN_PASSWORD.
+# Docker Compose will refuse to start Grafana if this is unset.
+GF_SECURITY_ADMIN_USER=admin
+GF_SECURITY_ADMIN_PASSWORD=changeme_use_a_strong_password_here
+
+# ── FluidMCP bearer token (recommended) ───────────────────────────────────────
+# Set a stable token so it does not regenerate on every container restart.
+# Generate one with: openssl rand -hex 32
+# FMCP_BEARER_TOKEN=
+
+# ── MongoDB URI (optional — omit for in-memory mode) ─────────────────────────
+# MONGODB_URI=mongodb://mongo:27017

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ yarn-error.log*
 .env
 .env.*
 !.env.example
+!.env.observability.example
 
 # Logs
 logs/

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -3,22 +3,21 @@ version: "3.9"
 # FluidMCP Full Observability Stack
 # ─────────────────────────────────
 # Signals collected:
-#   Logs    → Promtail scrapes FluidMCP stderr (JSON) → Loki
+#   Logs    → Promtail tails Docker json-file logs → Loki
 #   Metrics → Prometheus scrapes /metrics every 10 s
 #   Traces  → FluidMCP OTLP HTTP → Tempo
 #   UI      → Grafana (all three datasources pre-wired)
 #
 # Usage:
-#   docker compose -f docker-compose.observability.yml up --build
+#   cp .env.observability.example .env.observability
+#   # Edit .env.observability and set GF_SECURITY_ADMIN_PASSWORD
+#   docker compose -f docker-compose.observability.yml --env-file .env.observability up --build
 #
-# URLs:
+# URLs (all bound to 127.0.0.1 — localhost only):
 #   FluidMCP   http://localhost:8099
-#   Grafana    http://localhost:3000   (admin / admin)
+#   Grafana    http://localhost:3000   (credentials from .env.observability)
 #   Prometheus http://localhost:9090
 #   Tempo      http://localhost:3200   (API / query)
-#
-# Environment:
-#   Copy .env.observability.example → .env and fill in secrets before first run.
 
 services:
 
@@ -33,24 +32,21 @@ services:
     environment:
       PORT: "8099"
       PYTHONUNBUFFERED: "1"
-      LOG_FORMAT: "json"                          # emit JSON lines for Promtail
+      LOG_FORMAT: "json"
       OTEL_ENABLED: "true"
       OTEL_SERVICE_NAME: "fluidmcp"
       OTEL_SERVICE_VERSION: "2.0.0"
-      OTEL_EXPORTER: "jaeger"                     # sends to Tempo via OTLP HTTP
+      OTEL_EXPORTER: "jaeger"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo:4318/v1/traces"
-      # Uncomment and set a stable bearer token to avoid regeneration on restart:
       # FMCP_BEARER_TOKEN: "${FMCP_BEARER_TOKEN}"
-      # MongoDB (optional — omit to run without persistence):
       # MONGODB_URI: "mongodb://mongo:27017"
-    volumes:
-      # Named volume so Promtail can read the log file written by the container
-      - fluidmcp_logs:/var/log/fluidmcp
     logging:
       driver: "json-file"
       options:
         max-size: "50m"
         max-file: "5"
+        # tag is embedded in each log line's attrs field;
+        # Promtail reads it to identify fluidmcp logs without the Docker socket.
         tag: "fluidmcp"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8099/health"]
@@ -64,11 +60,14 @@ services:
       - tempo
 
   # ── Prometheus ────────────────────────────────────────────────────────────
+  # Bound to 127.0.0.1: only accessible from the local machine.
+  # --web.enable-lifecycle is intentionally omitted (unauthenticated reload/quit).
+  # --web.enable-remote-write-receiver is omitted; Tempo uses its own storage.
   prometheus:
     image: prom/prometheus:v2.51.0
     container_name: prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./observability/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
@@ -79,20 +78,19 @@ services:
       - "--storage.tsdb.retention.time=15d"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
-      - "--web.enable-lifecycle"
-      # Enable remote-write receiver so Tempo can push exemplars back (optional)
-      - "--web.enable-remote-write-receiver"
     networks:
       - observability
 
   # ── Grafana Tempo (distributed tracing backend) ───────────────────────────
+  # 4318 (OTLP HTTP) bound to 127.0.0.1; FluidMCP reaches it via the internal
+  # Docker network (service name "tempo"), not through the host port.
   tempo:
     image: grafana/tempo:2.4.1
     container_name: tempo
     ports:
-      - "3200:3200"    # Tempo HTTP API / Grafana query
-      - "4317:4317"    # OTLP gRPC (optional, for gRPC exporters)
-      - "4318:4318"    # OTLP HTTP (FluidMCP sends here)
+      - "127.0.0.1:3200:3200"
+      - "127.0.0.1:4317:4317"
+      - "127.0.0.1:4318:4318"
     volumes:
       - ./observability/tempo/tempo.yml:/etc/tempo/tempo.yml:ro
       - tempo_data:/var/tempo
@@ -105,7 +103,7 @@ services:
     image: grafana/loki:2.9.4
     container_name: loki
     ports:
-      - "3100:3100"
+      - "127.0.0.1:3100:3100"
     volumes:
       - ./observability/loki/loki.yml:/etc/loki/loki.yml:ro
       - loki_data:/loki
@@ -113,15 +111,17 @@ services:
     networks:
       - observability
 
-  # ── Promtail (log shipper: Docker logs → Loki) ────────────────────────────
+  # ── Promtail (log shipper: Docker json-file logs → Loki) ──────────────────
+  # No Docker socket mount. Promtail reads log files directly from
+  # /var/lib/docker/containers (already :ro) using a glob path.
+  # The container "tag" attribute (set in fluidmcp logging.options) is extracted
+  # from each log line's JSON envelope to identify the fluidmcp container.
   promtail:
     image: grafana/promtail:2.9.4
     container_name: promtail
     volumes:
       - ./observability/promtail/promtail.yml:/etc/promtail/promtail.yml:ro
-      # Mount Docker socket so Promtail can discover and tail container logs
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
     command: ["-config.file=/etc/promtail/promtail.yml"]
     depends_on:
       - loki
@@ -129,18 +129,23 @@ services:
       - observability
 
   # ── Grafana (visualization) ────────────────────────────────────────────────
+  # Bound to 127.0.0.1 — not exposed to the wider network.
+  # Admin password MUST be set via GF_SECURITY_ADMIN_PASSWORD in .env.observability.
+  # The compose file intentionally has no fallback default to prevent accidental
+  # deployment with a weak password.
   grafana:
     image: grafana/grafana:10.4.2
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
-      GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_SECURITY_ADMIN_USER: "${GF_SECURITY_ADMIN_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GF_SECURITY_ADMIN_PASSWORD}"
       GF_USERS_ALLOW_SIGN_UP: "false"
       GF_PATHS_PROVISIONING: /etc/grafana/provisioning
-      # Enable Tempo → Loki trace-to-logs and Loki → Tempo logs-to-traces links
       GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+      # Disable anonymous access
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
     volumes:
       - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
       - ./examples/grafana-dashboard.json:/var/lib/grafana/dashboards/fluidmcp-metrics.json:ro
@@ -157,7 +162,6 @@ networks:
     driver: bridge
 
 volumes:
-  fluidmcp_logs:
   prometheus_data:
   tempo_data:
   loki_data:

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,164 @@
+version: "3.9"
+
+# FluidMCP Full Observability Stack
+# ─────────────────────────────────
+# Signals collected:
+#   Logs    → Promtail scrapes FluidMCP stderr (JSON) → Loki
+#   Metrics → Prometheus scrapes /metrics every 10 s
+#   Traces  → FluidMCP OTLP HTTP → Tempo
+#   UI      → Grafana (all three datasources pre-wired)
+#
+# Usage:
+#   docker compose -f docker-compose.observability.yml up --build
+#
+# URLs:
+#   FluidMCP   http://localhost:8099
+#   Grafana    http://localhost:3000   (admin / admin)
+#   Prometheus http://localhost:9090
+#   Tempo      http://localhost:3200   (API / query)
+#
+# Environment:
+#   Copy .env.observability.example → .env and fill in secrets before first run.
+
+services:
+
+  # ── FluidMCP Gateway ──────────────────────────────────────────────────────
+  fluidmcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: fluidmcp
+    ports:
+      - "8099:8099"
+    environment:
+      PORT: "8099"
+      PYTHONUNBUFFERED: "1"
+      LOG_FORMAT: "json"                          # emit JSON lines for Promtail
+      OTEL_ENABLED: "true"
+      OTEL_SERVICE_NAME: "fluidmcp"
+      OTEL_SERVICE_VERSION: "2.0.0"
+      OTEL_EXPORTER: "jaeger"                     # sends to Tempo via OTLP HTTP
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo:4318/v1/traces"
+      # Uncomment and set a stable bearer token to avoid regeneration on restart:
+      # FMCP_BEARER_TOKEN: "${FMCP_BEARER_TOKEN}"
+      # MongoDB (optional — omit to run without persistence):
+      # MONGODB_URI: "mongodb://mongo:27017"
+    volumes:
+      # Named volume so Promtail can read the log file written by the container
+      - fluidmcp_logs:/var/log/fluidmcp
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+        tag: "fluidmcp"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8099/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 45s
+      retries: 3
+    networks:
+      - observability
+    depends_on:
+      - tempo
+
+  # ── Prometheus ────────────────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.enable-lifecycle"
+      # Enable remote-write receiver so Tempo can push exemplars back (optional)
+      - "--web.enable-remote-write-receiver"
+    networks:
+      - observability
+
+  # ── Grafana Tempo (distributed tracing backend) ───────────────────────────
+  tempo:
+    image: grafana/tempo:2.4.1
+    container_name: tempo
+    ports:
+      - "3200:3200"    # Tempo HTTP API / Grafana query
+      - "4317:4317"    # OTLP gRPC (optional, for gRPC exporters)
+      - "4318:4318"    # OTLP HTTP (FluidMCP sends here)
+    volumes:
+      - ./observability/tempo/tempo.yml:/etc/tempo/tempo.yml:ro
+      - tempo_data:/var/tempo
+    command: ["-config.file=/etc/tempo/tempo.yml"]
+    networks:
+      - observability
+
+  # ── Grafana Loki (log aggregation) ────────────────────────────────────────
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./observability/loki/loki.yml:/etc/loki/loki.yml:ro
+      - loki_data:/loki
+    command: ["-config.file=/etc/loki/loki.yml"]
+    networks:
+      - observability
+
+  # ── Promtail (log shipper: Docker logs → Loki) ────────────────────────────
+  promtail:
+    image: grafana/promtail:2.9.4
+    container_name: promtail
+    volumes:
+      - ./observability/promtail/promtail.yml:/etc/promtail/promtail.yml:ro
+      # Mount Docker socket so Promtail can discover and tail container logs
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: ["-config.file=/etc/promtail/promtail.yml"]
+    depends_on:
+      - loki
+    networks:
+      - observability
+
+  # ── Grafana (visualization) ────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_PATHS_PROVISIONING: /etc/grafana/provisioning
+      # Enable Tempo → Loki trace-to-logs and Loki → Tempo logs-to-traces links
+      GF_FEATURE_TOGGLES_ENABLE: "traceqlEditor"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./examples/grafana-dashboard.json:/var/lib/grafana/dashboards/fluidmcp-metrics.json:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - loki
+      - tempo
+    networks:
+      - observability
+
+networks:
+  observability:
+    driver: bridge
+
+volumes:
+  fluidmcp_logs:
+  prometheus_data:
+  tempo_data:
+  loki_data:
+  grafana_data:

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -36,7 +36,7 @@ services:
       OTEL_ENABLED: "true"
       OTEL_SERVICE_NAME: "fluidmcp"
       OTEL_SERVICE_VERSION: "2.0.0"
-      OTEL_EXPORTER: "jaeger"
+      OTEL_EXPORTER: "otlp"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo:4318/v1/traces"
       # FMCP_BEARER_TOKEN: "${FMCP_BEARER_TOKEN}"
       # MONGODB_URI: "mongodb://mongo:27017"

--- a/fluidmcp/cli/cli.py
+++ b/fluidmcp/cli/cli.py
@@ -22,26 +22,59 @@ from .services.package_list import get_latest_version_dir
 from .services.config_resolver import INSTALLATION_DIR
 
 
+def _json_log_sink(message) -> None:
+    """
+    Loguru sink that emits one JSON object per line to stderr.
+    Promtail scrapes these lines and ships them to Loki.
+    The trace_id / span_id fields are injected when an OTEL span is active
+    so Grafana can correlate logs ↔ traces.
+    """
+    record = message.record
+    trace_id = span_id = None
+    try:
+        from .context import get_trace_id, get_span_id
+        trace_id = get_trace_id()
+        span_id = get_span_id()
+    except Exception:
+        pass
+
+    entry = {
+        "timestamp": record["time"].isoformat(),
+        "level": record["level"].name,
+        "message": record["message"],
+        "service": "fluidmcp",
+        "logger": record["name"],
+        "file": record["file"].name,
+        "line": record["line"],
+    }
+    if trace_id:
+        entry["trace_id"] = trace_id
+    if span_id:
+        entry["span_id"] = span_id
+    if record["exception"]:
+        entry["exception"] = str(record["exception"])
+
+    sys.stderr.write(json.dumps(entry) + "\n")
+    sys.stderr.flush()
+
+
 def configure_logger(verbose: bool = False) -> None:
-    """
-    Configure loguru logger based on verbosity flag.
-
-    Args:
-        verbose: If True, set level to DEBUG; otherwise INFO
-    """
-    # Remove default handler
+    """Configure loguru.  JSON output when LOG_FORMAT=json (default in containers)."""
     logger.remove()
-
-    # Set level based on verbose flag
     log_level = "DEBUG" if verbose else "INFO"
+    log_format = os.getenv("LOG_FORMAT", "json").lower()
 
-    # Add new handler with specified level and simple format
-    logger.add(
-        sys.stderr,
-        level=log_level,
-        format="<level>{message}</level>",
-        colorize=True
-    )
+    if log_format == "json":
+        # Structured JSON lines — consumed by Promtail → Loki
+        logger.add(_json_log_sink, level=log_level, colorize=False)
+    else:
+        # Human-readable coloured output for local dev
+        logger.add(
+            sys.stderr,
+            level=log_level,
+            format="<level>{message}</level>",
+            colorize=True,
+        )
 
 
 

--- a/fluidmcp/cli/cli.py
+++ b/fluidmcp/cli/cli.py
@@ -59,10 +59,12 @@ def _json_log_sink(message) -> None:
 
 
 def configure_logger(verbose: bool = False) -> None:
-    """Configure loguru.  JSON output when LOG_FORMAT=json (default in containers)."""
+    """Configure loguru. Default: human-readable colour output for local dev.
+    Set LOG_FORMAT=json (done automatically in docker-compose.observability.yml)
+    to emit structured JSON lines consumed by Promtail → Loki."""
     logger.remove()
     log_level = "DEBUG" if verbose else "INFO"
-    log_format = os.getenv("LOG_FORMAT", "json").lower()
+    log_format = os.getenv("LOG_FORMAT", "text").lower()
 
     if log_format == "json":
         # Structured JSON lines — consumed by Promtail → Loki

--- a/fluidmcp/cli/context.py
+++ b/fluidmcp/cli/context.py
@@ -1,0 +1,37 @@
+"""Request-scoped context storage (trace IDs, server ID) via contextvars."""
+from contextvars import ContextVar
+from typing import Optional
+
+_trace_id: ContextVar[Optional[str]] = ContextVar("trace_id", default=None)
+_span_id: ContextVar[Optional[str]] = ContextVar("span_id", default=None)
+_server_id: ContextVar[Optional[str]] = ContextVar("server_id", default=None)
+
+
+def get_trace_id() -> Optional[str]:
+    return _trace_id.get()
+
+
+def get_span_id() -> Optional[str]:
+    return _span_id.get()
+
+
+def get_server_id() -> Optional[str]:
+    return _server_id.get()
+
+
+def set_trace_id(value: Optional[str]) -> None:
+    _trace_id.set(value)
+
+
+def set_span_id(value: Optional[str]) -> None:
+    _span_id.set(value)
+
+
+def set_server_id(value: Optional[str]) -> None:
+    _server_id.set(value)
+
+
+def clear_context() -> None:
+    _trace_id.set(None)
+    _span_id.set(None)
+    _server_id.set(None)

--- a/fluidmcp/cli/otel.py
+++ b/fluidmcp/cli/otel.py
@@ -1,0 +1,162 @@
+"""
+OpenTelemetry initialization for FluidMCP.
+
+Supports OTLP HTTP export (Grafana Tempo / Jaeger), console debug, or both.
+Gracefully no-ops if packages are missing or the collector is unreachable.
+
+Environment variables:
+    OTEL_ENABLED                  true | false  (default: true)
+    OTEL_SERVICE_NAME             (default: fluidmcp)
+    OTEL_SERVICE_VERSION          (default: 2.0.0)
+    OTEL_EXPORTER                 jaeger | console | both  (default: jaeger)
+    OTEL_EXPORTER_OTLP_ENDPOINT   (default: http://tempo:4318/v1/traces)
+    OTEL_SHUTDOWN_TIMEOUT         seconds (default: 5.0)
+"""
+import os
+import threading
+import time
+from loguru import logger
+
+_otel_initialized = False
+_otel_shutdown_lock = threading.Lock()
+_otel_shutdown_done = False
+_otel_provider = None
+
+
+def init_otel() -> bool:
+    global _otel_initialized
+
+    if _otel_initialized:
+        return True
+
+    if os.getenv("OTEL_ENABLED", "true").lower() == "false":
+        logger.info("OpenTelemetry disabled via OTEL_ENABLED=false")
+        return False
+
+    try:
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+        from opentelemetry.sdk.resources import Resource
+
+        service_name = os.getenv("OTEL_SERVICE_NAME", "fluidmcp")
+        service_version = os.getenv("OTEL_SERVICE_VERSION", "2.0.0")
+
+        resource = Resource.create({
+            "service.name": service_name,
+            "service.version": service_version,
+        })
+
+        global _otel_provider
+        provider = TracerProvider(resource=resource)
+        _otel_provider = provider
+
+        exporter_type = os.getenv("OTEL_EXPORTER", "jaeger").lower()
+        exporters_added = []
+
+        if exporter_type in ("jaeger", "both"):
+            try:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+                otlp_endpoint = os.getenv(
+                    "OTEL_EXPORTER_OTLP_ENDPOINT",
+                    "http://tempo:4318/v1/traces",
+                )
+                otlp_exporter = OTLPSpanExporter(endpoint=otlp_endpoint)
+                provider.add_span_processor(BatchSpanProcessor(otlp_exporter))
+                exporters_added.append(f"otlp({otlp_endpoint})")
+                logger.info(f"OpenTelemetry OTLP exporter → {otlp_endpoint}")
+
+                if not _verify_endpoint(otlp_endpoint):
+                    logger.warning("OTLP endpoint unreachable — spans will queue until collector is ready")
+
+            except ImportError:
+                logger.error("opentelemetry-exporter-otlp-proto-http not installed")
+            except Exception as exc:
+                logger.error(f"Failed to configure OTLP exporter: {exc}")
+
+        if exporter_type in ("console", "both"):
+            try:
+                provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+                exporters_added.append("console")
+            except Exception as exc:
+                logger.warning(f"Console exporter failed: {exc}")
+
+        if not exporters_added:
+            logger.error("No OTEL exporters configured — tracing disabled")
+            return False
+
+        trace.set_tracer_provider(provider)
+        _otel_initialized = True
+        logger.info(f"OpenTelemetry ready: service={service_name} exporters={exporters_added}")
+        return True
+
+    except ImportError as exc:
+        logger.error(f"OpenTelemetry packages missing: {exc}")
+        return False
+    except Exception as exc:
+        logger.error(f"OpenTelemetry init failed: {exc}")
+        return False
+
+
+def _verify_endpoint(endpoint: str, timeout: float = 2.0) -> bool:
+    try:
+        import httpx
+        base = endpoint.rsplit("/v1/traces", 1)[0]
+        with httpx.Client(timeout=timeout) as client:
+            client.get(base, follow_redirects=False)
+        return True
+    except Exception:
+        return False
+
+
+def instrument_fastapi_app(app) -> bool:
+    if not _otel_initialized:
+        return False
+    try:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        FastAPIInstrumentor.instrument_app(app)
+        logger.info("FastAPI instrumented with OpenTelemetry")
+        return True
+    except ImportError as exc:
+        logger.warning(f"FastAPI OTEL instrumentation missing: {exc}")
+        return False
+    except Exception as exc:
+        logger.warning(f"FastAPI OTEL instrumentation failed: {exc}")
+        return False
+
+
+def shutdown_otel(timeout_seconds: float = 5.0) -> bool:
+    global _otel_shutdown_done, _otel_provider
+
+    with _otel_shutdown_lock:
+        if _otel_shutdown_done:
+            return True
+
+    if not _otel_initialized or _otel_provider is None:
+        return True
+
+    try:
+        env_timeout = os.getenv("OTEL_SHUTDOWN_TIMEOUT")
+        if env_timeout:
+            try:
+                timeout_seconds = max(float(env_timeout), 0.1)
+            except ValueError:
+                pass
+
+        timeout_millis = int(timeout_seconds * 1000)
+        flushed = _otel_provider.force_flush(timeout_millis=timeout_millis)
+        if not flushed:
+            logger.warning(f"OTEL force_flush timed out after {timeout_seconds}s — some spans may be lost")
+        _otel_provider.shutdown()
+        logger.info("OpenTelemetry shutdown complete")
+
+        with _otel_shutdown_lock:
+            _otel_shutdown_done = True
+        return flushed
+
+    except Exception as exc:
+        logger.error(f"OpenTelemetry shutdown error: {exc}")
+        with _otel_shutdown_lock:
+            _otel_shutdown_done = True
+        return False

--- a/fluidmcp/cli/otel.py
+++ b/fluidmcp/cli/otel.py
@@ -1,17 +1,18 @@
 """
 OpenTelemetry initialization for FluidMCP.
 
-Supports OTLP HTTP export (Grafana Tempo / Jaeger), console debug, or both.
+Supports OTLP HTTP export (Grafana Tempo), console debug, or both.
 Gracefully no-ops if packages are missing or the collector is unreachable.
 
 Environment variables:
     OTEL_ENABLED                  true | false  (default: true)
     OTEL_SERVICE_NAME             (default: fluidmcp)
     OTEL_SERVICE_VERSION          (default: 2.0.0)
-    OTEL_EXPORTER                 jaeger | console | both  (default: jaeger)
+    OTEL_EXPORTER                 otlp | console | both  (default: otlp)
     OTEL_EXPORTER_OTLP_ENDPOINT   (default: http://tempo:4318/v1/traces)
     OTEL_SHUTDOWN_TIMEOUT         seconds (default: 5.0)
 """
+import asyncio
 import os
 import threading
 import time
@@ -51,10 +52,12 @@ def init_otel() -> bool:
         provider = TracerProvider(resource=resource)
         _otel_provider = provider
 
-        exporter_type = os.getenv("OTEL_EXPORTER", "jaeger").lower()
+        # "otlp" is the correct name — previously called "jaeger" because the
+        # OTLP exporter originated from the Jaeger project. Renamed for clarity.
+        exporter_type = os.getenv("OTEL_EXPORTER", "otlp").lower()
         exporters_added = []
 
-        if exporter_type in ("jaeger", "both"):
+        if exporter_type in ("otlp", "both"):
             try:
                 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 
@@ -67,8 +70,13 @@ def init_otel() -> bool:
                 exporters_added.append(f"otlp({otlp_endpoint})")
                 logger.info(f"OpenTelemetry OTLP exporter → {otlp_endpoint}")
 
-                if not _verify_endpoint(otlp_endpoint):
-                    logger.warning("OTLP endpoint unreachable — spans will queue until collector is ready")
+                # Verify reachability non-blocking — fire-and-forget in a thread
+                # so we don't stall the async event loop during startup.
+                threading.Thread(
+                    target=_verify_endpoint_sync,
+                    args=(otlp_endpoint,),
+                    daemon=True,
+                ).start()
 
             except ImportError:
                 logger.error("opentelemetry-exporter-otlp-proto-http not installed")
@@ -86,6 +94,10 @@ def init_otel() -> bool:
             logger.error("No OTEL exporters configured — tracing disabled")
             return False
 
+        # Wire httpx instrumentation so outbound HTTP calls from backends
+        # (Prometheus, Loki, Tempo clients) appear as child spans automatically.
+        _instrument_httpx()
+
         trace.set_tracer_provider(provider)
         _otel_initialized = True
         logger.info(f"OpenTelemetry ready: service={service_name} exporters={exporters_added}")
@@ -99,15 +111,34 @@ def init_otel() -> bool:
         return False
 
 
-def _verify_endpoint(endpoint: str, timeout: float = 2.0) -> bool:
+def _verify_endpoint_sync(endpoint: str, timeout: float = 2.0) -> None:
+    """
+    Log a warning if the OTLP collector is unreachable at startup.
+    Runs in a daemon thread — never blocks the event loop.
+    """
     try:
         import httpx
         base = endpoint.rsplit("/v1/traces", 1)[0]
         with httpx.Client(timeout=timeout) as client:
             client.get(base, follow_redirects=False)
-        return True
+        logger.debug(f"OTLP endpoint reachable: {base}")
     except Exception:
-        return False
+        logger.warning(
+            f"OTLP endpoint unreachable at startup: {endpoint} — "
+            "spans will queue in memory until the collector is ready"
+        )
+
+
+def _instrument_httpx() -> None:
+    """Instrument httpx so outbound HTTP calls appear as child OTEL spans."""
+    try:
+        from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+        HTTPXClientInstrumentor().instrument()
+        logger.debug("httpx instrumented with OpenTelemetry")
+    except ImportError:
+        logger.debug("opentelemetry-instrumentation-httpx not installed — skipping")
+    except Exception as exc:
+        logger.debug(f"httpx instrumentation skipped: {exc}")
 
 
 def instrument_fastapi_app(app) -> bool:
@@ -127,14 +158,24 @@ def instrument_fastapi_app(app) -> bool:
 
 
 def shutdown_otel(timeout_seconds: float = 5.0) -> bool:
+    """
+    Flush and shut down the OTEL tracer provider.
+
+    Thread-safe: all state checks are inside the lock to eliminate the TOCTOU
+    race between the idempotency check and the initialized/provider checks.
+    """
     global _otel_shutdown_done, _otel_provider
 
     with _otel_shutdown_lock:
+        # All early-exit conditions checked inside the lock — no TOCTOU window.
         if _otel_shutdown_done:
             return True
+        if not _otel_initialized or _otel_provider is None:
+            _otel_shutdown_done = True
+            return True
 
-    if not _otel_initialized or _otel_provider is None:
-        return True
+        # Mark done immediately inside the lock so concurrent callers skip.
+        _otel_shutdown_done = True
 
     try:
         env_timeout = os.getenv("OTEL_SHUTDOWN_TIMEOUT")
@@ -147,16 +188,13 @@ def shutdown_otel(timeout_seconds: float = 5.0) -> bool:
         timeout_millis = int(timeout_seconds * 1000)
         flushed = _otel_provider.force_flush(timeout_millis=timeout_millis)
         if not flushed:
-            logger.warning(f"OTEL force_flush timed out after {timeout_seconds}s — some spans may be lost")
+            logger.warning(
+                f"OTEL force_flush timed out after {timeout_seconds}s — some spans may be lost"
+            )
         _otel_provider.shutdown()
         logger.info("OpenTelemetry shutdown complete")
-
-        with _otel_shutdown_lock:
-            _otel_shutdown_done = True
         return flushed
 
     except Exception as exc:
         logger.error(f"OpenTelemetry shutdown error: {exc}")
-        with _otel_shutdown_lock:
-            _otel_shutdown_done = True
         return False

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -16,6 +16,8 @@ import secrets
 from pathlib import Path
 from uvicorn import Config, Server
 
+from starlette.middleware.base import BaseHTTPMiddleware
+
 from .repositories import DatabaseManager, InMemoryBackend, PersistenceBackend
 from .services.server_manager import ServerManager, MCPHealthMonitor
 from .api.management import router as mgmt_router
@@ -24,6 +26,26 @@ from .services.metrics import get_registry
 from .services.frontend_utils import setup_frontend_routes
 from .api.inspector import router as inspector_router, cleanup_sessions
 from .auth import verify_token
+from .otel import init_otel, instrument_fastapi_app
+from .context import set_trace_id, set_span_id, clear_context
+
+
+class TraceContextMiddleware(BaseHTTPMiddleware):
+    """Inject OTEL trace/span IDs into per-request contextvars for log correlation."""
+
+    async def dispatch(self, request, call_next):
+        clear_context()
+        try:
+            from opentelemetry import trace
+            span = trace.get_current_span()
+            if span and span.is_recording():
+                ctx = span.get_span_context()
+                if ctx.is_valid:
+                    set_trace_id(format(ctx.trace_id, "032x"))
+                    set_span_id(format(ctx.span_id, "016x"))
+        except Exception as exc:
+            logger.debug(f"TraceContextMiddleware: {exc}")
+        return await call_next(request)
 
 
 import sentry_sdk
@@ -130,6 +152,10 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
     Returns:
         FastAPI application
     """
+    # Initialize OpenTelemetry before app creation so FastAPI instrumentation
+    # can wrap the ASGI app at the correct layer.
+    init_otel()
+
     app = FastAPI(
         title="FluidMCP Gateway",
         description="Unified gateway for MCP servers with dynamic management",
@@ -163,6 +189,9 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # Inject OTEL trace/span IDs into contextvars for log correlation
+    app.add_middleware(TraceContextMiddleware)
 
     # Add request size limiting middleware for security (prevent DoS via large payloads)
     # Max 10MB request body size (configurable via MAX_REQUEST_SIZE_MB env var)
@@ -269,6 +298,10 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
 
     # Serve frontend from backend (single-port deployment)
     setup_frontend_routes(app, host="0.0.0.0", port=port)
+
+    # Instrument FastAPI with OpenTelemetry — captures HTTP request spans.
+    # Must be called AFTER all routes/middleware are registered.
+    instrument_fastapi_app(app)
 
     # Add a health check endpoint with actual connection verification
     # NOTE: /health (and /metrics below) are intentionally NOT instrumented with
@@ -393,6 +426,10 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
     @app.on_event("shutdown")
     async def shutdown_event():
         """Clean up resources on application shutdown."""
+        # Flush and close OTEL spans before anything else closes
+        from .otel import shutdown_otel
+        await asyncio.to_thread(shutdown_otel)
+
         from .api.management import cleanup_http_client
         await cleanup_http_client()
         logger.info("HTTP client cleaned up")

--- a/fluidmcp/cli/server.py
+++ b/fluidmcp/cli/server.py
@@ -31,10 +31,23 @@ from .context import set_trace_id, set_span_id, clear_context
 
 
 class TraceContextMiddleware(BaseHTTPMiddleware):
-    """Inject OTEL trace/span IDs into per-request contextvars for log correlation."""
+    """Inject OTEL trace/span IDs into per-request contextvars for log correlation.
+
+    This middleware must be added AFTER instrument_fastapi_app() so that it sits
+    inside the FastAPIInstrumentor ASGI wrapper. Starlette reverses add_middleware()
+    order, meaning the last-added middleware runs first. By adding this one after
+    FastAPIInstrumentor wraps the app, the OTEL span is already active when
+    dispatch() is called, so span.is_recording() reliably returns True.
+
+    The trace/span IDs are extracted after call_next() returns so we capture the
+    span that was active during the entire request, not just at entry.
+    """
 
     async def dispatch(self, request, call_next):
         clear_context()
+        response = await call_next(request)
+        # Extract trace context after call_next: the OTEL span is guaranteed
+        # to exist here because FastAPIInstrumentor creates it around call_next.
         try:
             from opentelemetry import trace
             span = trace.get_current_span()
@@ -45,7 +58,7 @@ class TraceContextMiddleware(BaseHTTPMiddleware):
                     set_span_id(format(ctx.span_id, "016x"))
         except Exception as exc:
             logger.debug(f"TraceContextMiddleware: {exc}")
-        return await call_next(request)
+        return response
 
 
 import sentry_sdk
@@ -190,9 +203,6 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
         allow_headers=["*"],
     )
 
-    # Inject OTEL trace/span IDs into contextvars for log correlation
-    app.add_middleware(TraceContextMiddleware)
-
     # Add request size limiting middleware for security (prevent DoS via large payloads)
     # Max 10MB request body size (configurable via MAX_REQUEST_SIZE_MB env var)
     # Uses Starlette's exception to ensure proper handling and prevent bypassing
@@ -302,6 +312,12 @@ async def create_app(db_manager: DatabaseManager, server_manager: ServerManager,
     # Instrument FastAPI with OpenTelemetry — captures HTTP request spans.
     # Must be called AFTER all routes/middleware are registered.
     instrument_fastapi_app(app)
+
+    # TraceContextMiddleware is added AFTER instrument_fastapi_app() so it sits
+    # inside the FastAPIInstrumentor ASGI wrapper in the middleware stack.
+    # Starlette reverses add_middleware() order (last-added runs outermost), so
+    # adding this here means the OTEL span is already active when dispatch() runs.
+    app.add_middleware(TraceContextMiddleware)
 
     # Add a health check endpoint with actual connection verification
     # NOTE: /health (and /metrics below) are intentionally NOT instrumented with

--- a/observability/grafana/provisioning/dashboards/dashboard.yml
+++ b/observability/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: FluidMCP
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/dashboards/dashboard.yml
+++ b/observability/grafana/provisioning/dashboards/dashboard.yml
@@ -3,7 +3,7 @@ apiVersion: 1
 providers:
   - name: FluidMCP
     type: file
-    disableDeletion: false
+    disableDeletion: true
     updateIntervalSeconds: 30
     allowUiUpdates: true
     options:

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,64 @@
+apiVersion: 1
+
+datasources:
+  # ── Prometheus (metrics) ──────────────────────────────────────────────────
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: "10s"
+      exemplarTraceIdDestinations:
+        # When Prometheus has an exemplar with a trace_id label,
+        # clicking it opens the trace in Tempo automatically.
+        - name: trace_id
+          datasourceUid: tempo
+
+  # ── Grafana Tempo (traces) ─────────────────────────────────────────────────
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      # Enable trace → logs correlation: clicking a span opens matching Loki logs
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: "-1m"
+        spanEndTimeShift: "1m"
+        filterByTraceID: true
+        filterBySpanID: true
+        customQuery: true
+        query: '{service="fluidmcp"} |= "${__span.traceId}"'
+      # Enable trace → metrics correlation
+      tracesToMetrics:
+        datasourceUid: prometheus
+        spanStartTimeShift: "-2m"
+        spanEndTimeShift: "2m"
+        queries:
+          - name: "Request rate"
+            query: "sum(rate(fluidmcp_requests_total{$$__tags}[5m]))"
+
+  # ── Grafana Loki (logs) ────────────────────────────────────────────────────
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      maxLines: 1000
+      # Enable logs → traces correlation: clicking a trace_id opens it in Tempo
+      derivedFields:
+        - name: TraceID
+          matcherRegex: '"trace_id":"([a-f0-9]+)"'
+          url: "$${__value.raw}"
+          datasourceUid: tempo
+          urlDisplayLabel: "View Trace in Tempo"

--- a/observability/loki/loki.yml
+++ b/observability/loki/loki.yml
@@ -1,0 +1,42 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: warn
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+# Schema for chunk storage
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+# Retention: keep logs for 7 days
+limits_config:
+  retention_period: 168h
+  # Allow high-cardinality JSON fields from FluidMCP
+  max_label_names_per_series: 30
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# Enable structured metadata for trace correlation
+feature_flags:
+  otlp_incoming_metadata: true

--- a/observability/loki/loki.yml
+++ b/observability/loki/loki.yml
@@ -1,3 +1,6 @@
+# auth_enabled: false is safe for local development only.
+# For any non-local deployment, enable authentication and place Loki
+# behind a reverse proxy with TLS. See: https://grafana.com/docs/loki/latest/operations/authentication/
 auth_enabled: false
 
 server:

--- a/observability/prometheus/alerts.yml
+++ b/observability/prometheus/alerts.yml
@@ -1,0 +1,56 @@
+groups:
+  - name: fluidmcp
+    interval: 30s
+    rules:
+      - alert: FluidMCPDown
+        expr: up{job="fluidmcp"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "FluidMCP is unreachable"
+          description: "Prometheus cannot scrape FluidMCP at {{ $labels.instance }}"
+
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(fluidmcp_errors_total[5m]))
+            /
+            sum(rate(fluidmcp_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate on FluidMCP"
+          description: "Error rate is {{ $value | humanizePercentage }} over the last 5 minutes"
+
+      - alert: ServerDown
+        expr: fluidmcp_server_status == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "MCP server {{ $labels.server_id }} is down"
+          description: "Server has been in stopped state for more than 1 minute"
+
+      - alert: HighP95Latency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(fluidmcp_request_duration_seconds_bucket[5m])) by (le, server_id)
+          ) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High latency on {{ $labels.server_id }}"
+          description: "P95 request latency is {{ $value | humanizeDuration }}"
+
+      - alert: HighGPUMemory
+        expr: fluidmcp_gpu_memory_utilization_ratio > 0.95
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "GPU memory near capacity on {{ $labels.server_id }}"
+          description: "GPU utilisation is {{ printf \"%.1f%%\" (mul $value 100) }}"

--- a/observability/prometheus/alerts.yml
+++ b/observability/prometheus/alerts.yml
@@ -1,6 +1,6 @@
 groups:
   - name: fluidmcp
-    interval: 30s
+    interval: 10s
     rules:
       - alert: FluidMCPDown
         expr: up{job="fluidmcp"} == 0

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,7 +1,6 @@
 global:
-  scrape_interval: 15s
-  evaluation_interval: 15s
-  # Attach these labels to every time series scraped here
+  scrape_interval: 10s       # uniform interval — all jobs inherit this
+  evaluation_interval: 10s   # alert rules evaluated at the same cadence
   external_labels:
     cluster: "docker-compose"
     environment: "local"
@@ -13,7 +12,6 @@ scrape_configs:
   # ── FluidMCP Gateway ──────────────────────────────────────────────────────
   - job_name: "fluidmcp"
     metrics_path: "/metrics"
-    scrape_interval: 10s
     scrape_timeout: 5s
     # If FMCP_BEARER_TOKEN is set, uncomment:
     # bearer_token: "your-token-here"

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,29 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  # Attach these labels to every time series scraped here
+  external_labels:
+    cluster: "docker-compose"
+    environment: "local"
+
+rule_files:
+  - "alerts.yml"
+
+scrape_configs:
+  # ── FluidMCP Gateway ──────────────────────────────────────────────────────
+  - job_name: "fluidmcp"
+    metrics_path: "/metrics"
+    scrape_interval: 10s
+    scrape_timeout: 5s
+    # If FMCP_BEARER_TOKEN is set, uncomment:
+    # bearer_token: "your-token-here"
+    static_configs:
+      - targets: ["fluidmcp:8099"]
+        labels:
+          service: "fluidmcp-gateway"
+          environment: "docker"
+
+  # ── Prometheus self-scrape ─────────────────────────────────────────────────
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]

--- a/observability/promtail/promtail.yml
+++ b/observability/promtail/promtail.yml
@@ -10,44 +10,40 @@ clients:
 
 scrape_configs:
 
-  # ── Scrape all Docker container logs ──────────────────────────────────────
-  # Promtail discovers containers via the Docker socket and tails their log files.
-  # For the fluidmcp container it parses the JSON log lines and promotes
-  # level, trace_id, and span_id as Loki labels so you can filter/correlate.
-  - job_name: docker
-    docker_sd_configs:
-      - host: unix:///var/run/docker.sock
-        refresh_interval: 5s
-        filters:
-          - name: status
-            values: ["running"]
+  # ── Docker json-file log scrape (no Docker socket required) ───────────────
+  # Docker writes each container's stdout/stderr to:
+  #   /var/lib/docker/containers/<container-id>/<container-id>-json.log
+  # Promtail reads these files directly (volume mounted :ro).
+  # The Docker json-file driver wraps each line in:
+  #   {"log":"<line>\n","stream":"stdout","time":"<rfc3339nano>","attrs":{"tag":"<tag>"}}
+  # We unwrap it with the "docker" pipeline stage and use the "tag" attr
+  # (set to "fluidmcp" in the compose logging.options) to identify the container.
+  - job_name: docker_files
 
-    relabel_configs:
-      # Use the container name as the Loki "container" label
-      - source_labels: ["__meta_docker_container_name"]
-        regex: "/(.*)"
-        target_label: container
-
-      # Keep the Docker image name for easy filtering
-      - source_labels: ["__meta_docker_container_image"]
-        target_label: image
-
-      # Expose the compose service name
-      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
-        target_label: service
-
-      # Set job=fluidmcp for the gateway container specifically
-      - source_labels: ["container"]
-        regex: "fluidmcp"
-        replacement: "fluidmcp"
-        target_label: job
+    static_configs:
+      - targets: ["localhost"]
+        labels:
+          job: docker
+          # Glob picks up every container's log file on this host
+          __path__: /var/lib/docker/containers/*/*-json.log
 
     pipeline_stages:
-      # Docker wraps container output in a JSON envelope; unwrap it first
+      # Unwrap the Docker json-file envelope
       - docker: {}
 
-      # FluidMCP emits JSON log lines (when LOG_FORMAT=json).
-      # Parse them and promote key fields as labels.
+      # Extract the "tag" attribute injected by the Docker json-file driver
+      - json:
+          expressions:
+            docker_tag: attrs.tag
+
+      # Promote the tag as a label so we can filter by container
+      - labels:
+          container:
+            source: docker_tag
+
+      # ── FluidMCP-specific enrichment ──────────────────────────────────────
+      # FluidMCP emits structured JSON log lines (LOG_FORMAT=json).
+      # Parse them and promote level, trace_id, span_id.
       - match:
           selector: '{container="fluidmcp"}'
           stages:
@@ -57,21 +53,23 @@ scrape_configs:
                   trace_id: trace_id
                   span_id: span_id
                   msg: message
-                  logger: logger
+                  svc: service
 
-            # Promote level as a Loki label (enables level-based filtering)
+            # level as a Loki label enables filter-by-severity in Grafana
             - labels:
                 level:
                   source: level
+                service:
+                  source: svc
 
-            # Attach trace/span IDs as structured metadata (Loki 2.9+)
-            # They appear in the log detail panel and enable Loki → Tempo links
+            # Structured metadata carries trace/span IDs into Loki's index
+            # enabling the Loki → Tempo "View Trace" button per log line
             - structured_metadata:
                 traceID:
                   source: trace_id
                 spanID:
                   source: span_id
 
-            # Use the parsed message as the log line (not the raw JSON)
+            # Replace the raw JSON envelope with the human-readable message
             - output:
                 source: msg

--- a/observability/promtail/promtail.yml
+++ b/observability/promtail/promtail.yml
@@ -1,0 +1,77 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+
+  # ── Scrape all Docker container logs ──────────────────────────────────────
+  # Promtail discovers containers via the Docker socket and tails their log files.
+  # For the fluidmcp container it parses the JSON log lines and promotes
+  # level, trace_id, and span_id as Loki labels so you can filter/correlate.
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+        filters:
+          - name: status
+            values: ["running"]
+
+    relabel_configs:
+      # Use the container name as the Loki "container" label
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: container
+
+      # Keep the Docker image name for easy filtering
+      - source_labels: ["__meta_docker_container_image"]
+        target_label: image
+
+      # Expose the compose service name
+      - source_labels: ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: service
+
+      # Set job=fluidmcp for the gateway container specifically
+      - source_labels: ["container"]
+        regex: "fluidmcp"
+        replacement: "fluidmcp"
+        target_label: job
+
+    pipeline_stages:
+      # Docker wraps container output in a JSON envelope; unwrap it first
+      - docker: {}
+
+      # FluidMCP emits JSON log lines (when LOG_FORMAT=json).
+      # Parse them and promote key fields as labels.
+      - match:
+          selector: '{container="fluidmcp"}'
+          stages:
+            - json:
+                expressions:
+                  level: level
+                  trace_id: trace_id
+                  span_id: span_id
+                  msg: message
+                  logger: logger
+
+            # Promote level as a Loki label (enables level-based filtering)
+            - labels:
+                level:
+                  source: level
+
+            # Attach trace/span IDs as structured metadata (Loki 2.9+)
+            # They appear in the log detail panel and enable Loki → Tempo links
+            - structured_metadata:
+                traceID:
+                  source: trace_id
+                spanID:
+                  source: span_id
+
+            # Use the parsed message as the log line (not the raw JSON)
+            - output:
+                source: msg

--- a/observability/tempo/tempo.yml
+++ b/observability/tempo/tempo.yml
@@ -1,0 +1,52 @@
+stream_over_http_enabled: true
+
+server:
+  http_listen_port: 3200
+  log_level: warn
+
+# Accept traces in multiple formats
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+          endpoint: "0.0.0.0:4318"
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+# Pipeline: ingestion → block building → query
+ingester:
+  max_block_duration: 5m
+
+# Local filesystem storage (swap for S3/GCS in production)
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+# Compaction keeps disk usage bounded
+compactor:
+  compaction:
+    block_retention: 48h
+
+# Expose metrics so Prometheus can scrape Tempo itself
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+
+# Query frontend for Grafana
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,12 @@ idna==3.10
 jiter==0.9.0
 jmespath==1.0.1
 loguru==0.7.3
+opentelemetry-api==1.27.0
+opentelemetry-sdk==1.27.0
+opentelemetry-exporter-otlp-proto-http==1.27.0
+opentelemetry-instrumentation-fastapi==0.48b0
+opentelemetry-instrumentation-httpx==0.48b0
+opentelemetry-instrumentation==0.48b0
 motor==3.7.1
 openai==1.77.0
 pathlib==1.0.1


### PR DESCRIPTION
## Summary

- **OpenTelemetry tracing** — `otel.py` initialises a `TracerProvider` with OTLP HTTP export to Grafana Tempo; `context.py` stores `trace_id`/`span_id` in per-request `ContextVar`s; `TraceContextMiddleware` in `server.py` injects them on every request
- **Structured JSON logging** — `cli.py` now emits one JSON object per log line (`timestamp`, `level`, `message`, `trace_id`, `span_id`) when `LOG_FORMAT=json` (default in containers); Promtail parses and ships these to Loki
- **Full Docker Compose stack** — `docker-compose.observability.yml` wires FluidMCP → Prometheus → Tempo → Loki → Promtail → Grafana in a single `docker compose up`
- **Pre-wired Grafana** — all three datasources provisioned automatically; cross-signal correlation enabled (logs ↔ traces ↔ metrics exemplars)

## Services

| Service | Port | Purpose |
|---|---|---|
| FluidMCP | 8099 | Gateway (emits OTLP traces + JSON logs + `/metrics`) |
| Prometheus | 9090 | Scrapes `/metrics` every 10 s, holds alert rules |
| Grafana Tempo | 3200 / 4318 | Receives OTLP HTTP traces from FluidMCP |
| Grafana Loki | 3100 | Receives logs from Promtail |
| Promtail | — | Tails Docker container logs → Loki |
| Grafana | 3000 | Unified UI (admin/admin) |

## Files changed

```
requirements.txt                          ← 6 OTEL packages added
fluidmcp/cli/otel.py                      ← new: OTEL init/shutdown
fluidmcp/cli/context.py                   ← new: per-request trace context
fluidmcp/cli/server.py                    ← TraceContextMiddleware + init/shutdown hooks
fluidmcp/cli/cli.py                       ← structured JSON log sink
docker-compose.observability.yml          ← full stack compose
observability/prometheus/prometheus.yml   ← scrape config
observability/prometheus/alerts.yml       ← 5 alert rules
observability/tempo/tempo.yml             ← OTLP HTTP receiver
observability/loki/loki.yml               ← log storage, 7d retention
observability/promtail/promtail.yml       ← Docker discovery + JSON parsing
observability/grafana/provisioning/       ← datasources + dashboard provider
```

## How to run

```bash
docker compose -f docker-compose.observability.yml up --build
# Grafana → http://localhost:3000  (admin/admin)
```

## Test plan

- [ ] `docker compose up` starts all 6 services without errors
- [ ] `curl http://localhost:8099/health` returns `{"status":"healthy"}`
- [ ] `curl http://localhost:8099/metrics` returns Prometheus text format
- [ ] Grafana Explore → Loki → `{service="fluidmcp"}` shows FluidMCP log lines with `level` labels
- [ ] Grafana Explore → Tempo → search by service name returns HTTP spans
- [ ] Clicking a Loki log line with `trace_id` opens the matching trace in Tempo
- [ ] Prometheus → Status → Targets shows `fluidmcp` as UP