### PR TITLE
Fix DockerHub build: remove unused setSelectedResourceUri prop in ResourcesPanel

### DIFF
--- a/fluidmcp/frontend/src/components/inspector/ResourcesPanel.tsx
+++ b/fluidmcp/frontend/src/components/inspector/ResourcesPanel.tsx
@@ -12,7 +12,6 @@ interface ResourcesPanelProps {
   resources: MCPResource[];
   resourcesLoading: boolean;
   selectedResourceUri: string | null;
-  setSelectedResourceUri: (uri: string | null) => void;
   resourceContent: { text?: string; blob?: string; mimeType?: string } | null;
   resourceContentLoading: boolean;
   templateParams: Record<string, string>;
@@ -26,7 +25,6 @@ export const ResourcesPanel: React.FC<ResourcesPanelProps> = ({
   resources,
   resourcesLoading,
   selectedResourceUri,
-  setSelectedResourceUri,
   resourceContent,
   resourceContentLoading,
   templateParams,

--- a/fluidmcp/frontend/src/pages/MCPInspector.tsx
+++ b/fluidmcp/frontend/src/pages/MCPInspector.tsx
@@ -1162,7 +1162,6 @@ export default function MCPInspector() {
                       resources={resources}
                       resourcesLoading={resourcesLoading}
                       selectedResourceUri={selectedResourceUri}
-                      setSelectedResourceUri={setSelectedResourceUri}
                       resourceContent={resourceContent}
                       resourceContentLoading={resourceContentLoading}
                       templateParams={templateParams}


### PR DESCRIPTION
## Summary

`tsc -b` has been failing on every push to `development`/`main` since the MCP Inspector panel-extraction refactor, which has silently broken the `Push Docker image to DockerHub` workflow (every run since 2026-06-29 has failed to build/publish):

```
src/components/inspector/ResourcesPanel.tsx(29,3): error TS6133: 'setSelectedResourceUri' is declared but its value is never read.
```

`ResourcesPanel` received `setSelectedResourceUri` as a prop but never called it — all selection-state transitions (`onRefresh`, `onSelectTemplate`, `onLoadResource`) already update `selectedResourceUri` in the parent (`MCPInspector.tsx`), so the direct setter prop was dead weight left over from the refactor.

## Changes

- Removed `setSelectedResourceUri` from `ResourcesPanelProps` and the component's destructured params.
- Removed the corresponding `setSelectedResourceUri={setSelectedResourceUri}` at the call site in `MCPInspector.tsx` (kept `selectedResourceUri` — still used for display and passed down).
- No behavior change: the setter was unused inside the child, and the parent's own `useState` setter is untouched and still used elsewhere.

## Test plan

- [x] `npx tsc -b` — clean, no errors.
- [x] `npm run build` (`tsc -b && vite build`, the exact command the Docker image build runs) — completes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)