### PR TITLE
[MCP-667]: Fix streamable-HTTP MCP handshake: handle JSON-RPC notifications correctly

### DIFF
--- a/fluidmcp/cli/services/package_launcher.py
+++ b/fluidmcp/cli/services/package_launcher.py
@@ -7,7 +7,7 @@ import asyncio
 import time
 import threading
 import httpx
-from typing import Union, Dict, Any, Iterator, AsyncIterator
+from typing import Union, Dict, Any, Iterator, AsyncIterator, Optional, Tuple
 from pathlib import Path
 from loguru import logger
 from fastapi import Request, APIRouter, Body, Depends, HTTPException
@@ -149,7 +149,7 @@ async def _proxy_to_http_server(
     timeout: float = 60.0,
     session_id: str = None,
     client: httpx.AsyncClient = None,
-) -> dict:
+) -> Tuple[Optional[dict], Optional[str]]:
     """
     Forward a JSON-RPC request to a streamable-http MCP server via POST /mcp.
 
@@ -163,7 +163,11 @@ async def _proxy_to_http_server(
                     handshake). When None a fresh short-lived client is created.
 
     Returns:
-        Parsed JSON response dict.
+        (response, upstream_session_id) — response is the parsed JSON-RPC
+        response dict, or None for a JSON-RPC *notification* (a payload with
+        no "id"), since the spec defines no response body for those (servers
+        typically ack with an empty 202). upstream_session_id is the
+        Mcp-Session-Id header from this response, if the upstream sent one.
 
     Raises:
         HTTPException on any HTTP or connection error.
@@ -175,6 +179,10 @@ async def _proxy_to_http_server(
     if session_id:
         headers["mcp-session-id"] = session_id
 
+    # A JSON-RPC notification (no "id") gets no JSON-RPC response by spec —
+    # don't attempt to parse one, or an empty/non-JSON ack body raises here.
+    is_notification = "id" not in payload
+
     # Use the caller-supplied shared pool when available. If not (e.g. tool
     # discovery at startup, or SSE fallback paths), create a short-lived client
     # and close it in the finally block so connections don't leak.
@@ -185,15 +193,20 @@ async def _proxy_to_http_server(
     try:
         resp = await client.post(mcp_url, json=payload, headers=headers, timeout=timeout)
         resp.raise_for_status()
+        upstream_session_id = resp.headers.get("mcp-session-id")
+
+        if is_notification:
+            return None, upstream_session_id
+
         # FastMCP returns text/event-stream even for non-streaming responses.
         # Unwrap the SSE envelope to get the plain JSON-RPC payload.
         content_type = resp.headers.get("content-type", "")
         if "text/event-stream" in content_type:
             for line in resp.text.splitlines():
                 if line.startswith("data: "):
-                    return json.loads(line[6:])
+                    return json.loads(line[6:]), upstream_session_id
             raise Exception(f"No data line in SSE response: {resp.text!r}")
-        return resp.json()
+        return resp.json(), upstream_session_id
     except httpx.HTTPStatusError as e:
         raise HTTPException(
             e.response.status_code,
@@ -579,10 +592,11 @@ def create_dynamic_router(server_manager):
             try:
                 # ── Network transport: forward via HTTP ──────────────────────────
                 if isinstance(process, NetworkSubprocessHandle):
+                    upstream_session_id = None
                     if process.transport == "http":
                         try:
                             _http_timeout = float(os.environ.get("FMCP_HTTP_PROXY_TIMEOUT", "60"))
-                            response = await _proxy_to_http_server(process.base_url, request, timeout=_http_timeout, session_id=process.session_id, client=process.http_client)
+                            response, upstream_session_id = await _proxy_to_http_server(process.base_url, request, timeout=_http_timeout, session_id=process.session_id, client=process.http_client)
                         except HTTPException as exc:
                             if exc.status_code == 504:
                                 monitor = getattr(server_manager, "_health_monitor", None)
@@ -600,7 +614,12 @@ def create_dynamic_router(server_manager):
                             raise
                     else:
                         response = await _proxy_to_sse_server(process.base_url, request)
-                    return JSONResponse(content=response)
+                    response_headers = {"Mcp-Session-Id": upstream_session_id} if upstream_session_id else None
+                    if response is None:
+                        # JSON-RPC notification (e.g. notifications/initialized) — the
+                        # spec defines no response body for these; ack with empty 202.
+                        return Response(status_code=202, headers=response_headers)
+                    return JSONResponse(content=response, headers=response_headers)
 
                 # ── SSE transport: forward via HTTP ─────────────────────────────
                 if isinstance(process, SseSubprocessHandle):
@@ -712,8 +731,10 @@ def create_dynamic_router(server_manager):
                 if isinstance(process, NetworkSubprocessHandle):
                     if process.transport == "http":
                         try:
-                            response = await _proxy_to_http_server(process.base_url, request, session_id=process.session_id, client=process.http_client)
-                            yield f"data: {json.dumps(response)}\n\n"
+                            response, _upstream_session_id = await _proxy_to_http_server(process.base_url, request, session_id=process.session_id, client=process.http_client)
+                            if response is not None:
+                                # JSON-RPC notifications have no response to relay.
+                                yield f"data: {json.dumps(response)}\n\n"
                         except Exception as e:
                             completion_status = "error"
                             collector.record_error("http_proxy_error")
@@ -876,7 +897,7 @@ def create_dynamic_router(server_manager):
             if isinstance(process, NetworkSubprocessHandle):
                 payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
                 if process.transport == "http":
-                    response = await _proxy_to_http_server(process.base_url, payload, timeout=30.0, session_id=process.session_id, client=process.http_client)
+                    response, _upstream_session_id = await _proxy_to_http_server(process.base_url, payload, timeout=30.0, session_id=process.session_id, client=process.http_client)
                 else:
                     response = await _proxy_to_sse_server(process.base_url, payload, timeout=30.0)
                 return JSONResponse(content=response)
@@ -961,7 +982,7 @@ def create_dynamic_router(server_manager):
                     raise HTTPException(400, "Tool name is required")
                 payload = {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": request_body}
                 if process.transport == "http":
-                    response = await _proxy_to_http_server(process.base_url, payload, timeout=60.0, session_id=process.session_id, client=process.http_client)
+                    response, _upstream_session_id = await _proxy_to_http_server(process.base_url, payload, timeout=60.0, session_id=process.session_id, client=process.http_client)
                 else:
                     response = await _proxy_to_sse_server(process.base_url, payload, timeout=60.0)
                 return JSONResponse(content=response)

--- a/fluidmcp/frontend/src/components/inspector/ResourcesPanel.tsx
+++ b/fluidmcp/frontend/src/components/inspector/ResourcesPanel.tsx
@@ -12,7 +12,6 @@ interface ResourcesPanelProps {
   resources: MCPResource[];
   resourcesLoading: boolean;
   selectedResourceUri: string | null;
-  setSelectedResourceUri: (uri: string | null) => void;
   resourceContent: { text?: string; blob?: string; mimeType?: string } | null;
   resourceContentLoading: boolean;
   templateParams: Record<string, string>;
@@ -26,7 +25,6 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
   resources,
   resourcesLoading,
   selectedResourceUri,
-  setSelectedResourceUri,
   resourceContent,
   resourceContentLoading,
   templateParams,

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1162,7 +1162,6 @@ export default function MCPInspector() {
                       resources={resources}
                       resourcesLoading={resourcesLoading}
                       selectedResourceUri={selectedResourceUri}
-                      setSelectedResourceUri={setSelectedResourceUri}
                       resourceContent={resourceContent}
                       resourceContentLoading={resourceContentLoading}
                       templateParams={templateParams}

--- a/tests/test_streamable_http_proxy.py
+++ b/tests/test_streamable_http_proxy.py
@@ -1,0 +1,122 @@
+"""Unit tests for the streamable-http proxy's JSON-RPC notification handling.
+
+Regression coverage for a bug where a JSON-RPC *notification* (a request with
+no "id", e.g. "notifications/initialized") sent through the streamable-http
+gateway crashed: the upstream MCP server correctly acks notifications with an
+empty-body 202, but the proxy unconditionally called `resp.json()`, raising
+JSONDecodeError on the empty body. That became an opaque 500 (or blank
+response) to the real client, breaking its handshake at stage 2 (initialize ->
+notifications/initialized -> first real request).
+"""
+import httpx
+import pytest
+
+from fluidmcp.cli.services.package_launcher import _proxy_to_http_server
+
+
+def _mock_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+@pytest.mark.asyncio
+async def test_notification_ack_does_not_crash():
+    """A notification (no "id") gets an empty-body 202 ack — must not raise."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, content=b"")
+
+    client = _mock_client(handler)
+    try:
+        response, session_id = await _proxy_to_http_server(
+            "http://127.0.0.1:9999",
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert response is None
+    assert session_id is None
+
+
+@pytest.mark.asyncio
+async def test_notification_ack_propagates_session_header():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(202, content=b"", headers={"Mcp-Session-Id": "sess-123"})
+
+    client = _mock_client(handler)
+    try:
+        response, session_id = await _proxy_to_http_server(
+            "http://127.0.0.1:9999",
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert response is None
+    assert session_id == "sess-123"
+
+
+@pytest.mark.asyncio
+async def test_regular_request_returns_parsed_body_and_session_id():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": 1, "result": {"ok": True}},
+            headers={"Mcp-Session-Id": "sess-abc"},
+        )
+
+    client = _mock_client(handler)
+    try:
+        response, session_id = await _proxy_to_http_server(
+            "http://127.0.0.1:9999",
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert response == {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+    assert session_id == "sess-abc"
+
+
+@pytest.mark.asyncio
+async def test_sse_envelope_still_unwrapped_for_regular_requests():
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = 'data: {"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}\n\n'
+        return httpx.Response(200, content=body, headers={"content-type": "text/event-stream"})
+
+    client = _mock_client(handler)
+    try:
+        response, session_id = await _proxy_to_http_server(
+            "http://127.0.0.1:9999",
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert response == {"jsonrpc": "2.0", "id": 2, "result": {"tools": []}}
+    assert session_id is None
+
+
+@pytest.mark.asyncio
+async def test_session_id_header_sent_when_provided():
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["mcp-session-id"] = request.headers.get("mcp-session-id")
+        return httpx.Response(202, content=b"")
+
+    client = _mock_client(handler)
+    try:
+        await _proxy_to_http_server(
+            "http://127.0.0.1:9999",
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            session_id="existing-session",
+            client=client,
+        )
+    finally:
+        await client.aclose()
+
+    assert captured["mcp-session-id"] == "existing-session"


### PR DESCRIPTION
## Summary

Fixes a bug where spec-compliant streamable-HTTP MCP clients (e.g. an OpenAI-Agents-SDK-based sandbox agent) failed to initialize against a FluidMCP-hosted MCP server, while the same server worked fine over stdio.

- `POST /{server_name}/mcp` (`proxy_jsonrpc` / `_proxy_to_http_server` in `fluidmcp/cli/services/package_launcher.py`) had no concept of JSON-RPC **notifications** (messages with no `"id"`, e.g. `notifications/initialized`).
- The upstream MCP server correctly acks a notification with an empty-body `202`, but the proxy unconditionally called `resp.json()` on every response, raising `JSONDecodeError` on that empty body — converted into an opaque `500`.
- A client doing the full 3-stage handshake (`initialize` → `notifications/initialized` → first request) never got past stage 2. A client that skips straight to stage 3 (e.g. the existing fluid-gpt engine integration) never hit this, which is why it "worked" there.

## Changes

- `_proxy_to_http_server` now detects an id-less payload and returns `(None, upstream_session_id)` without attempting to parse a response body for it.
- `proxy_jsonrpc` acks notifications with an empty `202 Accepted` instead of crashing, and propagates any `Mcp-Session-Id` header from the upstream back to the caller.
- Updated the three other call sites (`sse_stream`, `list_tools`, `call_tool`) for the new `(response, session_id)` return signature (these build their own payloads with an `id`, so behavior is unchanged for them).

**Also bundled in this PR (unrelated to the above, folded in so there's a single PR to review today):** a one-line-diff fix for a pre-existing frontend `tsc` build error (`ResourcesPanel.tsx` TS6133: `setSelectedResourceUri` declared but never read) that has been breaking the `Push Docker image to DockerHub` workflow on every push since 2026-06-29 — meaning no new image has published since 2026-06-23, independent of anything in this PR. Without this, merging the handshake fix alone would still fail to actually publish. Verified `npm run build` (`tsc -b && vite build`, the exact Docker build step) passes clean with it included.

## Test plan

- [x] New regression tests in `tests/test_streamable_http_proxy.py` (5 tests): notification ack doesn't crash, session header propagation on notification acks and regular responses, SSE-envelope unwrapping still works, session ID header sent upstream correctly.
- [x] `pytest tests/test_streamable_http_proxy.py tests/test_concurrency_limiting.py` — 30 passed.
- [x] `npx tsc -b` and `npm run build` — clean, confirming the DockerHub build will actually succeed once this merges.

