### PR TITLE
[MCP-669]: Restore env_file support for MCP server subprocess launch (ONGC regression)

### DIFF
--- a/fluidmcp/cli/services/server_manager.py
+++ b/fluidmcp/cli/services/server_manager.py
@@ -823,6 +823,59 @@ class ServerManager:
             env_vars = config.get("env", {})
             working_dir = config.get("working_dir", ".")
             install_path = config.get("install_path", ".")
+
+            # Load env_file if specified, merging before inline env (inline takes precedence)
+            env_file_path = config.pop("env_file", None)
+            if env_file_path:
+                env_file_resolved = (
+                    Path(env_file_path).resolve()
+                    if Path(env_file_path).is_absolute()
+                    else (Path(working_dir) / env_file_path).resolve()
+                )
+                # Security: env_file must be under install_path or working_dir
+                install_resolved = Path(install_path).resolve()
+                working_resolved = Path(working_dir).resolve()
+                under_install = (
+                    env_file_resolved == install_resolved
+                    or install_resolved in env_file_resolved.parents
+                )
+                under_working = (
+                    env_file_resolved == working_resolved
+                    or working_resolved in env_file_resolved.parents
+                )
+                if not (under_install or under_working):
+                    logger.warning(
+                        f"env_file '{env_file_resolved}' is outside install_path/working_dir — skipping"
+                    )
+                elif not env_file_resolved.exists():
+                    logger.warning(f"env_file '{env_file_resolved}' not found — skipping")
+                else:
+                    file_env: Dict[str, str] = {}
+                    for line in env_file_resolved.read_text().splitlines():
+                        line = line.strip()
+                        if not line or line.startswith("#"):
+                            continue
+                        if "=" not in line:
+                            continue
+                        k, _, v = line.partition("=")
+                        k = k.strip()
+                        v = v.strip()
+                        if (v.startswith('"') and v.endswith('"')) or (
+                            v.startswith("'") and v.endswith("'")
+                        ):
+                            v = v[1:-1]
+                        file_env[k] = v
+                    # Inline env overlays on top of file env
+                    env_vars = {**file_env, **env_vars}
+
+            # Promote TRANSPORT_TYPE from env_file to config transport (if not already set)
+            # Supports transport declaration via inline env (apply_transport during config
+            # resolution, before env_file is loaded) or via env_file (here, once it's loaded).
+            if not config.get("transport"):
+                _env_transport = env_vars.get("TRANSPORT_TYPE", "")
+                if _env_transport in ("sse", "http"):
+                    config["transport"] = _env_transport
+
             working_dir_path = Path(working_dir)
 
             # 🔹 Auto-reclone if directory missing (Railway ephemeral container fix)

--- a/tests/test_env_file_support.py
+++ b/tests/test_env_file_support.py
@@ -1,0 +1,143 @@
+"""Regression test for env_file support in ServerManager._spawn_mcp_process.
+
+Covers a real production bug: servers configured with an "env_file" key
+(pointing to a .env-style file, as used by on-prem/ONGC deployments) need
+that file's vars loaded and merged, and TRANSPORT_TYPE from that file must
+promote config["transport"] so HTTP-transport servers get MCP_PORT injected.
+This support existed on a divergent branch but was missing from `development`
+until this fix — servers relying on env_file crashed with MCP_PORT=None.
+
+The actual subprocess spawn + MCP handshake (stdio/http) is mocked out so
+these tests exercise only the env_file-loading and transport-promotion logic
+that changed, without needing a real MCP-protocol-speaking server process.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fluidmcp.cli.repositories import InMemoryBackend
+from fluidmcp.cli.services.server_manager import ServerManager
+
+
+@pytest.fixture
+def backend():
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def server_manager(backend):
+    return ServerManager(backend)
+
+
+class _FakeProcess:
+    """Stand-in for subprocess.Popen — alive, does nothing."""
+    pid = 12345
+    stdin = MagicMock()
+    stdout = MagicMock()
+    stderr = None
+
+    def poll(self):
+        return None
+
+    def kill(self):
+        pass
+
+    def wait(self, timeout=None):
+        return 0
+
+
+def _capturing_popen(captured_env):
+    def fake_popen(cmd_list, **kwargs):
+        captured_env.update(kwargs.get("env", {}))
+        return _FakeProcess()
+    return fake_popen
+
+
+@pytest.mark.asyncio
+async def test_env_file_promotes_transport_and_injects_mcp_port(tmp_path, server_manager):
+    env_file = tmp_path / ".env"
+    env_file.write_text("TRANSPORT_TYPE=http\nCUSTOM_VAR=hello\n")
+    (tmp_path / "server.py").write_text("pass")  # never actually executed, Popen is mocked
+
+    config = {
+        "command": "python3",
+        "args": [str(tmp_path / "server.py")],
+        "env": {},
+        "working_dir": str(tmp_path),
+        "install_path": str(tmp_path),
+        "env_file": ".env",
+    }
+
+    captured_env = {}
+    fake_handle = object()
+
+    with patch("fluidmcp.cli.services.server_manager.subprocess.Popen", side_effect=_capturing_popen(captured_env)), \
+         patch.object(ServerManager, "_handshake_http_subprocess", new=AsyncMock(return_value=fake_handle)):
+        result = await server_manager._spawn_mcp_process("probe-server", config)
+
+    assert result is fake_handle, "HTTP handshake path should have been taken and its handle returned"
+    assert captured_env.get("MCP_PORT"), "MCP_PORT was not injected — transport was not promoted from env_file"
+    assert int(captured_env["MCP_PORT"]) > 0
+    assert captured_env.get("CUSTOM_VAR") == "hello", "env_file vars beyond TRANSPORT_TYPE were not merged into the subprocess env"
+
+    # transport promotion should also be reflected back onto the config dict
+    assert config["transport"] == "http"
+    # env_file key should be consumed (matches original deploy_onprod behavior)
+    assert "env_file" not in config
+
+
+@pytest.mark.asyncio
+async def test_no_env_file_key_is_unaffected(tmp_path, server_manager):
+    """Servers without env_file must behave exactly as before (no transport promotion, no MCP_PORT)."""
+    (tmp_path / "server.py").write_text("pass")
+
+    config = {
+        "command": "python3",
+        "args": [str(tmp_path / "server.py")],
+        "env": {},
+        "working_dir": str(tmp_path),
+        "install_path": str(tmp_path),
+    }
+
+    captured_env = {}
+
+    with patch("fluidmcp.cli.services.server_manager.subprocess.Popen", side_effect=_capturing_popen(captured_env)), \
+         patch("fluidmcp.cli.services.server_manager.initialize_mcp_server", return_value=True), \
+         patch.object(ServerManager, "_discover_and_cache_tools", new=AsyncMock(return_value=None)):
+        result = await server_manager._spawn_mcp_process("probe-server-stdio", config)
+
+    assert result is not None
+    assert "MCP_PORT" not in captured_env
+    assert config.get("transport") is None
+
+
+@pytest.mark.asyncio
+async def test_env_file_outside_working_dir_is_rejected(tmp_path, server_manager):
+    """Security: env_file must stay under install_path/working_dir — a path-traversal attempt is skipped, not followed."""
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    (outside_dir / "evil.env").write_text("TRANSPORT_TYPE=http\n")
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    (work_dir / "server.py").write_text("pass")
+
+    config = {
+        "command": "python3",
+        "args": [str(work_dir / "server.py")],
+        "env": {},
+        "working_dir": str(work_dir),
+        "install_path": str(work_dir),
+        "env_file": "../outside/evil.env",
+    }
+
+    captured_env = {}
+
+    with patch("fluidmcp.cli.services.server_manager.subprocess.Popen", side_effect=_capturing_popen(captured_env)), \
+         patch("fluidmcp.cli.services.server_manager.initialize_mcp_server", return_value=True), \
+         patch.object(ServerManager, "_discover_and_cache_tools", new=AsyncMock(return_value=None)):
+        result = await server_manager._spawn_mcp_process("probe-server-escape", config)
+
+    assert result is not None
+    assert "MCP_PORT" not in captured_env, "env_file outside install_path/working_dir must be skipped, not loaded"
+    assert config.get("transport") is None


### PR DESCRIPTION
## Summary

Restores `env_file` support in `ServerManager._spawn_mcp_process`, which was silently missing from `development` and caused a production outage today when ONGC's on-prem deployment was switched from a `deploy_onprod`-based image to a `development`-based one (after PR #877 merged and DockerHub credentials were fixed).

All of ONGC's custom MCP servers (`ongc-hr-personal`, `ongc-hr-medical`, `ongc-hr-analytics`, etc.) declare their config like:
```json
{
  "command": "python",
  "args": ["servers/ongc_hr_personal/server.py"],
  "env_file": "servers/ongc_hr_personal/.env"
}
```
Their `server.py` reads `MCP_PORT` unconditionally at import time. On `development`, `env_file` was never read anywhere, so `TRANSPORT_TYPE` (declared inside that file) never promoted `config["transport"]`, `MCP_PORT` was never injected, and every one of these servers crashed on launch with:
```
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'
```

## Root cause

This feature was built on a side branch (`simplyfiy_env_structure` → `onprem_replica_config` → `deploy_onprod`) and **never merged into `development`** — confirmed via `git log`, there's no merge commit bringing any of that lineage into `development`'s history. `deploy_onprod` and `development` diverged long ago and were never reconciled for this feature specifically.

## Changes

`_spawn_mcp_process` now (matching `deploy_onprod`'s original behavior exactly):
- Loads `env_file` when present (`.pop()`'d off config), parses `KEY=VALUE` lines (skips blanks/comments, strips matching quotes).
- Merges file vars under inline `env` (inline takes precedence — unchanged semantics).
- Promotes `TRANSPORT_TYPE` from the loaded file into `config["transport"]` if not already set, so the existing HTTP-transport `MCP_PORT` allocation (unchanged) picks it up.
- Same path-traversal guard as before: `env_file` must resolve under `install_path` or `working_dir`, or it's skipped with a warning.

## Test plan

- [x] New `tests/test_env_file_support.py` (3 tests, subprocess spawn + handshake mocked out to isolate the actual logic changed):
  - `env_file` with `TRANSPORT_TYPE=http` → `MCP_PORT` injected, other vars merged, `config["transport"]` set, `env_file` key consumed.
  - No `env_file` key → unaffected (no promotion, no `MCP_PORT`), matching prior behavior exactly.
  - `env_file` path escaping `install_path`/`working_dir` → rejected, not loaded.
- [x] Full relevant suite (`test_env_file_support`, `test_concurrency_limiting`, `test_crash_root_cause`, `test_debug_aggregator`, `test_debug_api_crashes_stderr`, `test_debug_api_resources`, `test_per_server_resource_gauges`, `test_resource_kill_policy`, `test_server_manager_cleanup`, `test_stability_alerts`, `test_streamable_http_proxy`) — 152 passed; the 2 pre-existing `test_debug_api_crashes_stderr` failures are confirmed unrelated (reproduce identically with this change reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)